### PR TITLE
Added code to get http-connect to work with the test client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,21 +60,21 @@ python -m SimpleHTTPServer
 ```
 
 - Start proxy service
-```
+```console
 ./bin/proxy-server --serverCaCert=certs/master/issued/ca.crt --serverCert=certs/master/issued/proxy-master.crt --serverKey=certs/master/private/proxy-master.key --clusterCaCert=certs/agent/issued/ca.crt --clusterCert=certs/agent/issued/proxy-master.crt --clusterKey=certs/agent/private/proxy-master.key
 ```
 
 - Start agent service
-```
+```console
 ./bin/proxy-agent --caCert=certs/agent/issued/ca.crt --agentCert=certs/agent/issued/proxy-agent.crt --agentKey=certs/agent/private/proxy-agent.key
 ```
 
 - Run client (mTLS enabled sample client)
-```
+```console
 ./bin/proxy-test-client --caCert=certs/master/issued/ca.crt --clientCert=certs/master/issued/proxy-client.crt --clientKey=certs/master/private/proxy-client.key
 ```
 
-### HTTP-Connect Client using mTLS Proxy with dial back Agent
+### HTTP-Connect Client using mTLS Proxy with dial back Agent (Either curl OR test client)
 
 ```
 client =HTTP-CONNECT=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPServer(:8000)
@@ -89,17 +89,22 @@ python -m SimpleHTTPServer
 ```
 
 - Start proxy service
-```
+```console
 ./bin/proxy-server --mode=http-connect --serverCaCert=certs/master/issued/ca.crt --serverCert=certs/master/issued/proxy-master.crt --serverKey=certs/master/private/proxy-master.key --clusterCaCert=certs/agent/issued/ca.crt --clusterCert=certs/agent/issued/proxy-master.crt --clusterKey=certs/agent/private/proxy-master.key
 ```
 
 - Start agent service
-```
+```console
 ./bin/proxy-agent --caCert=certs/agent/issued/ca.crt --agentCert=certs/agent/issued/proxy-agent.crt --agentKey=certs/agent/private/proxy-agent.key
 ```
 
-- Run curl client (curl using a mTLS http-connect proxy)
+- Run client (mTLS & http-connect enabled sample client)
+```console
+./bin/proxy-test-client --mode=http-connect  --proxyHost=127.0.0.1 --caCert=certs/master/issued/ca.crt --clientCert=certs/master/issued/proxy-client.crt --clientKey=certs/master/private/proxy-client.key
 ```
+
+- Run curl client (curl using a mTLS http-connect proxy)
+```console
 curl -v -p --proxy-key certs/master/private/proxy-client.key --proxy-cert certs/master/issued/proxy-client.crt --proxy-cacert certs/master/issued/ca.crt --proxy-cert-type PEM -x https://127.0.0.1:8090  http://localhost:8000```
 ```
 

--- a/pkg/agent/agentserver/server.go
+++ b/pkg/agent/agentserver/server.go
@@ -43,8 +43,6 @@ func (c *ProxyClientConnection) send(pkt *agent.Packet) error {
 			return nil
 		}
 		writer := c.Http
-		klog.Warningf("pkt is set to %v.", pkt)
-		klog.Warningf("GetData() returns %v.", pkt.GetData())
 		_, err := writer.Write(pkt.GetData().Data)
 		return err
 	} else {

--- a/pkg/agent/agentserver/tunnel.go
+++ b/pkg/agent/agentserver/tunnel.go
@@ -34,7 +34,6 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.Method,
 		r.Host,
 		r.TLS.PeerCertificates[0].Subject.CommonName) // can do authz with certs
-
 	if r.Method != http.MethodConnect {
 		http.Error(w, "this proxy only supports CONNECT passthrough", http.StatusMethodNotAllowed)
 		return


### PR DESCRIPTION
Added sample code to get http-connect to work with the test client.
Client can now be configured to use either grpc to a grpc proxy server or http-connect to a http mode proxy server.
Also removed extraneous packet logging which is not useful and potentially problematic.

Unified the logic for client grpc and http-connect. Introduced a getDialer method. 
Moved all logic for grpc & http-connect to getDialer. 
Made both paths return a dialer and swtiched to using standard http client.