### PR TITLE
Prevent logging packet data in client

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -88,7 +88,7 @@ func (t *grpcTunnel) serve() {
 			return
 		}
 
-		klog.Infof("[tracing] recv packet %+v", pkt)
+		klog.V(6).Infof("[tracing] recv packet, type: %s", pkt.Type)
 
 		switch pkt.Type {
 		case client.PacketType_DIAL_RSP:
@@ -165,7 +165,7 @@ func (t *grpcTunnel) Dial(protocol, address string) (net.Conn, error) {
 			},
 		},
 	}
-	klog.Infof("[tracing] send packet %+v", req)
+	klog.V(6).Infof("[tracing] send packet, type: %s", req.Type)
 
 	err := t.stream.Send(req)
 	if err != nil {

--- a/konnectivity-client/pkg/client/conn.go
+++ b/konnectivity-client/pkg/client/conn.go
@@ -54,7 +54,7 @@ func (c *conn) Write(data []byte) (n int, err error) {
 		},
 	}
 
-	klog.Infof("[tracing] send req %+v", req)
+	klog.V(6).Infof("[tracing] send req, type: %s", req.Type)
 
 	err = c.stream.Send(req)
 	if err != nil {
@@ -122,7 +122,7 @@ func (c *conn) Close() error {
 		},
 	}
 
-	klog.Infof("[tracing] send req %+v", req)
+	klog.V(6).Infof("[tracing] send req, type: %s", req.Type)
 
 	if err := c.stream.Send(req); err != nil {
 		return err

--- a/pkg/agent/agentclient/client.go
+++ b/pkg/agent/agentclient/client.go
@@ -117,7 +117,7 @@ func (a *AgentClient) Serve() {
 			return
 		}
 
-		klog.Infof("[tracing] recv packet %+v", pkt)
+		klog.Infof("[tracing] recv packet, type: %s", pkt.Type)
 
 		if pkt == nil {
 			klog.Warningf("empty packet received")
@@ -183,7 +183,6 @@ func (a *AgentClient) Serve() {
 		case client.PacketType_DATA:
 			data := pkt.GetData()
 			klog.Infof("received DATA(id=%d)", data.ConnectID)
-			klog.Infof("[tracing] %v", data)
 
 			if ctx, ok := a.connContext[data.ConnectID]; ok {
 				ctx.dataCh <- data.Data

--- a/pkg/agent/agentserver/tunnel.go
+++ b/pkg/agent/agentserver/tunnel.go
@@ -127,7 +127,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			klog.Errorf("error sending packet %v", err)
 			continue
 		}
-		klog.Infof("Forwarding on tunnel, packet %v", string(pkt[:n]))
+		klog.Infof("Forwarding on tunnel, packet type: %s", packet.Type)
 	}
 
 	klog.Infof("Stopping transfer to %q", r.Host)


### PR DESCRIPTION
We are current logging every packet and polluting the apiserver logs quite a bit (https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/88095/pull-kubernetes-e2e-gce-network-proxy/1230228481132990464/artifacts/e2e-1ded8ff5d7-fe237-master/kube-apiserver.log)

The packet isn't human readable and I feel that it's better to just log that the packet is sent rather than the packet itself.

Sample line:

```
I0219 21:20:03.572332       1 conn.go:57] [tracing] send req type:DATA data:<connectID:314 data:"\024\003\003\000\001\001\027\003\003\003\205\225\265\250\330\260N\222]9?(T\326y\237\315\356\036x\375\360&`\355\332\336D?1}\254\231\214[G\310o\016\247\3525@\016_\330\227\343\201\303\026Kq\373\227\237kF\321\327\375\341\240\365\252\346\255\363\\U\016\323\271-Z\273>F\346\013<\320>\026P\020\272\0023-\264#\007\n\347\371I_$\210\247\034`\206\3764j~\262\021\222/\247\373TeB\r\221\274\326\260R\216\227\002\177\376\253\212\252\001A\037\341\265f\022\241\177\327\006\2700KM\006v@^%(\226K\021#R\214\3027-*\207vU\234\237\227q\336\341O@\310\347\344\263\3602\014\032\356P\261n\005\235\233\\\241\005\242z\304i\025\006\245mYm\255\016\222\250\177-\237\210bB~\206XJ\302\3673{\344\343\233d\035\361\\\310|\240\220\342\014A\315\321\023\226\212~\177\273\336\252Dzs\217\014\360d\345\300v\365\356\n\236\206G\364k\256}\353-\214\304\313\222\202\2146.\225T\r\207#\024\343>\317C\345\347-I\022\243\240\026N%Tg\302\261\035\205Be\355\230\363\t\343y\206\037\376\231\315\262O\343{\321OI~\372|\255.>\005\327\277\250\025\261B\246\026\325i\035\025$t\367Y\034\230\036\214&\207U\032HG;\2023l\217Z\312\341\352\216\2155\037/\016\333*\225;P\344wA\014\264\277\\\014\177\277\227:\277\325\262|SWH\256\371n\016\263\222\247\266\344P\370\315+\213q\017\240\261\202\226\234HyX\300\245\263\201\303\327Q(\177=\241\025K\rF\212\327\247\001\333R\321\277\367\375\034\017\003\300<\353\253LA\276H\256\354\006\200O\350;\272^!\252W<\304\325~\316\310\313ZZ\002\332\277\353>\206LK\213u*\255\222\023y8\033\362e\357`A0z\347\235_\331\350&@\255\344G\006\222\230B\360\276\244\023\365&sE\\s2\n\344\210\202R\353\251\277\324%9\314\363\361r}\213\004l*\013\323A\307\324\254\336'\245g\275\226.\337\264B\2157z\030\352*\013\236\247\000\300\361\354\373\332\031\311\274a\361\352\314M\301\334?\031#\251\007:/\320\220\014\203 \2664\342\252\241\214\331\021\255d\036\367OK\332\366\027\345\007\261\304\307\243\037!\235\270\234\241\356(\310^\205{\210\352(J\026B\221\r5\032\010)a\330\212x)&#\210\324m\007\332xq\365\3751/\207\t\000\263\213g{A\233\272{\007\212\370\320u\010\241Q\262\026\236\262\341\007\177\362d1:\316\200q\341\243Y\267\247\332D\322\\2\357\351\177\031\362Iq)\205\360t\251\373\247\253\320\234z\202rkwB(\263\237\325F\364\236\003\206E\305\230mN\315\341\007\220\366\313%<\2249\331\205\272w4\033r\261R\222\301`\256\364\262#\243/QaIWQ\021\224\016\241|\036\320/r\202^\266\311\356\335\270v\230Fex\273q\375\351\244\333\337d\235\222\256'\362\204R\202\325\265\376\254\"\317*{u\353\334\366\022\274c\3648\033\237\0269\030\224\312\207 \023|$\303m\276g\303~/\014\005`\327\027T\337\231\343\267\241$\r~\216\245\302\250\320f\316J\016\265\255\364\325\311\215\304\214\033]\034\240?\343Y%\242H\013'\023CF\300|\341\257U(\332\343\276\310\376\027\003\003\001\031\r;t/\333\\\330\226\356\243\326\000A\031r\354\337LT\r\234\325q\262Q\243\303\335w~B'\213\016\035HS\3246b\210Wz\002\332/\036\246\023\241\017`\266\363\010\030\014\257\007p\000\r\315':vvg1\262/\023\362\273\323~K \311\022OT\323\261-\237\024\212{\323K\027/q\301\236f\365\243\354\342\001\220\225sBz\204\333\324\030\\\024\354\213/\230E\331sh;+L\205\013\335c\\\341\356[\330c\213n\361<\221\033\233\322\224\323\243\226\245\253w<y \374l\211\020\372\005\222\032\013\275\362\360\355\244xm\205\251\214\320\316\324\370\244\3613\323\300\222\3561\272j#`\223\233c\027z\361\336Q\363\342\036U\231r\341\032\234&e\347&\202,f\260\360\007[_\014\356lvDx\357\225\375n\210n\276\215\205\240\314-\262`\237p\020\311\017b\006\237\025\247w\305\313[+\234M.\n{\216\016\303c*N\245V\244\3138\0223\227G\215[\215\331\030\231d\271\343\206\027\003\003\0005\2156\001\340\313\303\026=!e\322\027\253\354\357\310\251\340\373\352|\315<5odue\213\206~\234\"\024\315\304s~\0171\324\207o\233}\322\252\333]\304\036\214\376" > 
```

/assign @caesarxuchao 
/cc @cheftako 