### PR TITLE
Add verbosity levels and structured logs

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -105,17 +105,17 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 }
 
 func (o *GrpcProxyAgentOptions) Print() {
-	klog.Warningf("AgentCert set to \"%s\".\n", o.agentCert)
-	klog.Warningf("AgentKey set to \"%s\".\n", o.agentKey)
-	klog.Warningf("CACert set to \"%s\".\n", o.caCert)
-	klog.Warningf("ProxyServerHost set to \"%s\".\n", o.proxyServerHost)
-	klog.Warningf("ProxyServerPort set to %d.\n", o.proxyServerPort)
-	klog.Warningf("HealthServerPort set to %d.\n", o.healthServerPort)
-	klog.Warningf("AdminServerPort set to %d.\n", o.adminServerPort)
-	klog.Warningf("AgentID set to %s.\n", o.agentID)
-	klog.Warningf("SyncInterval set to %v.\n", o.syncInterval)
-	klog.Warningf("ProbeInterval set to %v.\n", o.probeInterval)
-	klog.Warningf("ServiceAccountTokenPath set to \"%s\".\n", o.serviceAccountTokenPath)
+	klog.V(1).Infof("AgentCert set to %q.\n", o.agentCert)
+	klog.V(1).Infof("AgentKey set to %q.\n", o.agentKey)
+	klog.V(1).Infof("CACert set to %q.\n", o.caCert)
+	klog.V(1).Infof("ProxyServerHost set to %q.\n", o.proxyServerHost)
+	klog.V(1).Infof("ProxyServerPort set to %d.\n", o.proxyServerPort)
+	klog.V(1).Infof("HealthServerPort set to %d.\n", o.healthServerPort)
+	klog.V(1).Infof("AdminServerPort set to %d.\n", o.adminServerPort)
+	klog.V(1).Infof("AgentID set to %s.\n", o.agentID)
+	klog.V(1).Infof("SyncInterval set to %v.\n", o.syncInterval)
+	klog.V(1).Infof("ProbeInterval set to %v.\n", o.probeInterval)
+	klog.V(1).Infof("ServiceAccountTokenPath set to %q.\n", o.serviceAccountTokenPath)
 }
 
 func (o *GrpcProxyAgentOptions) Validate() error {
@@ -249,9 +249,9 @@ func (a *Agent) runHealthServer(o *GrpcProxyAgentOptions) error {
 	go func() {
 		err := healthServer.ListenAndServe()
 		if err != nil {
-			klog.Warningf("health server received %v.\n", err)
+			klog.ErrorS(err, "health server could not listen")
 		}
-		klog.Warningf("Health server stopped listening\n")
+		klog.V(0).Infoln("Health server stopped listening")
 	}()
 
 	return nil
@@ -278,9 +278,9 @@ func (a *Agent) runAdminServer(o *GrpcProxyAgentOptions) error {
 	go func() {
 		err := adminServer.ListenAndServe()
 		if err != nil {
-			klog.Warningf("admin server received %v.\n", err)
+			klog.ErrorS(err, "admin server could not listen")
 		}
-		klog.Warningf("Admin server stopped listening\n")
+		klog.V(0).Infoln("Admin server stopped listening")
 	}()
 
 	return nil

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -97,18 +97,18 @@ func (o *GrpcProxyClientOptions) Flags() *pflag.FlagSet {
 }
 
 func (o *GrpcProxyClientOptions) Print() {
-	klog.Warningf("ClientCert set to %q.\n", o.clientCert)
-	klog.Warningf("ClientKey set to %q.\n", o.clientKey)
-	klog.Warningf("CACert set to %q.\n", o.caCert)
-	klog.Warningf("RequestProto set to %q.\n", o.requestProto)
-	klog.Warningf("RequestPath set to %q.\n", o.requestPath)
-	klog.Warningf("RequestHost set to %q.\n", o.requestHost)
-	klog.Warningf("RequestPort set to %d.\n", o.requestPort)
-	klog.Warningf("ProxyHost set to %q.\n", o.proxyHost)
-	klog.Warningf("ProxyPort set to %d.\n", o.proxyPort)
-	klog.Warningf("ProxyUdsName set to %q.\n", o.proxyUdsName)
-	klog.Warningf("TestRequests set to %q.\n", o.testRequests)
-	klog.Warningf("TestDelaySec set to %d.\n", o.testDelaySec)
+	klog.V(1).Infof("ClientCert set to %q.\n", o.clientCert)
+	klog.V(1).Infof("ClientKey set to %q.\n", o.clientKey)
+	klog.V(1).Infof("CACert set to %q.\n", o.caCert)
+	klog.V(1).Infof("RequestProto set to %q.\n", o.requestProto)
+	klog.V(1).Infof("RequestPath set to %q.\n", o.requestPath)
+	klog.V(1).Infof("RequestHost set to %q.\n", o.requestHost)
+	klog.V(1).Infof("RequestPort set to %d.\n", o.requestPort)
+	klog.V(1).Infof("ProxyHost set to %q.\n", o.proxyHost)
+	klog.V(1).Infof("ProxyPort set to %d.\n", o.proxyPort)
+	klog.V(1).Infof("ProxyUdsName set to %q.\n", o.proxyUdsName)
+	klog.V(1).Infof("TestRequests set to %q.\n", o.testRequests)
+	klog.V(1).Infof("TestDelaySec set to %d.\n", o.testDelaySec)
 }
 
 func (o *GrpcProxyClientOptions) Validate() error {
@@ -244,7 +244,7 @@ func (c *Client) run(o *GrpcProxyClientOptions) error {
 		}
 
 		if i != o.testRequests {
-			klog.Warningf("Waiting for %d seconds.", o.testDelaySec)
+			klog.V(1).InfoS("Wating for next connection test.", "seconds", o.testDelaySec)
 			wait := time.Duration(o.testDelaySec) * time.Second
 			time.Sleep(wait)
 		}
@@ -269,7 +269,7 @@ func (c *Client) makeRequest(o *GrpcProxyClientOptions, client *http.Client) err
 	if err != nil {
 		return fmt.Errorf("failed to read response from client, got %v", err)
 	}
-	klog.Info(string(data))
+	klog.V(4).Infoln(string(data))
 	return nil
 }
 
@@ -292,7 +292,7 @@ func (c *Client) getUDSDialer(o *GrpcProxyClientOptions) (func(ctx context.Conte
 		<-ch
 		if proxyConn != nil {
 			err := proxyConn.Close()
-			klog.Infof("connection closed: %v", err)
+			klog.ErrorS(err, "connection closed")
 		}
 	}()
 
@@ -304,7 +304,7 @@ func (c *Client) getUDSDialer(o *GrpcProxyClientOptions) (func(ctx context.Conte
 			// timeout - is turned off as this is test code and eases debugging.
 			c, err := net.DialTimeout("unix", o.proxyUdsName, 0)
 			if err != nil {
-				klog.Errorf("failed to create connection to uds name %s, error: %v", o.proxyUdsName, err)
+				klog.ErrorS(err, "failed to create connection to uds", "name", o.proxyUdsName)
 			}
 			return c, err
 		})
@@ -370,7 +370,7 @@ func (c *Client) getMTLSDialer(o *GrpcProxyClientOptions) (func(ctx context.Cont
 	go func() {
 		<-ch
 		err := proxyConn.Close()
-		klog.Infof("connection closed: %v", err)
+		klog.ErrorS(err, "connection closed")
 	}()
 
 	switch o.mode {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -244,7 +244,7 @@ func (c *Client) run(o *GrpcProxyClientOptions) error {
 		}
 
 		if i != o.testRequests {
-			klog.V(1).InfoS("Wating for next connection test.", "seconds", o.testDelaySec)
+			klog.V(1).InfoS("Waiting for next connection test.", "seconds", o.testDelaySec)
 			wait := time.Duration(o.testDelaySec) * time.Second
 			time.Sleep(wait)
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -136,27 +136,27 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 }
 
 func (o *ProxyRunOptions) Print() {
-	klog.Warningf("ServerCert set to %q.\n", o.serverCert)
-	klog.Warningf("ServerKey set to %q.\n", o.serverKey)
-	klog.Warningf("ServerCACert set to %q.\n", o.serverCaCert)
-	klog.Warningf("ClusterCert set to %q.\n", o.clusterCert)
-	klog.Warningf("ClusterKey set to %q.\n", o.clusterKey)
-	klog.Warningf("ClusterCACert set to %q.\n", o.clusterCaCert)
-	klog.Warningf("Mode set to %q.\n", o.mode)
-	klog.Warningf("UDSName set to %q.\n", o.udsName)
-	klog.Warningf("DeleteUDSFile set to %v.\n", o.deleteUDSFile)
-	klog.Warningf("Server port set to %d.\n", o.serverPort)
-	klog.Warningf("Agent port set to %d.\n", o.agentPort)
-	klog.Warningf("Admin port set to %d.\n", o.adminPort)
-	klog.Warningf("Health port set to %d.\n", o.healthPort)
-	klog.Warningf("EnableProfiling set to %v.\n", o.enableProfiling)
-	klog.Warningf("EnableContentionProfiling set to %v.\n", o.enableContentionProfiling)
-	klog.Warningf("ServerID set to %s.\n", o.serverID)
-	klog.Warningf("ServerCount set to %d.\n", o.serverCount)
-	klog.Warningf("AgentNamespace set to %q.\n", o.agentNamespace)
-	klog.Warningf("AgentServiceAccount set to %q.\n", o.agentServiceAccount)
-	klog.Warningf("AuthenticationAudience set to %q.\n", o.authenticationAudience)
-	klog.Warningf("KubeconfigPath set to %q.\n", o.kubeconfigPath)
+	klog.V(1).Infof("ServerCert set to %q.\n", o.serverCert)
+	klog.V(1).Infof("ServerKey set to %q.\n", o.serverKey)
+	klog.V(1).Infof("ServerCACert set to %q.\n", o.serverCaCert)
+	klog.V(1).Infof("ClusterCert set to %q.\n", o.clusterCert)
+	klog.V(1).Infof("ClusterKey set to %q.\n", o.clusterKey)
+	klog.V(1).Infof("ClusterCACert set to %q.\n", o.clusterCaCert)
+	klog.V(1).Infof("Mode set to %q.\n", o.mode)
+	klog.V(1).Infof("UDSName set to %q.\n", o.udsName)
+	klog.V(1).Infof("DeleteUDSFile set to %v.\n", o.deleteUDSFile)
+	klog.V(1).Infof("Server port set to %d.\n", o.serverPort)
+	klog.V(1).Infof("Agent port set to %d.\n", o.agentPort)
+	klog.V(1).Infof("Admin port set to %d.\n", o.adminPort)
+	klog.V(1).Infof("Health port set to %d.\n", o.healthPort)
+	klog.V(1).Infof("EnableProfiling set to %v.\n", o.enableProfiling)
+	klog.V(1).Infof("EnableContentionProfiling set to %v.\n", o.enableContentionProfiling)
+	klog.V(1).Infof("ServerID set to %s.\n", o.serverID)
+	klog.V(1).Infof("ServerCount set to %d.\n", o.serverCount)
+	klog.V(1).Infof("AgentNamespace set to %q.\n", o.agentNamespace)
+	klog.V(1).Infof("AgentServiceAccount set to %q.\n", o.agentServiceAccount)
+	klog.V(1).Infof("AuthenticationAudience set to %q.\n", o.authenticationAudience)
+	klog.V(1).Infof("KubeconfigPath set to %q.\n", o.kubeconfigPath)
 }
 
 func (o *ProxyRunOptions) Validate() error {
@@ -348,26 +348,23 @@ func (p *Proxy) run(o *ProxyRunOptions) error {
 		AuthenticationAudience: o.authenticationAudience,
 	}
 	server := server.NewProxyServer(o.serverID, int(o.serverCount), authOpt)
-
-	klog.Info("Starting master server for client connections.")
+	klog.V(1).Infoln("Starting master server for client connections.")
 	masterStop, err := p.runMasterServer(ctx, o, server)
 	if err != nil {
 		return fmt.Errorf("failed to run the master server: %v", err)
 	}
 
-	klog.Info("Starting agent server for tunnel connections.")
+	klog.V(1).Infoln("Starting agent server for tunnel connections.")
 	err = p.runAgentServer(o, server)
 	if err != nil {
 		return fmt.Errorf("failed to run the agent server: %v", err)
 	}
-
-	klog.Info("Starting admin server for debug connections.")
+	klog.V(1).Infoln("Starting admin server for debug connections.")
 	err = p.runAdminServer(o, server)
 	if err != nil {
 		return fmt.Errorf("failed to run the admin server: %v", err)
 	}
-
-	klog.Info("Starting health server for healthchecks.")
+	klog.V(1).Infoln("Starting health server for healthchecks.")
 	err = p.runHealthServer(o, server)
 	if err != nil {
 		return fmt.Errorf("failed to run the health server: %v", err)
@@ -375,7 +372,7 @@ func (p *Proxy) run(o *ProxyRunOptions) error {
 
 	stopCh := SetupSignalHandler()
 	<-stopCh
-	klog.Info("Shutting down server.")
+	klog.V(1).Infoln("Shutting down server.")
 
 	if masterStop != nil {
 		masterStop()
@@ -410,7 +407,7 @@ func (p *Proxy) runMasterServer(ctx context.Context, o *ProxyRunOptions, server 
 func (p *Proxy) runUDSMasterServer(ctx context.Context, o *ProxyRunOptions, s *server.ProxyServer) (StopFunc, error) {
 	if o.deleteUDSFile {
 		if err := os.Remove(o.udsName); err != nil && !os.IsNotExist(err) {
-			klog.Warningf("failed to delete file %s: %v", o.udsName, err)
+			klog.ErrorS(err, "failed to delete file", "file", o.udsName)
 		}
 	}
 	var stop StopFunc
@@ -436,14 +433,14 @@ func (p *Proxy) runUDSMasterServer(ctx context.Context, o *ProxyRunOptions, s *s
 			var lc net.ListenConfig
 			udsListener, err := lc.Listen(ctx, "unix", o.udsName)
 			if err != nil {
-				klog.Errorf("failed to listen on uds name %s: %v ", o.udsName, err)
+				klog.ErrorS(err, "failed to listen on uds", "name", o.udsName)
 			}
 			defer func() {
 				udsListener.Close()
 			}()
 			err = server.Serve(udsListener)
 			if err != nil {
-				klog.Errorf("failed to serve uds requests: %v", err)
+				klog.ErrorS(err, "failed to serve uds requests")
 			}
 		}()
 	}
@@ -514,7 +511,7 @@ func (p *Proxy) runMTLSMasterServer(ctx context.Context, o *ProxyRunOptions, s *
 		go func() {
 			err := server.ListenAndServeTLS("", "") // empty files defaults to tlsConfig
 			if err != nil {
-				klog.Errorf("failed to listen on master port %v", err)
+				klog.ErrorS(err, "failed to listen on master port")
 			}
 		}()
 	}
@@ -568,9 +565,9 @@ func (p *Proxy) runAdminServer(o *ProxyRunOptions, server *server.ProxyServer) e
 	go func() {
 		err := adminServer.ListenAndServe()
 		if err != nil {
-			klog.Warningf("admin server received %v.\n", err)
+			klog.ErrorS(err, "admin server could not listen")
 		}
-		klog.Warningf("Admin server stopped listening\n")
+		klog.V(1).Infoln("Admin server stopped listening")
 	}()
 
 	return nil
@@ -603,9 +600,9 @@ func (p *Proxy) runHealthServer(o *ProxyRunOptions, server *server.ProxyServer) 
 	go func() {
 		err := healthServer.ListenAndServe()
 		if err != nil {
-			klog.Warningf("health server received %v.\n", err)
+			klog.ErrorS(err, "health server could not listen")
 		}
-		klog.Warningf("Health server stopped listening\n")
+		klog.V(1).Infoln("Health server stopped listening")
 	}()
 
 	return nil

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -80,7 +80,7 @@ func (o *TestServerRunOptions) Validate() error {
 
 func newTestServerRunOptions() *TestServerRunOptions {
 	o := TestServerRunOptions{
-		serverPort:             8000,
+		serverPort: 8000,
 	}
 	return &o
 }

--- a/konnectivity-client/go.sum
+++ b/konnectivity-client/go.sum
@@ -63,6 +63,7 @@ google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLY
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
+google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -94,11 +94,11 @@ func (t *grpcTunnel) serve(c clientConn) {
 			return
 		}
 		if err != nil || pkt == nil {
-			klog.Warningf("stream read error: %v", err)
+			klog.ErrorS(err, "stream read failure")
 			return
 		}
 
-		klog.V(6).Infof("[tracing] recv packet, type: %s", pkt.Type)
+		klog.V(5).InfoS("[tracing] recv packet", "type", pkt.Type)
 
 		switch pkt.Type {
 		case client.PacketType_DIAL_RSP:
@@ -108,7 +108,7 @@ func (t *grpcTunnel) serve(c clientConn) {
 			t.pendingDialLock.RUnlock()
 
 			if !ok {
-				klog.Warning("DialResp not recognized; dropped")
+				klog.V(1).Infoln("DialResp not recognized; dropped")
 			} else {
 				ch <- dialResult{
 					err:    resp.Error,
@@ -125,7 +125,7 @@ func (t *grpcTunnel) serve(c clientConn) {
 			if ok {
 				conn.readCh <- resp.Data
 			} else {
-				klog.Warningf("connection id %d not recognized", resp.ConnectID)
+				klog.V(1).InfoS("connection not recognized", "connectionID", resp.ConnectID)
 			}
 		case client.PacketType_CLOSE_RSP:
 			resp := pkt.GetCloseResponse()
@@ -142,7 +142,7 @@ func (t *grpcTunnel) serve(c clientConn) {
 				t.connsLock.Unlock()
 				return
 			}
-			klog.Warningf("connection id %d not recognized", resp.ConnectID)
+			klog.V(1).InfoS("connection not recognized", "connectionID", resp.ConnectID)
 		}
 	}
 }
@@ -175,14 +175,14 @@ func (t *grpcTunnel) Dial(protocol, address string) (net.Conn, error) {
 			},
 		},
 	}
-	klog.V(6).Infof("[tracing] send packet, type: %s", req.Type)
+	klog.V(5).InfoS("[tracing] send packet", "type", req.Type)
 
 	err := t.stream.Send(req)
 	if err != nil {
 		return nil, err
 	}
 
-	klog.Info("DIAL_REQ sent to proxy server")
+	klog.V(5).Infoln("DIAL_REQ sent to proxy server")
 
 	c := &conn{stream: t.stream}
 

--- a/konnectivity-client/pkg/client/client_test.go
+++ b/konnectivity-client/pkg/client/client_test.go
@@ -176,7 +176,7 @@ func pipe() (*fakeStream, *fakeStream) {
 }
 
 func (s *fakeStream) Send(packet *client.Packet) error {
-	klog.Infof("[DEBUG] send packet %+v", packet)
+	klog.V(4).InfoS("[DEBUG] send", "packet", packet)
 	if packet == nil {
 		return nil
 	}
@@ -187,7 +187,7 @@ func (s *fakeStream) Send(packet *client.Packet) error {
 func (s *fakeStream) Recv() (*client.Packet, error) {
 	select {
 	case pkt := <-s.r:
-		klog.Infof("[DEBUG] recv packet %+v", pkt)
+		klog.V(4).InfoS("[DEBUG] recv", "packet", pkt)
 		return pkt, nil
 	case <-time.After(5 * time.Second):
 		return nil, errors.New("timeout recv")

--- a/konnectivity-client/pkg/client/conn.go
+++ b/konnectivity-client/pkg/client/conn.go
@@ -54,7 +54,7 @@ func (c *conn) Write(data []byte) (n int, err error) {
 		},
 	}
 
-	klog.V(6).Infof("[tracing] send req, type: %s", req.Type)
+	klog.V(5).InfoS("[tracing] send req", "type", req.Type)
 
 	err = c.stream.Send(req)
 	if err != nil {
@@ -112,7 +112,7 @@ func (c *conn) SetWriteDeadline(t time.Time) error {
 // Close closes the connection. It also sends CLOSE_REQ packet over
 // proxy service to notify remote to drop the connection.
 func (c *conn) Close() error {
-	klog.Info("conn.Close()")
+	klog.V(4).Infoln("closing connection")
 	req := &client.Packet{
 		Type: client.PacketType_CLOSE_REQ,
 		Payload: &client.Packet_CloseRequest{
@@ -122,7 +122,7 @@ func (c *conn) Close() error {
 		},
 	}
 
-	klog.V(6).Infof("[tracing] send req, type: %s", req.Type)
+	klog.V(5).InfoS("[tracing] send req", "type", req.Type)
 
 	if err := c.stream.Send(req); err != nil {
 		return err

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -271,7 +271,7 @@ func (a *AgentClient) Serve() {
 		klog.V(5).InfoS("[tracing] recv packet", "type", pkt.Type)
 
 		if pkt == nil {
-			klog.V(2).Infoln("empty packet received")
+			klog.V(3).Infoln("empty packet received")
 			continue
 		}
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -157,14 +157,14 @@ func (a *AgentClient) Connect() (int, error) {
 	a.conn = conn
 	a.stream = stream
 	a.serverID = serverID
-	klog.Infof("Connect to server %s", serverID)
+	klog.V(2).InfoS("Connect to", "server", serverID)
 	return serverCount, nil
 }
 
 // Close closes the underlying connection.
 func (a *AgentClient) Close() {
 	if a.conn == nil {
-		klog.Warning("Unexpected empty AgentClient.conn")
+		klog.Errorln("Unexpected empty AgentClient.conn")
 	}
 	a.conn.Close()
 	close(a.stopCh)
@@ -226,7 +226,7 @@ func (a *AgentClient) initializeAuthContext(ctx context.Context) (context.Contex
 
 	// load current service account's token value
 	if b, err = ioutil.ReadFile(a.serviceAccountTokenPath); err != nil {
-		klog.Errorf("Failed to read token from %q. err: %v", a.serviceAccountTokenPath, err)
+		klog.ErrorS(err, "Failed to read token", "path", a.serviceAccountTokenPath)
 		return nil, err
 	}
 	ctx = metadata.AppendToOutgoingContext(ctx, header.AuthenticationTokenContextKey, header.AuthenticationTokenContextSchemePrefix+string(b))
@@ -248,12 +248,12 @@ func (a *AgentClient) initializeAuthContext(ctx context.Context) (context.Contex
 // The requests include things like opening a connection to a server,
 // streaming data and close the connection.
 func (a *AgentClient) Serve() {
-	klog.Infof("Start serving for serverID %s", a.serverID)
+	klog.V(2).InfoS("Start serving", "serverID", a.serverID)
 	go a.probe()
 	for {
 		select {
 		case <-a.stopCh:
-			klog.Info("stop agent client.")
+			klog.V(2).Infoln("stop agent client.")
 			return
 		default:
 		}
@@ -261,23 +261,23 @@ func (a *AgentClient) Serve() {
 		pkt, err := a.Recv()
 		if err != nil {
 			if err == io.EOF {
-				klog.Info("received EOF, exit")
+				klog.V(2).Infoln("received EOF, exit")
 				return
 			}
-			klog.Warningf("stream read error: %v", err)
+			klog.ErrorS(err, "could not read stream")
 			return
 		}
 
-		klog.Infof("[tracing] recv packet, type: %s", pkt.Type)
+		klog.V(5).InfoS("[tracing] recv packet", "type", pkt.Type)
 
 		if pkt == nil {
-			klog.Warningf("empty packet received")
+			klog.V(2).Infoln("empty packet received")
 			continue
 		}
 
 		switch pkt.Type {
 		case client.PacketType_DIAL_REQ:
-			klog.Info("received DIAL_REQ")
+			klog.V(4).Infoln("received DIAL_REQ")
 			resp := &client.Packet{
 				Type:    client.PacketType_DIAL_RSP,
 				Payload: &client.Packet_DialResponse{DialResponse: &client.DialResponse{}},
@@ -291,7 +291,7 @@ func (a *AgentClient) Serve() {
 			if err != nil {
 				resp.GetDialResponse().Error = err.Error()
 				if err := a.Send(resp); err != nil {
-					klog.Warningf("stream send error: %v", err)
+					klog.ErrorS(err, "could not send stream")
 				}
 				continue
 			}
@@ -303,7 +303,7 @@ func (a *AgentClient) Serve() {
 				conn:   conn,
 				dataCh: dataCh,
 				cleanFunc: func() {
-					klog.Infof("close connection(id=%d)", connID)
+					klog.V(4).InfoS("close connection", "connectionID", connID)
 					resp := &client.Packet{
 						Type:    client.PacketType_CLOSE_RSP,
 						Payload: &client.Packet_CloseResponse{CloseResponse: &client.CloseResponse{}},
@@ -316,7 +316,7 @@ func (a *AgentClient) Serve() {
 					}
 
 					if err := a.Send(resp); err != nil {
-						klog.Warningf("close response send error: %v", err)
+						klog.ErrorS(err, "close response failure")
 					}
 
 					close(dataCh)
@@ -327,7 +327,7 @@ func (a *AgentClient) Serve() {
 
 			resp.GetDialResponse().ConnectID = connID
 			if err := a.Send(resp); err != nil {
-				klog.Warningf("stream send error: %v", err)
+				klog.ErrorS(err, "stream send failure")
 				continue
 			}
 
@@ -336,7 +336,7 @@ func (a *AgentClient) Serve() {
 
 		case client.PacketType_DATA:
 			data := pkt.GetData()
-			klog.Infof("received DATA(id=%d)", data.ConnectID)
+			klog.V(4).InfoS("received DATA", "connectionID", data.ConnectID)
 
 			ctx, ok := a.connManager.Get(data.ConnectID)
 			if ok {
@@ -347,7 +347,7 @@ func (a *AgentClient) Serve() {
 			closeReq := pkt.GetCloseRequest()
 			connID := closeReq.ConnectID
 
-			klog.Infof("received CLOSE_REQ(id=%d)", connID)
+			klog.V(4).InfoS("received CLOSE_REQ", "connectionID", connID)
 
 			ctx, ok := a.connManager.Get(connID)
 			if ok {
@@ -360,13 +360,13 @@ func (a *AgentClient) Serve() {
 				resp.GetCloseResponse().ConnectID = connID
 				resp.GetCloseResponse().Error = "Unknown connectID"
 				if err := a.Send(resp); err != nil {
-					klog.Warningf("close response send error: %v", err)
+					klog.ErrorS(err, "close response send failure", err)
 					continue
 				}
 			}
 
 		default:
-			klog.Warningf("unrecognized packet type: %+v", pkt)
+			klog.V(2).InfoS("unrecognized packet", "type", pkt)
 		}
 	}
 }
@@ -381,14 +381,14 @@ func (a *AgentClient) remoteToProxy(connID int64, ctx *connContext) {
 
 	for {
 		n, err := ctx.conn.Read(buf[:])
-		klog.Infof("received %d bytes from remote for connID[%d]", n, connID)
+		klog.V(4).InfoS("received data from remote", "bytes", n, "connID", connID)
 
 		if err == io.EOF {
-			klog.Info("connection EOF")
+			klog.V(2).Infoln("connection EOF")
 			return
 		} else if err != nil {
 			// Normal when receive a CLOSE_REQ
-			klog.Warningf("connection read error: %v", err)
+			klog.ErrorS(err, "connection read failure")
 			return
 		} else {
 			resp.Payload = &client.Packet_Data{Data: &client.Data{
@@ -396,7 +396,7 @@ func (a *AgentClient) remoteToProxy(connID int64, ctx *connContext) {
 				ConnectID: connID,
 			}}
 			if err := a.Send(resp); err != nil {
-				klog.Warningf("stream send error: %v", err)
+				klog.ErrorS(err, "stream send failure")
 			}
 		}
 	}
@@ -410,13 +410,13 @@ func (a *AgentClient) proxyToRemote(connID int64, ctx *connContext) {
 		for {
 			n, err := ctx.conn.Write(d[pos:])
 			if err == nil {
-				klog.Infof("[connID: %d] write last %d data to remote", connID, n)
+				klog.V(4).InfoS("write to remote", "connID", connID, "lastData", n)
 				break
 			} else if n > 0 {
-				klog.Infof("[connID: %d] write %d data to remote with error: %v", connID, n, err)
+				klog.ErrorS(err, "write to remote with failure", "connID", connID, "lastData", n)
 				pos += n
 			} else {
-				klog.Errorf("conn write error: %v", err)
+				klog.ErrorS(err, "conn write failure")
 				return
 			}
 		}
@@ -437,7 +437,7 @@ func (a *AgentClient) probe() {
 				continue
 			}
 		}
-		klog.Infof("Connection state %v, removing client used to connect to %v", a.conn.GetState(), a.serverID)
+		klog.V(1).InfoS("Removing client used for server connection", "state", a.conn.GetState(), "serverID", a.serverID)
 		a.cs.RemoveClient(a.serverID)
 		return
 	}

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -211,7 +211,7 @@ func pipe() (agent.AgentService_ConnectClient, agent.AgentService_ConnectClient)
 }
 
 func (s *fakeStream) Send(packet *client.Packet) error {
-	klog.Infof("[DEBUG] send packet %+v", packet)
+	klog.V(4).InfoS("[DEBUG] send", "packet", packet)
 	s.w <- packet
 	return nil
 }
@@ -219,7 +219,7 @@ func (s *fakeStream) Send(packet *client.Packet) error {
 func (s *fakeStream) Recv() (*client.Packet, error) {
 	select {
 	case pkg := <-s.r:
-		klog.Infof("[DEBUG] recv packet %+v", pkg)
+		klog.V(4).InfoS("[DEBUG] recv", "packet", pkg)
 		return pkg, nil
 	case <-time.After(5 * time.Second):
 		return nil, errors.New("timeout recv")

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -148,7 +148,7 @@ func (cs *ClientSet) sync() {
 	var duration time.Duration
 	for {
 		if err := cs.syncOnce(); err != nil {
-			klog.Error(err)
+			klog.ErrorS(err, "cannot sync once")
 			duration = backoff.Step()
 		} else {
 			backoff = cs.resetBackoff()
@@ -172,17 +172,17 @@ func (cs *ClientSet) syncOnce() error {
 		return err
 	}
 	if cs.serverCount != 0 && cs.serverCount != serverCount {
-		klog.Warningf("current server count is %d, server %s suggests there are %d servers",
-			cs.serverCount, c.serverID, serverCount)
+		klog.V(2).InfoS("Server count change suggestion by server",
+			"current", cs.serverCount, "serverID", c.serverID, "actual", serverCount)
 
 	}
 	cs.serverCount = serverCount
 	if err := cs.AddClient(c.serverID, c); err != nil {
-		klog.Infof("closing connection: %v", err)
+		klog.ErrorS(err, "closing connection failure when adding a client")
 		c.Close()
 		return nil
 	}
-	klog.Infof("sync added client connecting to proxy server %s", c.serverID)
+	klog.V(2).InfoS("sync added client connecting to proxy server", "serverID", c.serverID)
 	go c.Serve()
 	return nil
 }

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -122,7 +122,7 @@ func NewDefaultBackendStorage() *DefaultBackendStorage {
 
 // AddBackend adds a backend.
 func (s *DefaultBackendStorage) AddBackend(agentID string, conn agent.AgentService_ConnectServer) Backend {
-	klog.Infof("register Backend %v for agentID %s", conn, agentID)
+	klog.V(2).InfoS("Register backend for agent", "connection", conn, "agentID", agentID)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	_, ok := s.backends[agentID]
@@ -130,7 +130,7 @@ func (s *DefaultBackendStorage) AddBackend(agentID string, conn agent.AgentServi
 	if ok {
 		for _, v := range s.backends[agentID] {
 			if v.conn == conn {
-				klog.Warningf("this should not happen. Adding existing connection %v for agentID %s", conn, agentID)
+				klog.V(1).InfoS("This should not happen. Adding existing backend for agent", "connection", conn, "agentID", agentID)
 				return v
 			}
 		}
@@ -144,12 +144,12 @@ func (s *DefaultBackendStorage) AddBackend(agentID string, conn agent.AgentServi
 
 // RemoveBackend removes a backend.
 func (s *DefaultBackendStorage) RemoveBackend(agentID string, conn agent.AgentService_ConnectServer) {
-	klog.Infof("remove Backend %v for agentID %s", conn, agentID)
+	klog.V(2).InfoS("Remove connection for agent", "connection", conn, "agentID", agentID)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	backends, ok := s.backends[agentID]
 	if !ok {
-		klog.Warningf("can't find agentID %s in the backends", agentID)
+		klog.V(1).InfoS("Cannot find agent in backends", "agentID", agentID)
 		return
 	}
 	var found bool
@@ -157,7 +157,7 @@ func (s *DefaultBackendStorage) RemoveBackend(agentID string, conn agent.AgentSe
 		if c.conn == conn {
 			s.backends[agentID] = append(s.backends[agentID][:i], s.backends[agentID][i+1:]...)
 			if i == 0 && len(s.backends[agentID]) != 0 {
-				klog.Warningf("this should not happen. Removed connection %v that is not the first connection, remaining connections are %v", conn, s.backends[agentID])
+				klog.V(1).InfoS("This should not happen. Removed connection that is not the first connection", "connection", conn, "remainingConnections", s.backends[agentID])
 			}
 			found = true
 		}
@@ -173,7 +173,7 @@ func (s *DefaultBackendStorage) RemoveBackend(agentID string, conn agent.AgentSe
 		}
 	}
 	if !found {
-		klog.Errorf("can't find conn %v for agentID %s in the backends", conn, agentID)
+		klog.V(1).InfoS("Cannot find connection for agent in backends", "connection", conn, "agentID", agentID)
 	}
 }
 
@@ -200,7 +200,7 @@ func (s *DefaultBackendStorage) GetRandomBackend() (Backend, error) {
 		return nil, &ErrNotFound{}
 	}
 	agentID := s.agentIDs[s.random.Intn(len(s.agentIDs))]
-	klog.Infof("pick agentID=%s as backend", agentID)
+	klog.V(4).InfoS("Pick agent as backend", "agentID", agentID)
 	// always return the first connection to an agent, because the agent
 	// will close later connections if there are multiple.
 	return s.backends[agentID][0], nil

--- a/proto/header/header.go
+++ b/proto/header/header.go
@@ -29,5 +29,5 @@ const (
 	AuthenticationTokenContextSchemePrefix = "Bearer "
 
 	// UserAgent is used to provide the client information in a proxy request
-	UserAgent   = "user-agent"
+	UserAgent = "user-agent"
 )


### PR DESCRIPTION
Logs now are now use [logging conventions](https://github.com/kubernetes/community/blob/407895f4995d5e311a3fa371d59245c360f78c49/contributors/devel/sig-instrumentation/logging.md) and [structured logging conventions](https://github.com/kubernetes/community/blob/01165b1a4a37c5d38057c4eee0584e2c285d0a08/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)

Fixes #28 