### PR TITLE
Avoid only listening on localhost for admin server

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -227,7 +227,7 @@ func (a *Agent) runAdminServer(o *GrpcProxyAgentOptions) error {
 	muxHandler.HandleFunc("/ready", readinessHandler)
 	muxHandler.HandleFunc("/metrics", metricsHandler)
 	adminServer := &http.Server{
-		Addr:           "127.0.0.1:8093",
+		Addr:           ":8093",
 		Handler:        muxHandler,
 		MaxHeaderBytes: 1 << 20,
 	}

--- a/examples/kubernetes/konnectivity-agent.yaml
+++ b/examples/kubernetes/konnectivity-agent.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: konnectivity-agent
   namespace: kube-system
---- 
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -31,7 +31,6 @@ spec:
     livenessProbe:
       httpGet:
         scheme: HTTP
-        host: 127.0.0.1
         port: 8093
         path: /healthz
       initialDelaySeconds: 15


### PR DESCRIPTION
The admin server listens solely on localhost, and the assumption that the IP address of 127.0.0.1 is used to health check the konnectivity agent should not be made. 

when `hostNetwork` for the agent pod is turned on in a kubernetes cluster, kubelet can health check the agent by hitting 127.0.0.1. However, with `hostNetwork` off, kubelet is unable to reach the health check since it'll be pinging pod IP, but the admin server will only be listening on 127.0.0.1.

This is only a problem for the agent since the proxy server requires `hostNetwork`.

/assign @caesarxuchao 