### PR TITLE
Make proxy work even if proxy server is HA and is behind a LB

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -61,6 +63,9 @@ type GrpcProxyAgentOptions struct {
 	// Configuration for connecting to the proxy-server
 	proxyServerHost string
 	proxyServerPort int
+
+	agentID      string
+	syncInterval int
 }
 
 func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
@@ -70,6 +75,8 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.caCert, "ca-cert", o.caCert, "If non-empty the CAs we use to validate clients.")
 	flags.StringVar(&o.proxyServerHost, "proxy-server-host", o.proxyServerHost, "The hostname to use to connect to the proxy-server.")
 	flags.IntVar(&o.proxyServerPort, "proxy-server-port", o.proxyServerPort, "The port the proxy server is listening on.")
+	flags.StringVar(&o.agentID, "agent-id", o.agentID, "The unique ID of this agent. Default to a generated uuid if not set.")
+	flags.IntVar(&o.syncInterval, "sync-interval", o.syncInterval, "The seconds by which the agent periodically checks that it has connections to all instances of the proxy server.")
 	return flags
 }
 
@@ -79,6 +86,8 @@ func (o *GrpcProxyAgentOptions) Print() {
 	klog.Warningf("CACert set to \"%s\".\n", o.caCert)
 	klog.Warningf("ProxyServerHost set to \"%s\".\n", o.proxyServerHost)
 	klog.Warningf("ProxyServerPort set to %d.\n", o.proxyServerPort)
+	klog.Warningf("AgentID set to %s.\n", o.agentID)
+	klog.Warningf("SyncInterval set to %d.\n", o.syncInterval)
 }
 
 func (o *GrpcProxyAgentOptions) Validate() error {
@@ -116,6 +125,8 @@ func newGrpcProxyAgentOptions() *GrpcProxyAgentOptions {
 		caCert:          "",
 		proxyServerHost: "127.0.0.1",
 		proxyServerPort: 8091,
+		agentID:         uuid.New().String(),
+		syncInterval:    5,
 	}
 	return &o
 }
@@ -162,14 +173,8 @@ func (a *Agent) runProxyConnection(o *GrpcProxyAgentOptions) error {
 		return err
 	}
 	dialOption := grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
-	client, err := agentclient.NewAgentClient(fmt.Sprintf("%s:%d", o.proxyServerHost, o.proxyServerPort), dialOption)
-	if err != nil {
-		return err
-	}
-
-	stopCh := make(chan struct{})
-
-	go client.Serve(stopCh)
+	cs := agentclient.NewAgentClientSet(fmt.Sprintf("%s:%d", o.proxyServerHost, o.proxyServerPort), o.agentID, time.Duration(o.syncInterval)*time.Second, dialOption)
+	cs.Serve()
 
 	return nil
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -102,7 +102,7 @@ func (o *GrpcProxyAgentOptions) Print() {
 	klog.Warningf("ProxyServerHost set to \"%s\".\n", o.proxyServerHost)
 	klog.Warningf("ProxyServerPort set to %d.\n", o.proxyServerPort)
 	klog.Warningf("AgentID set to %s.\n", o.agentID)
-	klog.Warningf("SyncInterval set to %d.\n", o.syncInterval)
+	klog.Warningf("SyncInterval set to %d seconds.\n", o.syncInterval)
 	klog.Warningf("ProbeInterval set to %d.\n", o.probeInterval)
 	klog.Warningf("ReconnectInterval set to %d.\n", o.reconnectInterval)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,17 @@ go 1.12
 require (
 	github.com/beorn7/perks v1.0.0 // indirect
 	github.com/golang/protobuf v1.3.2
+	github.com/google/uuid v1.1.1
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/common v0.4.0 // indirect
 	github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/sys v0.0.0-20190225065934-cc5685c2db12 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/grpc v1.26.0
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/klog v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -21,9 +21,9 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/agent/agentclient/client.go
+++ b/pkg/agent/agentclient/client.go
@@ -33,21 +33,33 @@ type AgentClient struct {
 	nextConnID  int64
 	connContext map[int64]*connContext
 
-	stream *RedialableAgentClient
+	stream      *RedialableAgentClient
+	serverID    string // the proxy server this client connects to
+	serverCount int    // number of proxy servers, 1 if server is not HA.
+	stopCh      <-chan struct{}
 }
 
-// NewAgentClient creates an AgentClient
-func NewAgentClient(address string, opts ...grpc.DialOption) (*AgentClient, error) {
-	stream, err := NewRedialableAgentClient(address, opts...)
+func newAgentClient(address, agentID string, cs *ClientSet, opts ...grpc.DialOption) (*AgentClient, error) {
+	stream, err := NewRedialableAgentClient(address, agentID, cs, opts...)
 	if err != nil {
 		return nil, err
 	}
+	return newAgentClientWithRedialableAgentClient(stream), nil
+}
 
-	a := &AgentClient{
+func newAgentClientWithRedialableAgentClient(rac *RedialableAgentClient) *AgentClient {
+	return &AgentClient{
 		connContext: make(map[int64]*connContext),
-		stream:      stream,
+		stream:      rac,
+		serverID:    rac.serverID,
+		serverCount: rac.serverCount,
+		stopCh:      rac.stopCh,
 	}
-	return a, nil
+}
+
+// Close closes the underlying stream.
+func (c *AgentClient) Close() {
+	c.stream.Close()
 }
 
 // connContext tracks a connection from agent to node network.
@@ -75,10 +87,12 @@ func (c *connContext) cleanup() {
 // gRPC stream. Successful Connect is required before Serve. The
 // The requests include things like opening a connection to a server,
 // streaming data and close the connection.
-func (a *AgentClient) Serve(stopCh <-chan struct{}) {
+func (a *AgentClient) Serve() {
+	klog.Infof("Start serving for serverID %s", a.serverID)
+	go a.stream.probe()
 	for {
 		select {
-		case <-stopCh:
+		case <-a.stopCh:
 			klog.Info("stop agent client.")
 			return
 		default:

--- a/pkg/agent/agentclient/client.go
+++ b/pkg/agent/agentclient/client.go
@@ -33,10 +33,8 @@ type AgentClient struct {
 	nextConnID  int64
 	connContext map[int64]*connContext
 
-	stream      *RedialableAgentClient
-	serverID    string // the proxy server this client connects to
-	serverCount int    // number of proxy servers, 1 if server is not HA.
-	stopCh      <-chan struct{}
+	stream *RedialableAgentClient
+	stopCh <-chan struct{}
 }
 
 func newAgentClient(address, agentID string, cs *ClientSet, opts ...grpc.DialOption) (*AgentClient, error) {
@@ -51,8 +49,6 @@ func newAgentClientWithRedialableAgentClient(rac *RedialableAgentClient) *AgentC
 	return &AgentClient{
 		connContext: make(map[int64]*connContext),
 		stream:      rac,
-		serverID:    rac.serverID,
-		serverCount: rac.serverCount,
 		stopCh:      rac.stopCh,
 	}
 }
@@ -88,7 +84,7 @@ func (c *connContext) cleanup() {
 // The requests include things like opening a connection to a server,
 // streaming data and close the connection.
 func (a *AgentClient) Serve() {
-	klog.Infof("Start serving for serverID %s", a.serverID)
+	klog.Infof("Start serving for serverID %s", a.stream.serverID)
 	go a.stream.probe()
 	for {
 		select {

--- a/pkg/agent/agentclient/client.go
+++ b/pkg/agent/agentclient/client.go
@@ -55,6 +55,10 @@ func newAgentClientWithRedialableAgentClient(rac *RedialableAgentClient) *AgentC
 
 // Close closes the underlying stream.
 func (c *AgentClient) Close() {
+	if c.stream == nil {
+		klog.Warning("Unexpected empty AgentClient.stream")
+		return
+	}
 	c.stream.Close()
 }
 

--- a/pkg/agent/agentclient/client_test.go
+++ b/pkg/agent/agentclient/client_test.go
@@ -17,14 +17,15 @@ import (
 func TestServeData_HTTP(t *testing.T) {
 	var err error
 	var stream agent.AgentService_ConnectClient
+	stopCh := make(chan struct{})
 	client := &AgentClient{
 		connContext: make(map[int64]*connContext),
+		stopCh:      stopCh,
 	}
 	client.stream, stream = pipe2()
-	stopCh := make(chan struct{})
 
 	// Start agent
-	go client.Serve(stopCh)
+	go client.Serve()
 	defer close(stopCh)
 
 	// Start test http server as remote service
@@ -112,14 +113,15 @@ func TestServeData_HTTP(t *testing.T) {
 
 func TestClose_Client(t *testing.T) {
 	var stream agent.AgentService_ConnectClient
+	stopCh := make(chan struct{})
 	client := &AgentClient{
 		connContext: make(map[int64]*connContext),
+		stopCh:      stopCh,
 	}
 	client.stream, stream = pipe2()
-	stopCh := make(chan struct{})
 
 	// Start agent
-	go client.Serve(stopCh)
+	go client.Serve()
 	defer close(stopCh)
 
 	// Start test http server as remote service

--- a/pkg/agent/agentclient/clientset.go
+++ b/pkg/agent/agentclient/clientset.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentclient
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"k8s.io/klog"
+)
+
+// ClientSet consists of clients connected to each instance of an HA proxy server.
+type ClientSet struct {
+	mu      sync.Mutex              //protects the following
+	clients map[string]*AgentClient // map between serverID and the client
+	// connects to this server.
+
+	agentID     string // ID of this agent
+	address     string // proxy server address. Assuming HA proxy server
+	serverCount int    // number of proxy server instances, should be 1
+	// unless it is an HA server. Initialized when the ClientSet creates
+	// the first client.
+	syncInterval time.Duration // The interval by which the agent
+	// periodically checks that it has connections to all instances of the
+	// proxy server.
+	dialOption grpc.DialOption
+}
+
+func (cs *ClientSet) clientsCount() int {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return len(cs.clients)
+}
+
+func (cs *ClientSet) hasIDLocked(serverID string) bool {
+	_, ok := cs.clients[serverID]
+	return ok
+}
+
+func (cs *ClientSet) HasID(serverID string) bool {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.hasIDLocked(serverID)
+}
+
+func (cs *ClientSet) addClientLocked(serverID string, c *AgentClient) error {
+	if cs.hasIDLocked(serverID) {
+		return fmt.Errorf("client for proxy server %s already exists", serverID)
+	}
+	cs.clients[serverID] = c
+	return nil
+
+}
+
+func (cs *ClientSet) AddClient(serverID string, c *AgentClient) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	return cs.addClientLocked(serverID, c)
+}
+
+func (cs *ClientSet) RemoveClient(serverID string) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	delete(cs.clients, serverID)
+}
+
+func NewAgentClientSet(address, agentID string, syncInterval time.Duration, dialOption grpc.DialOption) *ClientSet {
+	return &ClientSet{
+		clients:      make(map[string]*AgentClient),
+		agentID:      agentID,
+		address:      address,
+		syncInterval: syncInterval,
+		dialOption:   dialOption,
+	}
+}
+
+func (cs *ClientSet) newAgentClient() (*AgentClient, error) {
+	return newAgentClient(cs.address, cs.agentID, cs, cs.dialOption)
+}
+
+// sync makes sure that #clients >= #proxy servers
+func (cs *ClientSet) sync() {
+	jitter := float64(0.2)
+	for {
+		if cs.serverCount != 0 {
+			sleep := cs.syncInterval + time.Duration(rand.Float64()*jitter*float64(cs.syncInterval))
+			time.Sleep(sleep)
+		}
+		if cs.serverCount == 0 || cs.clientsCount() < cs.serverCount {
+			c, err := cs.newAgentClient()
+			if err != nil {
+				klog.Error(err)
+				continue
+			}
+			cs.serverCount = c.serverCount
+			if err := cs.AddClient(c.serverID, c); err != nil {
+				klog.Infof("closing connection: %v", err)
+				c.Close()
+				continue
+			}
+			klog.Infof("sync added client connecting to proxy server %s", c.serverID)
+			go c.Serve()
+		}
+	}
+}
+
+func (cs *ClientSet) Serve() {
+	go cs.sync()
+}

--- a/pkg/agent/agentclient/clientset.go
+++ b/pkg/agent/agentclient/clientset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import (
 
 // ClientSet consists of clients connected to each instance of an HA proxy server.
 type ClientSet struct {
-	mu      sync.Mutex              //protects the following
+	mu      sync.Mutex              //protects the clients.
 	clients map[string]*AgentClient // map between serverID and the client
 	// connects to this server.
 

--- a/pkg/agent/agentclient/clientset.go
+++ b/pkg/agent/agentclient/clientset.go
@@ -138,13 +138,13 @@ func (cs *ClientSet) sync() {
 				klog.Error(err)
 				continue
 			}
-			cs.serverCount = c.serverCount
-			if err := cs.AddClient(c.serverID, c); err != nil {
+			cs.serverCount = c.stream.serverCount
+			if err := cs.AddClient(c.stream.serverID, c); err != nil {
 				klog.Infof("closing connection: %v", err)
 				c.Close()
 				continue
 			}
-			klog.Infof("sync added client connecting to proxy server %s", c.serverID)
+			klog.Infof("sync added client connecting to proxy server %s", c.stream.serverID)
 			go c.Serve()
 		}
 	}

--- a/pkg/agent/agentclient/stream.go
+++ b/pkg/agent/agentclient/stream.go
@@ -365,5 +365,8 @@ func (c *RedialableAgentClient) tryConnect() (connectResult, error) {
 }
 
 func (c *RedialableAgentClient) Close() {
+	if c.conn == nil {
+		klog.Warning("Unexpected empty RedialableAgentClient.stream")
+	}
 	c.conn.Close()
 }

--- a/pkg/agent/agentclient/stream_test.go
+++ b/pkg/agent/agentclient/stream_test.go
@@ -53,7 +53,7 @@ func TestReconnectExits(t *testing.T) {
 		}
 	}()
 
-	client.interrupt()
+	client.Close()
 
 	var got1 bool
 	var got2 bool

--- a/pkg/agent/agentserver/server_test.go
+++ b/pkg/agent/agentserver/server_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentserver
+
+import (
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
+)
+
+type fakeAgentService_ConnectServer struct {
+	agent.AgentService_ConnectServer
+}
+
+func TestAddRemoveBackends(t *testing.T) {
+	conn1 := new(fakeAgentService_ConnectServer)
+	conn12 := new(fakeAgentService_ConnectServer)
+	conn2 := new(fakeAgentService_ConnectServer)
+	conn22 := new(fakeAgentService_ConnectServer)
+	conn3 := new(fakeAgentService_ConnectServer)
+
+	p := NewProxyServer("", 1)
+	p.addBackend("agent1", conn1)
+	p.removeBackend("agent1", conn1)
+	expectedBackends := make(map[string][]agent.AgentService_ConnectServer)
+	expectedAgentIDs := []string{}
+	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	p = NewProxyServer("", 1)
+	p.addBackend("agent1", conn1)
+	p.addBackend("agent1", conn12)
+	p.addBackend("agent2", conn2)
+	p.addBackend("agent2", conn22)
+	p.addBackend("agent3", conn3)
+	p.removeBackend("agent2", conn2)
+	p.removeBackend("agent2", conn22)
+	p.removeBackend("agent1", conn1)
+	expectedBackends = map[string][]agent.AgentService_ConnectServer{
+		"agent1": []agent.AgentService_ConnectServer{conn12},
+		"agent3": []agent.AgentService_ConnectServer{conn3},
+	}
+	expectedAgentIDs = []string{"agent1", "agent3"}
+	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}

--- a/proto/header/header.go
+++ b/proto/header/header.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package header
+
+const (
+	ServerCount = "serverCount"
+	ServerID    = "serverID"
+	AgentID     = "agentID"
+)

--- a/tests/concurrent_test.go
+++ b/tests/concurrent_test.go
@@ -27,9 +27,7 @@ func TestProxy_Concurrency(t *testing.T) {
 	}
 	defer cleanup()
 
-	if err := runAgent(proxy.agent, stopCh); err != nil {
-		t.Fatal(err)
-	}
+	runAgent(proxy.agent, stopCh)
 
 	// Wait for agent to register on proxy server
 	time.Sleep(time.Second)

--- a/tests/ha_proxy_server_test.go
+++ b/tests/ha_proxy_server_test.go
@@ -1,0 +1,211 @@
+package tests
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/client"
+)
+
+type tcpLB struct {
+	t        *testing.T
+	mu       sync.RWMutex
+	backends []string
+}
+
+func copy(wc io.WriteCloser, r io.Reader) {
+	defer wc.Close()
+	io.Copy(wc, r)
+}
+
+func (lb *tcpLB) handleConnection(in net.Conn, backend string) {
+	out, err := net.Dial("tcp", backend)
+	if err != nil {
+		lb.t.Log(err)
+		return
+	}
+	go copy(out, in)
+	go copy(in, out)
+}
+
+func (lb *tcpLB) serve(stopCh chan struct{}) {
+	ln, err := net.Listen("tcp", ":8000")
+	if err != nil {
+		log.Fatalf("failed to bind: %s", err)
+	}
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+		conn, err := ln.Accept()
+		if err != nil {
+			log.Printf("failed to accept: %s", err)
+			continue
+		}
+		// go lb.handleConnection(conn, lb.randomBackend())
+		back := lb.randomBackend()
+		go lb.handleConnection(conn, back)
+	}
+}
+
+func (lb *tcpLB) addBackend(backend string) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	lb.backends = append(lb.backends, backend)
+}
+
+func (lb *tcpLB) removeBackend(backend string) {
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+	for i := range lb.backends {
+		if lb.backends[i] == backend {
+			lb.backends = append(lb.backends[:i], lb.backends[i+1:]...)
+			return
+		}
+	}
+}
+
+func (lb *tcpLB) randomBackend() string {
+	lb.mu.RLock()
+	defer lb.mu.RUnlock()
+	i := rand.Intn(len(lb.backends))
+	return lb.backends[i]
+}
+
+const haServerCount = 3
+
+func setupHAProxyServer(t *testing.T) ([]proxy, []func()) {
+	proxy1, cleanup1, err := runGRPCProxyServerWithServerCount(haServerCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy2, cleanup2, err := runGRPCProxyServerWithServerCount(haServerCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy3, cleanup3, err := runGRPCProxyServerWithServerCount(haServerCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return []proxy{proxy1, proxy2, proxy3}, []func(){cleanup1, cleanup2, cleanup3}
+}
+
+func TestBasicHAProxyServer_GRPC(t *testing.T) {
+	server := httptest.NewServer(newEchoServer("hello"))
+	defer server.Close()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	proxy, cleanups := setupHAProxyServer(t)
+
+	lb := tcpLB{
+		backends: []string{
+			proxy[0].agent,
+			proxy[1].agent,
+			proxy[2].agent,
+		},
+		t: t,
+	}
+	go lb.serve(stopCh)
+
+	clientset := runAgent(":8000", stopCh)
+
+	var ready bool
+	var hc, cc int
+	for i := 0; i < 3; i++ {
+		time.Sleep(1 * time.Second)
+		hc, cc = clientset.HealthyClientsCount(), clientset.ClientsCount()
+		t.Logf("got %d clients, %d of them are healthy", hc, cc)
+		if hc == 3 && cc == 3 {
+			ready = true
+			break
+		}
+	}
+	if !ready {
+		t.Fatalf("expected to get 3 clients, got %d clients, %d healthy clients", hc, cc)
+	}
+
+	// run test client
+	testProxyServer(t, proxy[0].front, server.URL)
+	testProxyServer(t, proxy[1].front, server.URL)
+	testProxyServer(t, proxy[2].front, server.URL)
+
+	t.Logf("basic HA proxy server test passed")
+
+	// interrupt the HA server
+	lb.removeBackend(proxy[0].agent)
+	cleanups[0]()
+
+	proxy4, cleanup4, err := runGRPCProxyServerWithServerCount(haServerCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lb.addBackend(proxy4.agent)
+	defer func() {
+		cleanups[1]()
+		cleanups[2]()
+		cleanup4()
+	}()
+	// give the agent some time to detect the disconnection
+	time.Sleep(1 * time.Second)
+
+	ready = false
+	for i := 0; i < 3; i++ {
+		time.Sleep(1 * time.Second)
+		hc, cc = clientset.HealthyClientsCount(), clientset.ClientsCount()
+		t.Logf("got %d clients, %d of them are healthy", hc, cc)
+		if hc == 3 && (cc == 3 || cc == 4) {
+			ready = true
+			break
+		}
+	}
+	if !ready {
+		t.Fatalf("expected to get 3 clients, got %d clients, %d healthy clients", hc, cc)
+	}
+	// run test client
+	testProxyServer(t, proxy[1].front, server.URL)
+	testProxyServer(t, proxy[2].front, server.URL)
+	testProxyServer(t, proxy4.front, server.URL)
+}
+
+func testProxyServer(t *testing.T, front string, target string) {
+	tunnel, err := client.CreateGrpcTunnel(front, grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := &http.Client{
+		Transport: &http.Transport{
+			Dial: tunnel.Dial,
+		},
+		Timeout: 1 * time.Second,
+	}
+
+	r, err := c.Get(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(data) != "hello" {
+		t.Errorf("expect %v; got %v", "hello", string(data))
+	}
+}

--- a/tests/tcp_server_test.go
+++ b/tests/tcp_server_test.go
@@ -54,9 +54,7 @@ func TestEchoServer(t *testing.T) {
 	}
 	defer cleanup()
 
-	if err := runAgent(proxy.agent, stopCh); err != nil {
-		t.Fatal(err)
-	}
+	runAgent(proxy.agent, stopCh)
 
 	// Wait for agent to register on proxy server
 	time.Sleep(time.Second)


### PR DESCRIPTION
This PR makes the proxy works for the following setup:

We have an HA k8s master, each kube-apiserver instance is accompanied by a proxy server instance. We need to ensure that every proxy server instance is connected to at least one proxy agent, so that every kube-apiserver instance can reach to the cluster nodes.

In some k8s deployments, the proxy server instances are behind a LB. Upon receiving a Connect RPC call from the proxy agent, the LB randomly picks an instance of the HA proxy server, and forwards the request to it. Thus, the current code cannot guarantee that every proxy server has connections to at least one proxy agents.

This PR makes the proxy agent establish connection with all instances of the proxy server. To overcome the randomness caused by the LB, the proxy agent tracks the proxy server ID when it makes connection, and it keeps making connections until it has connections to all proxy servers. If there are multiple connections to the same proxy server instance, the proxy agent only keeps the oldest one.

/assign @Jefftree @cheftako 
/cc @anfernee