### PR TITLE
Adding support for agent authenticate server by using kubeapi-server ca 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ python -m SimpleHTTPServer
 curl -v -p --proxy-key certs/master/private/proxy-client.key --proxy-cert certs/master/issued/proxy-client.crt --proxy-cacert certs/master/issued/ca.crt --proxy-cert-type PEM -x https://127.0.0.1:8090  http://localhost:8000```
 ```
 
+### Running on kubernetes
+See following [README.md](examples/kubernetes/README.md) 
+
 ## Troubleshoot
 
 ### Undefined ProtoPackageIsVersion3
@@ -118,4 +121,3 @@ protoc-gen-go binary has to be built from the vendored version:
 go install ./vendor/github.com/golang/protobuf/protoc-gen-go
 make gen
 ```
-

--- a/artifacts/images/client-build.Dockerfile
+++ b/artifacts/images/client-build.Dockerfile
@@ -1,0 +1,19 @@
+# Build the client binary
+FROM golang:1.12.1 as builder
+
+# Copy in the go src
+WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy
+COPY pkg/    pkg/
+COPY cmd/    cmd/
+COPY proto/  proto/
+COPY vendor/ vendor/
+
+# Build
+ARG ARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o proxy-test-client sigs.k8s.io/apiserver-network-proxy/cmd/client
+
+# Copy the loader into a thin image
+FROM scratch
+WORKDIR /
+COPY --from=builder /go/src/sigs.k8s.io/apiserver-network-proxy/proxy-test-client .
+ENTRYPOINT ["/proxy-test-client"]

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,53 @@
+# HTTP-Connect Client using UDS Proxy with dial back Agent runs on kubernetes cluster
+
+# Push all images to container registry
+```console
+TAG=$(git rev-parse HEAD)
+make docker-push TAG=${TAG}
+```
+
+# Start a test web-server as a kubernetes pod & service
+```bash
+kubectl apply -f examples/kubernetes/kubia.yaml
+```
+
+# Initialize environment variables
+*CLUSTER_CERT* and *CLUSTER_KEY* are certificates used for starting [kubernetes API server](https://kubernetes.io/docs/concepts/cluster-administration/certificates/)
+
+```bash
+CLUSTER_IP=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed -n "s/https\:\/\/\(\S*\).*$/\1/p")
+KUBIA_IP=$(kubectl get svc kubia -o=jsonpath='{.spec.clusterIP}')
+PROXY_IMAGE=$(docker images | grep "proxy-server-" -m1 | awk '{print $1}')
+AGENT_IMAGE=$(docker images | grep "proxy-agent-" -m1 | awk '{print $1}')
+TEST_CLIENT_IMAGE=$(docker images | grep "proxy-test-client-" -m1 | awk '{print $1}')
+CLUSTER_CERT=<yourdirectory/server.crt>
+CLUSTER_KEY=</yourdirectory/server.key>
+```
+
+#### GKE specific configuration
+```bash
+CLUSTER_CERT=/etc/srv/kubernetes/pki/apiserver.crt
+CLUSTER_KEY=/etc/srv/kubernetes/pki/apiserver.key
+```
+
+# Start **proxy-server** as a [static pod](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/) with following configuration
+```bash
+TAG=${TAG} PROXY_IMAGE=${PROXY_IMAGE} CLUSTER_CERT=${CLUSTER_CERT} CLUSTER_KEY=${CLUSTER_KEY} envsubst <  examples/kubernetes/konnectivity-server.yaml
+```
+#### GKE specific configuration
+*/etc/kubernetes/manifests* is a folder where .yaml file needs to be created for static pod
+
+# Start **proxy-agent** as a kubernetes pod
+```bash
+TAG=${TAG} AGENT_IMAGE=${AGENT_IMAGE} CLUSTER_IP=${CLUSTER_IP}  envsubst < examples/kubernetes/konnectivity-agent.yaml | kubectl apply -f -
+```
+
+# Run **test-client** as a [static pod](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/) with following configuration on same machine where **proxy-server** runs
+```bash
+TAG=${TAG} KUBIA_IP=${KUBIA_IP} TEST_CLIENT_IMAGE=${TEST_CLIENT_IMAGE} envsubst < examples/kubernetes/konnectivity-test-client.yaml
+```
+
+Last row in the following log file **/var/log/konnectivity-test-client.log** supposed to be: **You've hit kubia**
+
+#### GKE specific configuration
+*/etc/kubernetes/manifests* is a folder where .yaml file needs to be created for static pod

--- a/examples/kubernetes/konnectivity-agent.yaml
+++ b/examples/kubernetes/konnectivity-agent.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: konnectivity-agent
+  namespace: default
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+spec:
+  hostNetwork: true
+  containers:
+  - name: konnectivity-agent-container
+    image: ${AGENT_IMAGE}:${TAG}
+    resources:
+      requests:
+        cpu: 40m
+    command: [ "/proxy-agent"]
+    args: [
+      "--logtostderr=true",
+      "--ca-cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+      "--proxy-server-host=${CLUSTER_IP}",
+      "--proxy-server-port=8091",
+      ]
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        host: 127.0.0.1
+        port: 8093
+        path: /healthz
+      initialDelaySeconds: 15
+      timeoutSeconds: 15
+    resources:
+      limits:
+        cpu: 50m
+        memory: 30Mi

--- a/examples/kubernetes/konnectivity-server.yaml
+++ b/examples/kubernetes/konnectivity-server.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: konnectivity-server
+  namespace: kube-system
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+spec:
+  hostNetwork: true
+  containers:
+  - name: konnectivity-server-container
+    image: ${PROXY_IMAGE}:${TAG}
+    resources:
+      requests:
+        cpu: 1m
+    command: [ "/proxy-server"]
+    args: [
+      "--log-file=/var/log/konnectivity-server.log",
+      "--logtostderr=false",
+      "--log-file-max-size=0",
+      "--udsName=/etc/srv/kubernetes/konnectivity/konnectivity-server.socket",
+      "--cluster-cert=/etc/srv/kubernetes/pki/apiserver.crt",
+      "--cluster-key=/etc/srv/kubernetes/pki/apiserver.key",
+      "--server-port=0",
+      "--agent-port=8091",
+      "--admin-port=8092",
+      "--mode=http-connect"
+      ]
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        host: 127.0.0.1
+        port: 8092
+        path: /healthz
+      initialDelaySeconds: 10
+      timeoutSeconds: 60
+    ports:
+    - name: serverport
+      containerPort: 8090
+      hostPort: 8090
+    - name: agentport
+      containerPort: 8091
+      hostPort: 8091
+    - name: adminport
+      containerPort: 8092
+      hostPort: 8092
+    volumeMounts:
+    - name: varlogkonnectivityserver
+      mountPath: /var/log/konnectivity-server.log
+      readOnly: false
+    - name: pki
+      mountPath: /etc/srv/kubernetes/pki
+      readOnly: true
+    - name: konnectivity-home
+      mountPath: /etc/srv/kubernetes/konnectivity
+  volumes:
+  - name: varlogkonnectivityserver
+    hostPath:
+      path: /var/log/konnectivity-server.log
+      type: FileOrCreate
+  - name: pki
+    hostPath:
+      path: /etc/srv/kubernetes/pki
+  - name: konnectivity-home
+    hostPath:
+      path: /etc/srv/kubernetes/konnectivity
+      type: DirectoryOrCreate
+

--- a/examples/kubernetes/konnectivity-test-client.yaml
+++ b/examples/kubernetes/konnectivity-test-client.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: konnectivity-test-client
+  namespace: kube-system
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+spec:
+  hostNetwork: true
+  restartPolicy: Never
+  containers:
+  - name: konnectivity-test-client
+    image: ${TEST_CLIENT_IMAGE}:${TAG}
+    resources:
+      requests:
+        cpu: 1m
+    command: [ "/proxy-test-client"]
+    args: [
+      "--log-file=/var/log/konnectivity-test-client.log",
+      "--logtostderr=false",
+      "--proxy-uds=/etc/srv/kubernetes/konnectivity/konnectivity-server.socket",
+      "--proxy-host=",
+      "--proxy-port=0",
+      "--mode=http-connect",
+      "--request-port=80",
+      "--request-host=${KUBIA_IP}",
+      ]
+    volumeMounts:
+    - name: konnectivity-test-log
+      mountPath: /var/log/konnectivity-test-client.log
+      readOnly: false
+    - name: konnectivity-home
+      mountPath: /etc/srv/kubernetes/konnectivity
+  volumes:
+  - name: konnectivity-test-log
+    hostPath:
+      path: /var/log/konnectivity-test-client.log
+      type: FileOrCreate
+  - name: konnectivity-home
+    hostPath:
+      path: /etc/srv/kubernetes/konnectivity
+      type: DirectoryOrCreate

--- a/examples/kubernetes/kubia.yaml
+++ b/examples/kubernetes/kubia.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kubia
+  labels:
+    app: kubia
+spec:
+  containers:
+  - image: luksa/kubia
+    name: kubia
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubia
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: kubia
+

--- a/pkg/util/certificates.go
+++ b/pkg/util/certificates.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+)
+
+func getCACertPool(caFile string) (*x509.CertPool, error) {
+	certPool := x509.NewCertPool()
+	caCert, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert %s: %v", caFile, err)
+	}
+	ok := certPool.AppendCertsFromPEM(caCert)
+	if !ok {
+		return nil, fmt.Errorf("failed to append CA cert to the cert pool")
+	}
+	return certPool, nil
+}
+
+// GetClientTLSConfig returns tlsConfig based on x509 certs
+func GetClientTLSConfig(caFile, certFile, keyFile, serverName string) (*tls.Config, error) {
+	certPool, err := getCACertPool(caFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if certFile == "" && keyFile == "" {
+		// return TLS config based on CA only
+		tlsConfig := &tls.Config{
+			RootCAs: certPool,
+		}
+		return tlsConfig, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load X509 key pair %s and %s: %v", certFile, keyFile, err)
+	}
+
+	tlsConfig := &tls.Config{
+		ServerName:   serverName,
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      certPool,
+	}
+	return tlsConfig, nil
+}


### PR DESCRIPTION
The PR allows to reuse certificate generated for kubelet by proxy/agent/test-client, instead of generating dedicated set of certificates for proxy / agent / test-agent.

### Server
Proxy-server runs as a static  pod on master and initializes a grpc server with   /etc/srv/kubernetes/pki/apiserver.crt & /etc/srv/kubernetes/pki/apiserver.key (no CA certificate)

### Agent
Agent runs on node as a regular pod. It uses existing /var/run/secrets/kubernetes.io/serviceaccount/ca.crt (ca.crt bounds in every pod by k8s) to validate proxy-server's certificate returns during tls handshake.

### Test-Clinet
As part of the tests, test-client runs on master VM as a static pod and communicates with proxy-server via UDS.

