### PR TITLE
Run gofmt on all go files

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -7,13 +7,13 @@ import (
 	"github.com/anfernee/proxy-service/pkg/agent/agentclient"
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"github.com/spf13/cobra"
 )
 
 func main() {
@@ -23,7 +23,7 @@ func main() {
 	flags := command.Flags()
 	flags.AddFlagSet(o.Flags())
 	if err := command.Execute(); err != nil {
-		glog.Errorf( "error: %v\n", err)
+		glog.Errorf("error: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -31,7 +31,7 @@ func main() {
 type GrpcProxyAgentOptions struct {
 	agentCert string
 	agentKey  string
-	caCert     string
+	caCert    string
 }
 
 func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
@@ -95,7 +95,6 @@ func newAgentCommand(a *Agent, o *GrpcProxyAgentOptions) *cobra.Command {
 }
 
 type Agent struct {
-
 }
 
 func (a *Agent) run(o *GrpcProxyAgentOptions) error {
@@ -118,7 +117,7 @@ func (a *Agent) run(o *GrpcProxyAgentOptions) error {
 	return nil
 }
 
-func (p* Agent) runProxyConnection(o *GrpcProxyAgentOptions) error {
+func (p *Agent) runProxyConnection(o *GrpcProxyAgentOptions) error {
 	agentCert, err := tls.LoadX509KeyPair(o.agentCert, o.agentKey)
 	if err != nil {
 		return err
@@ -153,13 +152,13 @@ func (p* Agent) runProxyConnection(o *GrpcProxyAgentOptions) error {
 }
 
 func (p *Agent) runAdminServer(o *GrpcProxyAgentOptions) error {
-	livenessHandler := http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	livenessHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})
-	readinessHandler := http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	readinessHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})
-	metricsHandler := http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	metricsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		prometheus.Handler().ServeHTTP(w, r)
 	})
 

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -23,7 +23,7 @@ func main() {
 	flags := command.Flags()
 	flags.AddFlagSet(o.Flags())
 	if err := command.Execute(); err != nil {
-		glog.Errorf( "error: %v\n", err)
+		glog.Errorf("error: %v\n", err)
 		os.Exit(1)
 	}
 }
@@ -95,7 +95,6 @@ func newGrpcProxyClientCommand(c *Client, o *GrpcProxyClientOptions) *cobra.Comm
 }
 
 type Client struct {
-
 }
 
 func (c *Client) run(o *GrpcProxyClientOptions) error {
@@ -157,5 +156,3 @@ func (c *Client) run(o *GrpcProxyClientOptions) error {
 	}
 	return nil
 }
-
-

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -28,16 +28,16 @@ func main() {
 	flags := command.Flags()
 	flags.AddFlagSet(o.Flags())
 	if err := command.Execute(); err != nil {
-		glog.Errorf( "error: %v\n", err)
+		glog.Errorf("error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
 type ProxyRunOptions struct {
 	// Certificate setup for securing communication to the "client" i.e. the Kube API Server.
-	serverCert    string
-	serverKey     string
-	serverCaCert  string
+	serverCert   string
+	serverKey    string
+	serverCaCert string
 	// Certificate setup for securing communication to the "agent" i.e. the managed cluster.
 	clusterCert   string
 	clusterKey    string
@@ -62,8 +62,8 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.clusterCaCert, "clusterCaCert", o.clusterCaCert, "If non-empty the CA we use to validate Agent clients.")
 	flags.StringVar(&o.mode, "mode", "grpc", "Mode can be either 'grpc' or 'http-connect'.")
 	flags.UintVar(&o.serverPort, "serverPort", 8090, "Port we listen for server connections on.")
-	flags.UintVar(&o.agentPort,"agentPort", 8091, "Port we listen for agent connections on.")
-	flags.UintVar(&o.adminPort,"adminPort", 8092, "Port we listen for admin connections on.")
+	flags.UintVar(&o.agentPort, "agentPort", 8091, "Port we listen for agent connections on.")
+	flags.UintVar(&o.adminPort, "adminPort", 8092, "Port we listen for admin connections on.")
 	return flags
 }
 
@@ -149,16 +149,16 @@ func (o *ProxyRunOptions) Validate() error {
 
 func newProxyRunOptions() *ProxyRunOptions {
 	o := ProxyRunOptions{
-		serverCert: "",
-		serverKey: "",
-		serverCaCert: "",
-		clusterCert: "",
-		clusterKey: "",
+		serverCert:    "",
+		serverKey:     "",
+		serverCaCert:  "",
+		clusterCert:   "",
+		clusterKey:    "",
 		clusterCaCert: "",
-		mode: "grpc",
-		serverPort: 8090,
-		agentPort: 8091,
-		adminPort: 8092,
+		mode:          "grpc",
+		serverPort:    8090,
+		agentPort:     8091,
+		adminPort:     8092,
 	}
 	return &o
 }
@@ -176,7 +176,6 @@ func newProxyCommand(p *Proxy, o *ProxyRunOptions) *cobra.Command {
 }
 
 type Proxy struct {
-
 }
 
 func (p *Proxy) run(o *ProxyRunOptions) error {
@@ -245,9 +244,9 @@ func (p *Proxy) runMasterServer(o *ProxyRunOptions, server *agentserver.ProxySer
 		go func() {
 			// http-connect
 			server := &http.Server{
-				Addr:         addr,
-				TLSConfig:    tlsConfig,
-				Handler:      &agentserver.Tunnel{
+				Addr:      addr,
+				TLSConfig: tlsConfig,
+				Handler: &agentserver.Tunnel{
 					Server: server,
 				},
 				TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
@@ -296,13 +295,13 @@ func (p *Proxy) runAgentServer(o *ProxyRunOptions, server *agentserver.ProxyServ
 }
 
 func (p *Proxy) runAdminServer(o *ProxyRunOptions, server *agentserver.ProxyServer) error {
-	livenessHandler := http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	livenessHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})
-	readinessHandler := http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	readinessHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})
-	metricsHandler := http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	metricsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		prometheus.Handler().ServeHTTP(w, r)
 	})
 
@@ -326,4 +325,3 @@ func (p *Proxy) runAdminServer(o *ProxyRunOptions, server *agentserver.ProxyServ
 
 	return nil
 }
-

--- a/pkg/agent/agentserver/server.go
+++ b/pkg/agent/agentserver/server.go
@@ -3,9 +3,9 @@ package agentserver
 import (
 	"io"
 
+	"fmt"
 	"github.com/anfernee/proxy-service/proto/agent"
 	"github.com/golang/glog"
-	"fmt"
 	"net"
 )
 
@@ -14,7 +14,7 @@ type ProxyClientConnection struct {
 	Mode string
 	Grpc agent.ProxyService_ProxyServer
 	// Http http.ResponseWriter
-	Http net.Conn
+	Http      net.Conn
 	connected chan struct{}
 	connectID int64
 }
@@ -105,8 +105,8 @@ func (s *ProxyServer) serveRecv(stream agent.ProxyService_ProxyServer, recvCh <-
 				glog.Warningf("send packet to Backend failed: $v", err)
 			}
 			s.PendingDial[pkt.GetDialRequest().Random] = &ProxyClientConnection{
-				Mode: "grpc",
-				Grpc: stream,
+				Mode:      "grpc",
+				Grpc:      stream,
 				connected: make(chan struct{}),
 			}
 			glog.Info("DIAL_REQ sent to backend") // got this. but backend didn't receive anything.

--- a/pkg/agent/agentserver/tunnel.go
+++ b/pkg/agent/agentserver/tunnel.go
@@ -1,11 +1,11 @@
 package agentserver
 
 import (
-	"net/http"
-	"io"
 	"github.com/anfernee/proxy-service/proto/agent"
-	"math/rand"
 	"github.com/golang/glog"
+	"io"
+	"math/rand"
+	"net/http"
 )
 
 type Tunnel struct {
@@ -52,7 +52,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	connection := &ProxyClientConnection{
 		Mode: "http-connect",
 		// Http: w,
-		Http: conn,
+		Http:      conn,
 		connected: connected,
 	}
 	t.Server.PendingDial[random] = connection
@@ -80,7 +80,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer conn.Close()
 
 	glog.Infof("Starting proxy to %q", r.Host)
-	pkt := make([]byte, 1 << 12)
+	pkt := make([]byte, 1<<12)
 	for {
 		n, err := conn.Read(pkt[:])
 		if err == io.EOF {
@@ -95,7 +95,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Payload: &agent.Packet_Data{
 				Data: &agent.Data{
 					ConnectID: connection.connectID,
-					Data:	 pkt[:n],
+					Data:      pkt[:n],
 				},
 			},
 		}
@@ -105,5 +105,3 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	glog.Infof("Stopping transfer to %q", r.Host)
 	delete(t.Server.Frontends, connection.connectID)
 }
-
-

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -30,7 +30,7 @@ type grpcTunnel struct {
 	client      agent.ProxyServiceClient
 	stream      agent.ProxyService_ProxyClient
 	pendingDial map[int64]chan<- dialResult
-	conns map[int64]*conn
+	conns       map[int64]*conn
 }
 
 // CreateGrpcTunnel creates a grpc based tunnel
@@ -53,7 +53,7 @@ func CreateGrpcTunnel(address string, opts ...grpc.DialOption) (Tunnel, error) {
 		client:      client,
 		stream:      stream,
 		pendingDial: make(map[int64]chan<- dialResult),
-		conns: make(map[int64]*conn),
+		conns:       make(map[int64]*conn),
 	}
 
 	go tunnel.serve()

--- a/pkg/agent/client/conn.go
+++ b/pkg/agent/client/conn.go
@@ -2,9 +2,9 @@ package client
 
 import (
 	"errors"
+	"io"
 	"net"
 	"time"
-	"io"
 
 	"github.com/anfernee/proxy-service/proto/agent"
 	"github.com/golang/glog"
@@ -14,7 +14,7 @@ type conn struct {
 	stream agent.ProxyService_ProxyClient
 	connID int64
 	readCh chan []byte
-	rdata []byte
+	rdata  []byte
 }
 
 var _ net.Conn = &conn{}
@@ -25,7 +25,7 @@ func (c *conn) Write(data []byte) (n int, err error) {
 		Payload: &agent.Packet_Data{
 			Data: &agent.Data{
 				ConnectID: c.connID,
-				Data:	 data,
+				Data:      data,
 			},
 		},
 	}
@@ -42,24 +42,24 @@ func (c *conn) Write(data []byte) (n int, err error) {
 func (c *conn) Read(b []byte) (n int, err error) {
 	var data []byte
 
-		if c.rdata != nil {
-			data = c.rdata
-		} else {
-			data = <-c.readCh
-		}
+	if c.rdata != nil {
+		data = c.rdata
+	} else {
+		data = <-c.readCh
+	}
 
-		if data == nil {
-			return 0, io.EOF
-		}
+	if data == nil {
+		return 0, io.EOF
+	}
 
-		if len(data) > len(b) {
-			copy(b, data[:len(b)])
-			c.rdata = data[len(b):]
-			return len(b), nil
-		}
+	if len(data) > len(b) {
+		copy(b, data[:len(b)])
+		c.rdata = data[len(b):]
+		return len(b), nil
+	}
 
-		c.rdata = nil
-		copy(b, data)
+	c.rdata = nil
+	copy(b, data)
 
 	return len(data), nil
 }


### PR DESCRIPTION
This change runs gofmt on all of the go files (was a side-effect of vim-go and adding copyright statements) but seems worth merging since it's the standard for go style.

/kind cleanup
/assign @cheftako 