### PR TITLE
Log user agent in proxy server

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -185,7 +185,12 @@ func NewProxyServer(serverID string, serverCount int, agentAuthenticationOptions
 
 // Proxy handles incoming streams from gRPC frontend.
 func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
-	klog.Info("proxy request from client")
+	md, ok := metadata.FromIncomingContext(stream.Context())
+	if !ok {
+		return fmt.Errorf("failed to get context")
+	}
+	userAgent := md.Get(header.UserAgent)
+	klog.Infof("proxy request from client, userAgent %s", userAgent)
 
 	recvCh := make(chan *client.Packet, 10)
 	stopCh := make(chan error)

--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -33,7 +33,7 @@ type Tunnel struct {
 }
 
 func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	klog.Infof("Received %s request to %q", r.Method, r.Host)
+	klog.Infof("Received %s request to %q from userAgent %s", r.Method, r.Host, r.UserAgent())
 	if r.TLS != nil {
 		klog.Infof("TLS CommonName: %v", r.TLS.PeerCertificates[0].Subject.CommonName)
 	}

--- a/proto/header/header.go
+++ b/proto/header/header.go
@@ -27,4 +27,7 @@ const (
 	// AuthenticationTokenContextSchemePrefix has a prefix for auth token's content.
 	// (https://tools.ietf.org/html/rfc6750#section-2.1)
 	AuthenticationTokenContextSchemePrefix = "Bearer "
+
+	// UserAgent is used to provide the client information in a proxy request
+	UserAgent   = "user-agent"
 )


### PR DESCRIPTION
This logs user agent (caller information) on the proxy server. 

A corresponding PR will be added in k/k to propagate the caller (webhooks, logs, exec, etc)

/assign @caesarxuchao 
/cc @cheftako 