### PR TITLE
apiserver-network-proxy flags should use kebab-case not camelCase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,18 @@ bin/proxy-agent: bin cmd/agent/main.go proto/agent/agent.pb.go
 
 docker/proxy-agent: cmd/agent/main.go proto/agent/agent.pb.go
 	@[ "${REGISTRY}" ] || ( echo "REGISTRY is not set"; exit 1 )
+	@[ "${VERSION}" ] || ( echo "VERSION is not set"; exit 1 )
 	@[ "${PROJECT_ID}" ] || ( echo "PROJECT_ID is not set"; exit 1 )
-	docker build . -f artifacts/images/agent-build.Dockerfile -t ${REGISTRY}/${PROJECT_ID}/proxy-agent:latest
+	docker build . -f artifacts/images/agent-build.Dockerfile -t ${REGISTRY}/${PROJECT_ID}/proxy-agent:${VERSION}
 
 bin/proxy-server: bin cmd/proxy/main.go proto/agent/agent.pb.go proto/proxy.pb.go
 	go build -o bin/proxy-server cmd/proxy/main.go
 
 docker/proxy-server: cmd/proxy/main.go proto/agent/agent.pb.go proto/proxy.pb.go
 	@[ "${REGISTRY}" ] || ( echo "REGISTRY is not set"; exit 1 )
+	@[ "${VERSION}" ] || ( echo "VERSION is not set"; exit 1 )
 	@[ "${PROJECT_ID}" ] || ( echo "PROJECT_ID is not set"; exit 1 )
-	docker build . -f artifacts/images/server-build.Dockerfile -t ${REGISTRY}/${PROJECT_ID}/proxy-server:latest
+	docker build . -f artifacts/images/server-build.Dockerfile -t ${REGISTRY}/${PROJECT_ID}/proxy-server:${VERSION}
 
 bin/proxy-test-client: bin cmd/client/main.go proto/proxy.pb.go
 	go build -o bin/proxy-test-client cmd/client/main.go
@@ -97,8 +99,8 @@ build: bin/proxy-agent bin/proxy-server bin/proxy-test-client
 
 push-images: docker/proxy-agent docker/proxy-server
 	@[ "${DOCKER_CMD}" ] || ( echo "DOCKER_CMD is not set"; exit 1 )
-	${DOCKER_CMD} push ${REGISTRY}/${PROJECT_ID}/proxy-agent:latest
-	${DOCKER_CMD} push ${REGISTRY}/${PROJECT_ID}/proxy-server:latest
+	${DOCKER_CMD} push ${REGISTRY}/${PROJECT_ID}/proxy-agent:${VERSION}
+	${DOCKER_CMD} push ${REGISTRY}/${PROJECT_ID}/proxy-server:${VERSION}
 
 clean:
 	rm -rf proto/agent/agent.pb.go proto/proxy.pb.go easy-rsa.tar.gz easy-rsa-master cfssl cfssljson certs bin

--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ python -m SimpleHTTPServer
 
 - Start proxy service
 ```console
-./bin/proxy-server --serverCaCert=certs/master/issued/ca.crt --serverCert=certs/master/issued/proxy-master.crt --serverKey=certs/master/private/proxy-master.key --clusterCaCert=certs/agent/issued/ca.crt --clusterCert=certs/agent/issued/proxy-master.crt --clusterKey=certs/agent/private/proxy-master.key
+./bin/proxy-server --server-ca-cert=certs/master/issued/ca.crt --server-cert=certs/master/issued/proxy-master.crt --server-key=certs/master/private/proxy-master.key --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-master.crt --cluster-key=certs/agent/private/proxy-master.key
 ```
 
 - Start agent service
 ```console
-./bin/proxy-agent --caCert=certs/agent/issued/ca.crt --agentCert=certs/agent/issued/proxy-agent.crt --agentKey=certs/agent/private/proxy-agent.key
+./bin/proxy-agent --ca-cert=certs/agent/issued/ca.crt --agent-cert=certs/agent/issued/proxy-agent.crt --agent-key=certs/agent/private/proxy-agent.key
 ```
 
 - Run client (mTLS enabled sample client)
 ```console
-./bin/proxy-test-client --caCert=certs/master/issued/ca.crt --clientCert=certs/master/issued/proxy-client.crt --clientKey=certs/master/private/proxy-client.key
+./bin/proxy-test-client --ca-cert=certs/master/issued/ca.crt --client-cert=certs/master/issued/proxy-client.crt --client-key=certs/master/private/proxy-client.key
 ```
 
 ### HTTP-Connect Client using mTLS Proxy with dial back Agent (Either curl OR test client)
@@ -90,17 +90,17 @@ python -m SimpleHTTPServer
 
 - Start proxy service
 ```console
-./bin/proxy-server --mode=http-connect --serverCaCert=certs/master/issued/ca.crt --serverCert=certs/master/issued/proxy-master.crt --serverKey=certs/master/private/proxy-master.key --clusterCaCert=certs/agent/issued/ca.crt --clusterCert=certs/agent/issued/proxy-master.crt --clusterKey=certs/agent/private/proxy-master.key
+./bin/proxy-server --mode=http-connect --server-ca-cert=certs/master/issued/ca.crt --server-cert=certs/master/issued/proxy-master.crt --server-key=certs/master/private/proxy-master.key --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-master.crt --cluster-key=certs/agent/private/proxy-master.key
 ```
 
 - Start agent service
 ```console
-./bin/proxy-agent --caCert=certs/agent/issued/ca.crt --agentCert=certs/agent/issued/proxy-agent.crt --agentKey=certs/agent/private/proxy-agent.key
+./bin/proxy-agent --ca-cert=certs/agent/issued/ca.crt --agent-cert=certs/agent/issued/proxy-agent.crt --agent-key=certs/agent/private/proxy-agent.key
 ```
 
 - Run client (mTLS & http-connect enabled sample client)
 ```console
-./bin/proxy-test-client --mode=http-connect  --proxyHost=127.0.0.1 --caCert=certs/master/issued/ca.crt --clientCert=certs/master/issued/proxy-client.crt --clientKey=certs/master/private/proxy-client.key
+./bin/proxy-test-client --mode=http-connect  --proxy-host=127.0.0.1 --ca-cert=certs/master/issued/ca.crt --client-cert=certs/master/issued/proxy-client.crt --client-key=certs/master/private/proxy-client.key
 ```
 
 - Run curl client (curl using a mTLS http-connect proxy)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -67,11 +67,11 @@ type GrpcProxyAgentOptions struct {
 
 func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("proxy-agent", pflag.ContinueOnError)
-	flags.StringVar(&o.agentCert, "agentCert", o.agentCert, "If non-empty secure communication with this cert.")
-	flags.StringVar(&o.agentKey, "agentKey", o.agentKey, "If non-empty secure communication with this key.")
-	flags.StringVar(&o.caCert, "caCert", o.caCert, "If non-empty the CAs we use to validate clients.")
-	flags.StringVar(&o.proxyServerHost, "proxyServerHost", o.proxyServerHost, "The hostname to use to connect to the proxy-server.")
-	flags.IntVar(&o.proxyServerPort, "proxyServerPort", o.proxyServerPort, "The port the proxy server is listening on.")
+	flags.StringVar(&o.agentCert, "agent-cert", o.agentCert, "If non-empty secure communication with this cert.")
+	flags.StringVar(&o.agentKey, "agent-key", o.agentKey, "If non-empty secure communication with this key.")
+	flags.StringVar(&o.caCert, "ca-cert", o.caCert, "If non-empty the CAs we use to validate clients.")
+	flags.StringVar(&o.proxyServerHost, "proxy-server-host", o.proxyServerHost, "The hostname to use to connect to the proxy-server.")
+	flags.IntVar(&o.proxyServerPort, "proxy-server-port", o.proxyServerPort, "The port the proxy server is listening on.")
 	return flags
 }
 

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -73,15 +73,15 @@ type GrpcProxyClientOptions struct {
 
 func (o *GrpcProxyClientOptions) Flags() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("proxy", pflag.ContinueOnError)
-	flags.StringVar(&o.clientCert, "clientCert", o.clientCert, "If non-empty secure communication with this cert.")
-	flags.StringVar(&o.clientKey, "clientKey", o.clientKey, "If non-empty secure communication with this key.")
-	flags.StringVar(&o.caCert, "caCert", o.caCert, "If non-empty the CAs we use to validate clients.")
-	flags.StringVar(&o.requestProto, "requestProto", o.requestProto, "The protocol for the request to send through the proxy.")
-	flags.StringVar(&o.requestPath, "requestPath", o.requestPath, "The url request to send through the proxy.")
-	flags.StringVar(&o.requestHost, "requestHost", o.requestHost, "The host of the request server.")
-	flags.IntVar(&o.requestPort, "requestPort", o.requestPort, "The port the request server is listening on.")
-	flags.StringVar(&o.proxyHost, "proxyHost", o.proxyHost, "The host of the proxy server.")
-	flags.IntVar(&o.proxyPort, "proxyPort", o.proxyPort, "The port the proxy server is listening on.")
+	flags.StringVar(&o.clientCert, "client-cert", o.clientCert, "If non-empty secure communication with this cert.")
+	flags.StringVar(&o.clientKey, "client-key", o.clientKey, "If non-empty secure communication with this key.")
+	flags.StringVar(&o.caCert, "ca-cert", o.caCert, "If non-empty the CAs we use to validate clients.")
+	flags.StringVar(&o.requestProto, "request-proto", o.requestProto, "The protocol for the request to send through the proxy.")
+	flags.StringVar(&o.requestPath, "request-path", o.requestPath, "The url request to send through the proxy.")
+	flags.StringVar(&o.requestHost, "request-host", o.requestHost, "The host of the request server.")
+	flags.IntVar(&o.requestPort, "request-port", o.requestPort, "The port the request server is listening on.")
+	flags.StringVar(&o.proxyHost, "proxy-host", o.proxyHost, "The host of the proxy server.")
+	flags.IntVar(&o.proxyPort, "proxy-port", o.proxyPort, "The port the proxy server is listening on.")
 	flags.StringVar(&o.mode, "mode", o.mode, "Mode can be either 'grpc' or 'http-connect'.")
 
 	return flags

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -78,16 +78,16 @@ type ProxyRunOptions struct {
 
 func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("proxy-server", pflag.ContinueOnError)
-	flags.StringVar(&o.serverCert, "serverCert", o.serverCert, "If non-empty secure communication with this cert.")
-	flags.StringVar(&o.serverKey, "serverKey", o.serverKey, "If non-empty secure communication with this key.")
-	flags.StringVar(&o.serverCaCert, "serverCaCert", o.serverCaCert, "If non-empty the CA we use to validate KAS clients.")
-	flags.StringVar(&o.clusterCert, "clusterCert", o.clusterCert, "If non-empty secure communication with this cert.")
-	flags.StringVar(&o.clusterKey, "clusterKey", o.clusterKey, "If non-empty secure communication with this key.")
-	flags.StringVar(&o.clusterCaCert, "clusterCaCert", o.clusterCaCert, "If non-empty the CA we use to validate Agent clients.")
+	flags.StringVar(&o.serverCert, "server-cert", o.serverCert, "If non-empty secure communication with this cert.")
+	flags.StringVar(&o.serverKey, "server-key", o.serverKey, "If non-empty secure communication with this key.")
+	flags.StringVar(&o.serverCaCert, "server-ca-cert", o.serverCaCert, "If non-empty the CA we use to validate KAS clients.")
+	flags.StringVar(&o.clusterCert, "cluster-cert", o.clusterCert, "If non-empty secure communication with this cert.")
+	flags.StringVar(&o.clusterKey, "cluster-key", o.clusterKey, "If non-empty secure communication with this key.")
+	flags.StringVar(&o.clusterCaCert, "cluster-ca-cert", o.clusterCaCert, "If non-empty the CA we use to validate Agent clients.")
 	flags.StringVar(&o.mode, "mode", "grpc", "Mode can be either 'grpc' or 'http-connect'.")
-	flags.UintVar(&o.serverPort, "serverPort", 8090, "Port we listen for server connections on.")
-	flags.UintVar(&o.agentPort, "agentPort", 8091, "Port we listen for agent connections on.")
-	flags.UintVar(&o.adminPort, "adminPort", 8092, "Port we listen for admin connections on.")
+	flags.UintVar(&o.serverPort, "server-port", 8090, "Port we listen for server connections on.")
+	flags.UintVar(&o.agentPort, "agent-port", 8091, "Port we listen for agent connections on.")
+	flags.UintVar(&o.adminPort, "admin-port", 8092, "Port we listen for admin connections on.")
 	return flags
 }
 


### PR DESCRIPTION
Fixes #24 
Kubernetes standards for command line flags is to use kebab-case note camelCase.
As such the agent, client and proxy should all be switched to use kebab-case.
