### PR TITLE
Let the proxy server handle concurrent client requests correctly

### DIFF
--- a/pkg/agent/agentserver/backend_manager.go
+++ b/pkg/agent/agentserver/backend_manager.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentserver
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	"k8s.io/klog"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
+)
+
+// BackendManager is an interface to manage backend connections, i.e.,
+// connection to the proxy agents.
+type BackendManager interface {
+	// Backend returns a single backend.
+	Backend() (agent.AgentService_ConnectServer, error)
+	// AddBackend adds a backend.
+	AddBackend(agentID string, conn agent.AgentService_ConnectServer)
+	// RemoveBackend removes a backend.
+	RemoveBackend(agentID string, conn agent.AgentService_ConnectServer)
+}
+
+var _ BackendManager = &DefaultBackendManager{}
+
+// DefaultBackendManager is the default backend manager.
+type DefaultBackendManager struct {
+	mu sync.RWMutex //protects the following
+	// A map between agentID and its grpc connections.
+	// For a given agent, ProxyServer prefers backends[agentID][0] to send
+	// traffic, because backends[agentID][1:] are more likely to be closed
+	// by the agent to deduplicate connections to the same server.
+	backends map[string][]agent.AgentService_ConnectServer
+	// agentID is tracked in this slice to enable randomly picking an
+	// agentID in the Backend() method. There is no reliable way to
+	// randomly pick a key from a map (in this case, the backends) in
+	// Golang.
+	agentIDs []string
+	random   *rand.Rand
+}
+
+// NewDefaultBackendManager returns a DefaultBackendManager.
+func NewDefaultBackendManager() *DefaultBackendManager {
+	return &DefaultBackendManager{
+		backends: make(map[string][]agent.AgentService_ConnectServer),
+		random:   rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// AddBackend adds a backend.
+func (s *DefaultBackendManager) AddBackend(agentID string, conn agent.AgentService_ConnectServer) {
+	klog.Infof("register Backend %v for agentID %s", conn, agentID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.backends[agentID]
+	if ok {
+		for _, v := range s.backends[agentID] {
+			if v == conn {
+				klog.Warningf("this should not happen. Adding existing connection %v for agentID %s", conn, agentID)
+				return
+			}
+		}
+		s.backends[agentID] = append(s.backends[agentID], conn)
+		return
+	}
+	s.backends[agentID] = []agent.AgentService_ConnectServer{conn}
+	s.agentIDs = append(s.agentIDs, agentID)
+}
+
+// RemoveBackend removes a backend.
+func (s *DefaultBackendManager) RemoveBackend(agentID string, conn agent.AgentService_ConnectServer) {
+	klog.Infof("remove Backend %v for agentID %s", conn, agentID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	backends, ok := s.backends[agentID]
+	if !ok {
+		klog.Warningf("can't find agentID %s in the backends", agentID)
+		return
+	}
+	var found bool
+	for i, c := range backends {
+		if c == conn {
+			s.backends[agentID] = append(s.backends[agentID][:i], s.backends[agentID][i+1:]...)
+			if i == 0 && len(s.backends) != 0 {
+				klog.Warningf("this should not happen. Removed connection %v that is not the first connection, remaining connections are %v", conn, s.backends[agentID])
+			}
+			found = true
+		}
+	}
+	if len(s.backends[agentID]) == 0 {
+		delete(s.backends, agentID)
+		for i := range s.agentIDs {
+			if s.agentIDs[i] == agentID {
+				s.agentIDs[i] = s.agentIDs[len(s.agentIDs)-1]
+				s.agentIDs = s.agentIDs[:len(s.agentIDs)-1]
+				break
+			}
+		}
+	}
+	if !found {
+		klog.Errorf("can't find conn %v for agentID %s in the backends", conn, agentID)
+	}
+}
+
+// ErrNotFound indicates that no backend can be found.
+type ErrNotFound struct{}
+
+// Error returns the error message.
+func (e *ErrNotFound) Error() string {
+	return "No backend available"
+}
+
+// Backend returns a random backend.
+func (s *DefaultBackendManager) Backend() (agent.AgentService_ConnectServer, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.backends) == 0 {
+		return nil, &ErrNotFound{}
+	}
+	agentID := s.agentIDs[s.random.Intn(len(s.agentIDs))]
+	// always return the first connection to an agent, because the agent
+	// will close later connections if there are multiple.
+	return s.backends[agentID][0], nil
+}

--- a/pkg/agent/agentserver/backend_manager_test.go
+++ b/pkg/agent/agentserver/backend_manager_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agentserver
+
+import (
+	"reflect"
+	"testing"
+
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
+)
+
+type fakeAgentService_ConnectServer struct {
+	agent.AgentService_ConnectServer
+}
+
+func TestAddRemoveBackends(t *testing.T) {
+	conn1 := new(fakeAgentService_ConnectServer)
+	conn12 := new(fakeAgentService_ConnectServer)
+	conn2 := new(fakeAgentService_ConnectServer)
+	conn22 := new(fakeAgentService_ConnectServer)
+	conn3 := new(fakeAgentService_ConnectServer)
+
+	p := NewDefaultBackendManager()
+
+	p.AddBackend("agent1", conn1)
+	p.RemoveBackend("agent1", conn1)
+	expectedBackends := make(map[string][]agent.AgentService_ConnectServer)
+	expectedAgentIDs := []string{}
+	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	p = NewDefaultBackendManager()
+	p.AddBackend("agent1", conn1)
+	p.AddBackend("agent1", conn12)
+	// Adding the same connection again should be a no-op.
+	p.AddBackend("agent1", conn12)
+	p.AddBackend("agent2", conn2)
+	p.AddBackend("agent2", conn22)
+	p.AddBackend("agent3", conn3)
+	p.RemoveBackend("agent2", conn22)
+	p.RemoveBackend("agent2", conn2)
+	p.RemoveBackend("agent1", conn1)
+	// This is invalid. agent1 doesn't have conn3. This should be a no-op.
+	p.RemoveBackend("agent1", conn3)
+	expectedBackends = map[string][]agent.AgentService_ConnectServer{
+		"agent1": []agent.AgentService_ConnectServer{conn12},
+		"agent3": []agent.AgentService_ConnectServer{conn3},
+	}
+	expectedAgentIDs = []string{"agent1", "agent3"}
+	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}

--- a/pkg/agent/agentserver/tunnel.go
+++ b/pkg/agent/agentserver/tunnel.go
@@ -74,7 +74,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		connected: connected,
 	}
 	t.Server.PendingDial[random] = connection
-	backend, err := t.Server.randomBackend()
+	backend, err := t.Server.BackendManager.Backend()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("currently no tunnels available: %v", err), http.StatusInternalServerError)
 	}
@@ -131,5 +131,4 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	klog.Infof("Stopping transfer to %q", r.Host)
-	delete(t.Server.Frontends, connection.connectID)
 }

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -1,0 +1,159 @@
+package tests
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/agentserver"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
+)
+
+type simpleServer struct {
+	receivedSecondReq chan struct{}
+}
+
+// ServeHTTP blocks the response to the request whose body is "1" until a
+// request whose body is "2" is handled.
+func (s *simpleServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	bytes, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+	}
+	if string(bytes) == "2" {
+		close(s.receivedSecondReq)
+		w.Write([]byte("2"))
+	}
+	if string(bytes) == "1" {
+		<-s.receivedSecondReq
+		w.Write([]byte("1"))
+	}
+}
+
+// TODO: test http-connect as well.
+func getTestClient(front string, t *testing.T) *http.Client {
+	tunnel, err := client.CreateGrpcTunnel(front, grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			Dial: tunnel.Dial,
+		},
+		Timeout: 2 * time.Second,
+	}
+}
+
+// singleTimeManager makes sure that a backend only serves one request.
+type singleTimeManager struct {
+	mu       sync.Mutex
+	backends map[string]agent.AgentService_ConnectServer
+	used     map[string]struct{}
+}
+
+func (s *singleTimeManager) AddBackend(agentID string, conn agent.AgentService_ConnectServer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.backends[agentID] = conn
+}
+
+func (s *singleTimeManager) RemoveBackend(agentID string, conn agent.AgentService_ConnectServer) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.backends[agentID]
+	if !ok {
+		panic(fmt.Errorf("no backends found for %s", agentID))
+	}
+	if v != conn {
+		panic(fmt.Errorf("recorded connection %v does not match conn %v", v, conn))
+	}
+	delete(s.backends, agentID)
+}
+
+func (s *singleTimeManager) Backend() (agent.AgentService_ConnectServer, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k, v := range s.backends {
+		if _, ok := s.used[k]; !ok {
+			s.used[k] = struct{}{}
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("cannot find backend to a new agent")
+}
+
+func newSingleTimeGetter(m *agentserver.DefaultBackendManager) *singleTimeManager {
+	return &singleTimeManager{
+		used:     make(map[string]struct{}),
+		backends: make(map[string]agent.AgentService_ConnectServer),
+	}
+}
+
+var _ agentserver.BackendManager = &singleTimeManager{}
+
+func TestConcurrentClientRequest(t *testing.T) {
+	server := httptest.NewServer(&simpleServer{receivedSecondReq: make(chan struct{})})
+	defer server.Close()
+
+	proxy, ps, cleanup, err := runGRPCProxyServerWithServerCount(1)
+	ps.BackendManager = newSingleTimeGetter(agentserver.NewDefaultBackendManager())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	// Run two agents
+	runAgent(proxy.agent, stopCh)
+	runAgent(proxy.agent, stopCh)
+
+	client1 := getTestClient(proxy.front, t)
+	client2 := getTestClient(proxy.front, t)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		r, err := client1.Post(server.URL, "text/plain", bytes.NewBufferString("1"))
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if string(data) != "1" {
+			t.Errorf("expect %v; got %v", "1", string(data))
+		}
+	}()
+	// give client1 some time to establish the connection.
+	time.Sleep(1 * time.Second)
+	go func() {
+		defer wg.Done()
+		r, err := client2.Post(server.URL, "text/plain", bytes.NewBufferString("2"))
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if string(data) != "2" {
+			t.Errorf("expect %v; got %v", "2", string(data))
+		}
+	}()
+	wg.Wait()
+}

--- a/tests/ha_proxy_server_test.go
+++ b/tests/ha_proxy_server_test.go
@@ -86,17 +86,17 @@ func (lb *tcpLB) randomBackend() string {
 const haServerCount = 3
 
 func setupHAProxyServer(t *testing.T) ([]proxy, []func()) {
-	proxy1, cleanup1, err := runGRPCProxyServerWithServerCount(haServerCount)
+	proxy1, _, cleanup1, err := runGRPCProxyServerWithServerCount(haServerCount)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	proxy2, cleanup2, err := runGRPCProxyServerWithServerCount(haServerCount)
+	proxy2, _, cleanup2, err := runGRPCProxyServerWithServerCount(haServerCount)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	proxy3, cleanup3, err := runGRPCProxyServerWithServerCount(haServerCount)
+	proxy3, _, cleanup3, err := runGRPCProxyServerWithServerCount(haServerCount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 	lb.removeBackend(proxy[0].agent)
 	cleanups[0]()
 
-	proxy4, cleanup4, err := runGRPCProxyServerWithServerCount(haServerCount)
+	proxy4, _, cleanup4, err := runGRPCProxyServerWithServerCount(haServerCount)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Terms:
* connection: the persistent grpc connection between the proxy server and a proxy agent.
* stream: a dial request marks the begin of a stream, and a close request marks the end of a stream. There are multiple streams multiplexed in one connection. 
* client: the entity that sends the dial request to the proxy server. For example, kube-apiserver is a client.

Bug fixed by this PR:
* The proxy agent uses connID, an int64 counter, to index the streams it handles
* The proxy server also uses connID. However, different agents can have the same connID, causing incorrect routing among streams.

Contents of this PR:
* The first commit adds a unit test to demonstrate the bug
* The second commit fixes the proxy server to use agentID + connID to uniquely index a stream.

Alternatives:
* we can solve the problem from the agent side as well by making the connID unique across agents. I don't think it makes much difference.

/assign @Jefftree @cheftako @dberkov