### PR TITLE
Improve validation to when using SA authentication

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -235,6 +235,9 @@ func (o *ProxyRunOptions) Validate() error {
 	// validate agent authentication params
 	// all 4 parametes must be empty or must have value (except kubeconfigPath that might be empty)
 	if o.agentNamespace != "" || o.agentServiceAccount != "" || o.authenticationAudience != "" || o.kubeconfigPath != "" {
+		if o.clusterCaCert != "" {
+			return fmt.Errorf("clusterCaCert can not be used when service account authentication is enabled")
+		}
 		if o.agentNamespace == "" {
 			return fmt.Errorf("agentNamespace cannot be empty when agent authentication is enabled")
 		}


### PR DESCRIPTION
**What this PR does** 
This PR adds validation to prevent setting the clusterCA flag while running in SA auth mode thus avoiding vague connectivity issues. 

Fixes #103 

**Notes** 
Validation is the simple solution to prevent the issue, the other way would be to add logic to detect which mode it should run on based on the flags. 