### PR TITLE
Fix races

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=

--- a/pkg/agent/agentclient/client.go
+++ b/pkg/agent/agentclient/client.go
@@ -74,7 +74,7 @@ func (c *connContext) cleanup() {
 	c.cleanOnce.Do(c.cleanFunc)
 }
 
-// Connect connnects to proxy server to establish a gRPC stream,
+// Connect connects to proxy server to establish a gRPC stream,
 // on which the proxied traffic is multiplexed through the stream
 // and piped to the local connection. It register itself as a
 // backend from proxy server, so proxy server will route traffic
@@ -230,7 +230,7 @@ func (a *AgentClient) remoteToProxy(conn net.Conn, connID int64) {
 
 	for {
 		n, err := conn.Read(buf[:])
-		klog.Infof("received %d bytes from proxy server", n)
+		klog.Infof("received %d bytes from remote for connID[%d]", n, connID)
 
 		if err == io.EOF {
 			klog.Info("connection EOF")
@@ -264,8 +264,10 @@ func (a *AgentClient) proxyToRemote(conn net.Conn, connID int64) {
 		for {
 			n, err := conn.Write(d[pos:])
 			if err == nil {
+				klog.Infof("[connID: %d] write last %d data to remote", connID, n)
 				break
 			} else if n > 0 {
+				klog.Infof("[connID: %d] write %d data to remote with error: %v", connID, n, err)
 				pos += n
 			} else {
 				klog.Errorf("conn write error: %v", err)

--- a/pkg/agent/agentserver/backend_manager_test.go
+++ b/pkg/agent/agentserver/backend_manager_test.go
@@ -38,7 +38,7 @@ func TestAddRemoveBackends(t *testing.T) {
 
 	p.AddBackend("agent1", conn1)
 	p.RemoveBackend("agent1", conn1)
-	expectedBackends := make(map[string][]agent.AgentService_ConnectServer)
+	expectedBackends := make(map[string][]*backend)
 	expectedAgentIDs := []string{}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
@@ -60,9 +60,9 @@ func TestAddRemoveBackends(t *testing.T) {
 	p.RemoveBackend("agent1", conn1)
 	// This is invalid. agent1 doesn't have conn3. This should be a no-op.
 	p.RemoveBackend("agent1", conn3)
-	expectedBackends = map[string][]agent.AgentService_ConnectServer{
-		"agent1": []agent.AgentService_ConnectServer{conn12},
-		"agent3": []agent.AgentService_ConnectServer{conn3},
+	expectedBackends = map[string][]*backend{
+		"agent1": []*backend{newBackend(conn12)},
+		"agent3": []*backend{newBackend(conn3)},
 	}
 	expectedAgentIDs = []string{"agent1", "agent3"}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -78,7 +78,7 @@ func (s *singleTimeManager) RemoveBackend(agentID string, conn agent.AgentServic
 	delete(s.backends, agentID)
 }
 
-func (s *singleTimeManager) Backend() (agent.AgentService_ConnectServer, error) {
+func (s *singleTimeManager) Backend() (agentserver.Backend, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for k, v := range s.backends {


### PR DESCRIPTION
Add more logging.

Add lock to protect backend. It is not safe to call Send on a GRPC
stream from multiple Goroutines.

Add lock to protect pendingDials.

Seed the random generator before using it.
/assign @Jefftree @anfernee  @cheftako 

`kubectl cp` ran successfully 11 times in a row with this fix.

Opened issues for these two followup tasks:
1. #85: update the concurrency test, it should have caught the issue
2. #84: we use a mutex to protect the backend stream. Need to investigate if there is a more efficient implementation with channels.

Fixes #76.