### PR TITLE
add DNS:localhost to master certificate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ certs: easy-rsa-master cfssl cfssljson
 	cd easy-rsa-master/master; \
 	./easyrsa init-pki; \
 	./easyrsa --batch "--req-cn=127.0.0.1@$(date +%s)" build-ca nopass; \
-	./easyrsa --subject-alt-name="DNS:kubernetes,IP:127.0.0.1" build-server-full "proxy-master" nopass; \
+	./easyrsa --subject-alt-name="DNS:kubernetes,DNS:localhost,IP:127.0.0.1" build-server-full "proxy-master" nopass; \
 	./easyrsa build-client-full proxy-client nopass; \
 	echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","client auth"]}}}' > "ca-config.json"; \
 	echo '{"CN":"proxy","names":[{"O":"system:nodes"}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | "../../cfssl" gencert -ca=pki/ca.crt -ca-key=pki/private/ca.key -config=ca-config.json - | "../../cfssljson" -bare proxy
@@ -126,7 +126,7 @@ certs: easy-rsa-master cfssl cfssljson
 	cd easy-rsa-master/agent; \
 	./easyrsa init-pki; \
 	./easyrsa --batch "--req-cn=127.0.0.1@$(date +%s)" build-ca nopass; \
-	./easyrsa --subject-alt-name="DNS:kubernetes,IP:127.0.0.1" build-server-full "proxy-master" nopass; \
+	./easyrsa --subject-alt-name="DNS:kubernetes,DNS:localhost,IP:127.0.0.1" build-server-full "proxy-master" nopass; \
 	./easyrsa build-client-full proxy-agent nopass; \
 	echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","agent auth"]}}}' > "ca-config.json"; \
 	echo '{"CN":"proxy","names":[{"O":"system:nodes"}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | "../../cfssl" gencert -ca=pki/ca.crt -ca-key=pki/private/ca.key -config=ca-config.json - | "../../cfssljson" -bare proxy


### PR DESCRIPTION
When trying out the `python -m SimpleHTTPServer` example, got following error: 
```bash
Error: failed to get dialer for client, got failed to create tunnel localhost:8090, got rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: x509: certificate is valid for kubernetes, not localhost"
```
Add `DNS:localhost` to the proxy-server's certificate to fix it. 