### PR TITLE
Fix incorrect references to old repo.

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -20,7 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/anfernee/proxy-service/pkg/agent/agentclient"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/agentclient"
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -27,7 +27,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/anfernee/proxy-service/pkg/agent/client"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/client"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -28,8 +28,8 @@ import (
 
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/anfernee/proxy-service/pkg/agent/agentserver"
-	"github.com/anfernee/proxy-service/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/agentserver"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/examples/legacy/client/main.go
+++ b/examples/legacy/client/main.go
@@ -24,7 +24,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	proxy "github.com/anfernee/proxy-service/proto"
+	proxy "sigs.k8s.io/apiserver-network-proxy/proto"
 )
 
 func main() {

--- a/examples/legacy/server/main.go
+++ b/examples/legacy/server/main.go
@@ -23,8 +23,8 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/anfernee/proxy-service/pkg/server"
-	proxy "github.com/anfernee/proxy-service/proto"
+	"sigs.k8s.io/apiserver-network-proxy/proxy-service/pkg/server"
+	proxy "sigs.k8s.io/apiserver-network-proxy/proxy-service/proto"
 )
 
 func main() {

--- a/pkg/agent/agentclient/client.go
+++ b/pkg/agent/agentclient/client.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/anfernee/proxy-service/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
 )

--- a/pkg/agent/agentserver/server.go
+++ b/pkg/agent/agentserver/server.go
@@ -20,7 +20,7 @@ import (
 	"io"
 
 	"fmt"
-	"github.com/anfernee/proxy-service/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	"github.com/golang/glog"
 	"net"
 )

--- a/pkg/agent/agentserver/tunnel.go
+++ b/pkg/agent/agentserver/tunnel.go
@@ -17,7 +17,7 @@ limitations under the License.
 package agentserver
 
 import (
-	"github.com/anfernee/proxy-service/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	"github.com/golang/glog"
 	"io"
 	"math/rand"

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -24,7 +24,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/anfernee/proxy-service/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	"github.com/golang/glog"
 
 	"google.golang.org/grpc"

--- a/pkg/agent/client/conn.go
+++ b/pkg/agent/client/conn.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/anfernee/proxy-service/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	"github.com/golang/glog"
 )
 

--- a/pkg/agent/server/server.go
+++ b/pkg/agent/server/server.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"sync/atomic"
 
-	"github.com/anfernee/proxy-service/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	"github.com/golang/glog"
 )
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"sync/atomic"
 
-	proxy "github.com/anfernee/proxy-service/proto"
+	proxy "sigs.k8s.io/apiserver-network-proxy/proto"
 )
 
 type ProxyServer struct {


### PR DESCRIPTION
Some of the source was incorrectly pointing at the old repo.
If you have the old repo it would incorrectly pull it in.
This lead to using old code.
If you did not have the old repo it wouldn't build.