### PR TITLE
Add concurrency test

### DIFF
--- a/tests/concurrent_test.go
+++ b/tests/concurrent_test.go
@@ -22,6 +22,9 @@ func TestProxy_Concurrency(t *testing.T) {
 	defer close(stopCh)
 
 	proxy, cleanup, err := runGRPCProxyServer()
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer cleanup()
 
 	if err := runAgent(proxy.agent, stopCh); err != nil {

--- a/tests/concurrent_test.go
+++ b/tests/concurrent_test.go
@@ -1,0 +1,71 @@
+package tests
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/client"
+)
+
+func TestProxy_Concurrency(t *testing.T) {
+	length := 1 << 20
+	chunks := 10
+	server := httptest.NewServer(newSizedServer(length, chunks))
+	defer server.Close()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	proxy, cleanup, err := runGRPCProxyServer()
+	defer cleanup()
+
+	if err := runAgent(proxy.agent, stopCh); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for agent to register on proxy server
+	time.Sleep(time.Second)
+
+	// run test client
+	tunnel, err := client.CreateGrpcTunnel(proxy.front, grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	verify := func() {
+		defer wg.Done()
+
+		c := &http.Client{
+			Transport: &http.Transport{
+				Dial: tunnel.Dial,
+			},
+		}
+
+		r, err := c.Get(server.URL)
+		if err != nil {
+			t.Error(err)
+		}
+
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(data) != length*chunks {
+			t.Errorf("expect data length %d; got %d", length*chunks, len(data))
+		}
+	}
+
+	concurrency := 10
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go verify()
+	}
+	wg.Wait()
+}

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -102,6 +102,9 @@ func TestProxy_LargeResponse(t *testing.T) {
 	defer close(stopCh)
 
 	proxy, cleanup, err := runGRPCProxyServer()
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer cleanup()
 
 	if err := runAgent(proxy.agent, stopCh); err != nil {

--- a/tests/tcp_server_test.go
+++ b/tests/tcp_server_test.go
@@ -1,0 +1,130 @@
+package tests
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"k8s.io/klog"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/client"
+)
+
+func echo(conn net.Conn) {
+	var data [256]byte
+
+	for {
+		n, err := conn.Read(data[:])
+		if err != nil {
+			klog.Info(err)
+			return
+		}
+
+		_, err = conn.Write(data[:n])
+		if err != nil {
+			klog.Info(err)
+			return
+		}
+	}
+}
+
+func TestEchoServer(t *testing.T) {
+	ln, err := net.Listen("tcp", "")
+	if err != nil {
+		t.Error(err)
+	}
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				klog.Info(err)
+				break
+			}
+			go echo(conn)
+		}
+	}()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	proxy, cleanup, err := runGRPCProxyServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	if err := runAgent(proxy.agent, stopCh); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for agent to register on proxy server
+	time.Sleep(time.Second)
+
+	// run test client
+	tunnel, err := client.CreateGrpcTunnel(proxy.front, grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := tunnel.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Error(err)
+	}
+
+	msg := "1234567890123456789012345"
+	n, err := conn.Write([]byte(msg))
+	if err != nil {
+		t.Error(err)
+	}
+	if n != len(msg) {
+		t.Errorf("expect write %d; got %d", len(msg), n)
+	}
+
+	var data [10]byte
+
+	n, err = conn.Read(data[:])
+	if err != nil {
+		t.Error(err)
+	}
+	if string(data[:n]) != msg[:10] {
+		t.Errorf("expect %s; got %s", msg[:10], string(data[:n]))
+	}
+
+	n, err = conn.Read(data[:])
+	if err != nil {
+		t.Error(err)
+	}
+	if string(data[:n]) != msg[10:20] {
+		t.Errorf("expect %s; got %s", msg[10:20], string(data[:n]))
+	}
+
+	msg2 := "1234567"
+	n, err = conn.Write([]byte(msg2))
+	if err != nil {
+		t.Error(err)
+	}
+	if n != len(msg2) {
+		t.Errorf("expect write %d; got %d", len(msg2), n)
+	}
+
+	n, err = conn.Read(data[:])
+	if err != nil {
+		t.Error(err)
+	}
+	if string(data[:n]) != msg[20:] {
+		t.Errorf("expect %s; got %s", msg[20:], string(data[:n]))
+	}
+
+	n, err = conn.Read(data[:])
+	if err != nil {
+		t.Error(err)
+	}
+	if string(data[:n]) != msg2 {
+		t.Errorf("expect %s; got %s", msg, string(data[:n]))
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Use 10 concurrent clients to send http request to remote server and download 10M bytes content from the server. Found an issue where we have concurrent write to a map. 

We could test protocols other than http as well in future.

Fix #26