### PR TITLE
Fix error on DIAL_RSP for http-connect.

### DIFF
--- a/pkg/agent/agentserver/server.go
+++ b/pkg/agent/agentserver/server.go
@@ -44,6 +44,8 @@ func (c *ProxyClientConnection) send(pkt *agent.Packet) error {
 		} else if pkt.Type == agent.PacketType_DATA {
 			_, err := c.Http.Write(pkt.GetData().Data)
 			return err
+		} else if pkt.Type == agent.PacketType_DIAL_RSP {
+			return nil
 		} else {
 			return fmt.Errorf("attempt to send via unrecognized connection type %v", pkt.Type)
 		}

--- a/pkg/agent/agentserver/tunnel.go
+++ b/pkg/agent/agentserver/tunnel.go
@@ -75,6 +75,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t.Server.PendingDial[random] = connection
 	if t.Server.Backend == nil {
 		http.Error(w, "currently no tunnels available", http.StatusInternalServerError)
+		return
 	}
 	if err := t.Server.Backend.Send(dialRequest); err != nil {
 		klog.Errorf("failed to tunnel dial request %v", err)


### PR DESCRIPTION
As part of the handshake on a new tunnel the agent sends a DIAL_RSP.
The server "blindly" forwards this back to the client.
The http-connect code was not handling the DIAL_RSP as its not part of the protocol.
We now ignore the DIAL_RSP on http-connect rather than erroring on it.

Also fixed crash on client connecting when no agent connected.