### PR TITLE
Added controllable test http server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ requests on the other.
 ### GRPC Client using mTLS Proxy with dial back Agent
 
 ```
-client =HTTP over GRPC=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPServer(:8000)
+client =HTTP over GRPC=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> http-test-server(:8000)
   |                                                    ^
   |                          Tunnel                    |
   +----------------------------------------------------+
 ```
 
-- Start SimpleHTTPServer (Sample destination)
+- Start Simple test HTTP Server (Sample destination)
 ```console
-python -m SimpleHTTPServer
+./bin/http-test-server
 ```
 
 - Start proxy service
@@ -82,6 +82,36 @@ python -m SimpleHTTPServer
 ./bin/proxy-test-client --ca-cert=certs/master/issued/ca.crt --client-cert=certs/master/issued/proxy-client.crt --client-key=certs/master/private/proxy-client.key
 ```
 
+### GRPC+UDP Client using Proxy with dial back Agent
+
+```
+client =HTTP over GRPC+UDP=> (/tmp/uds-proxy) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPServer(:8000)
+  |                                                    ^
+  |                          Tunnel                    |
+  +----------------------------------------------------+
+```
+
+- Start Simple test HTTP Server (Sample destination)
+```console
+./bin/http-test-server
+```
+
+- Start proxy service
+```console
+./bin/proxy-server --server-port=0 --uds-name=/tmp/uds-proxy --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-master.crt --cluster-key=certs/agent/private/proxy-master.key
+```
+
+- Start agent service
+```console
+./bin/proxy-agent --ca-cert=certs/agent/issued/ca.crt --agent-cert=certs/agent/issued/proxy-agent.crt --agent-key=certs/agent/private/proxy-agent.key
+```
+
+- Run client (mTLS enabled sample client)
+```console
+./bin/proxy-test-client --proxy-port=0 --proxy-uds=/tmp/uds-proxy --proxy-host=""
+```
+
+
 ### HTTP-Connect Client using mTLS Proxy with dial back Agent (Either curl OR test client)
 
 ```
@@ -93,7 +123,7 @@ client =HTTP-CONNECT=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPSer
 
 - Start SimpleHTTPServer (Sample destination)
 ```console
-python -m SimpleHTTPServer
+./bin/http-test-server
 ```
 
 - Start proxy service

--- a/artifacts/images/test-server-build.Dockerfile
+++ b/artifacts/images/test-server-build.Dockerfile
@@ -1,0 +1,32 @@
+# Build the http test server binary
+FROM golang:1.13.4 as builder
+
+# Copy in the go src
+WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+
+# This is required before go mod download because we have a
+# replace directive for konnectivity-client in go.mod
+# The download will fail without the directory present
+COPY konnectivity-client/ konnectivity-client/
+
+# Cache dependencies
+RUN go mod download
+
+# Copy the sources
+COPY pkg/    pkg/
+COPY cmd/    cmd/
+
+# Build
+ARG ARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o http-test-server sigs.k8s.io/apiserver-network-proxy/cmd/test-server
+
+# Copy the loader into a thin image
+FROM scratch
+WORKDIR /
+COPY --from=builder /go/src/sigs.k8s.io/apiserver-network-proxy/http-test-server .
+ENTRYPOINT ["/http-test-server"]

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
+)
+
+func main() {
+	testServer := &TestServer{}
+	o := newTestServerRunOptions()
+	command := newTestServerCommand(testServer, o)
+	flags := command.Flags()
+	flags.AddFlagSet(o.Flags())
+	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	klog.InitFlags(local)
+	local.VisitAll(func(fl *flag.Flag) {
+		fl.Name = util.Normalize(fl.Name)
+		flags.AddGoFlag(fl)
+	})
+	if err := command.Execute(); err != nil {
+		klog.Errorf("error: %v\n", err)
+		klog.Flush()
+		os.Exit(1)
+	}
+}
+
+type TestServerRunOptions struct {
+	// Port we listen for server connections on.
+	serverPort uint
+}
+
+func (o *TestServerRunOptions) Flags() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("proxy-server", pflag.ContinueOnError)
+	flags.UintVar(&o.serverPort, "server-port", o.serverPort, "Port we listen for server connections on. Set to 0 for UDS.")
+	return flags
+}
+
+func (o *TestServerRunOptions) Print() {
+	klog.Warningf("Server port set to %d.\n", o.serverPort)
+}
+
+func (o *TestServerRunOptions) Validate() error {
+	if o.serverPort > 49151 {
+		return fmt.Errorf("please do not try to use ephemeral port %d for the server port", o.serverPort)
+	}
+	if o.serverPort < 1024 {
+		return fmt.Errorf("please do not try to use reserved port %d for the server port", o.serverPort)
+	}
+
+	return nil
+}
+
+func newTestServerRunOptions() *TestServerRunOptions {
+	o := TestServerRunOptions{
+		serverPort:             8000,
+	}
+	return &o
+}
+
+func newTestServerCommand(p *TestServer, o *TestServerRunOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "test http server",
+		Long: `A test http server, url determines behavior for certain tests.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return p.run(o)
+		},
+	}
+
+	return cmd
+}
+
+type TestServer struct {
+}
+
+type StopFunc func()
+
+func (p *TestServer) run(o *TestServerRunOptions) error {
+	o.Print()
+	if err := o.Validate(); err != nil {
+		return fmt.Errorf("failed to validate server options with %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	klog.Info("Starting test http server for client requests.")
+	masterStop, err := p.runMasterServer(ctx, o)
+	if err != nil {
+		return fmt.Errorf("failed to run the master server: %v", err)
+	}
+
+	stopCh := SetupSignalHandler()
+	<-stopCh
+	klog.Info("Shutting down server.")
+
+	if masterStop != nil {
+		masterStop()
+	}
+
+	return nil
+}
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+
+func SetupSignalHandler() (stopCh <-chan struct{}) {
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		close(stop)
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}
+
+func returnSuccess(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "<!DOCTYPE html>\n<html>\n    <head>\n        <title>Success</title>\n    </head>\n    <body>\n        <p>The success test page!</p>\n    </body>\n</html>")
+}
+
+func returnError(w http.ResponseWriter, req *http.Request) {
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}
+
+func closeNoResponse(w http.ResponseWriter, req *http.Request) {
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)
+		return
+	}
+	conn, _, err := hj.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	conn.Close()
+}
+
+func sleepReturnSuccess(w http.ResponseWriter, req *http.Request) {
+	sleepArr := req.URL.Query()["time"]
+	sleepInt := 10
+	var err error
+	if len(sleepArr) == 1 {
+		sleepStr := sleepArr[0]
+		sleepInt, err = strconv.Atoi(sleepStr)
+		if err != nil {
+			sleepInt = 10
+			klog.Warningf("Failed to parse sleep time (%s), default to %d, got error %v.", sleepStr, sleepInt, err)
+		}
+	} else {
+		klog.Warningf("Sleep time(%v) was length %d defaulting to sleep %d.", sleepArr, len(sleepArr), sleepInt)
+	}
+	sleep := time.Duration(sleepInt) * time.Second
+	time.Sleep(sleep)
+	returnSuccess(w, req)
+}
+
+func (p *TestServer) runMasterServer(ctx context.Context, o *TestServerRunOptions) (StopFunc, error) {
+	muxHandler := http.NewServeMux()
+	muxHandler.HandleFunc("/success", returnSuccess)
+	muxHandler.HandleFunc("/sleep", sleepReturnSuccess)
+	muxHandler.HandleFunc("/error", returnError)
+	muxHandler.HandleFunc("/close", closeNoResponse)
+	server := &http.Server{
+		Addr:           fmt.Sprintf("127.0.0.1:%d", o.serverPort),
+		Handler:        muxHandler,
+		MaxHeaderBytes: 1 << 20,
+	}
+
+	go func() {
+		err := server.ListenAndServe()
+		if err != nil {
+			klog.Warningf("HTTP test server received %v.\n", err)
+		}
+		klog.Warningf("HTTP test server stopped listening\n")
+	}()
+
+	stop := func() { server.Shutdown(ctx) }
+	return stop, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,10 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/grpc v1.27.0
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.17.1
 	k8s.io/apimachinery v0.17.1
 	k8s.io/client-go v0.17.1


### PR DESCRIPTION
Added controllable test http server.
Currently only support /success for baic page returned.
Plan to add various error producing pages as well.
Test server supports connection reuse which the old server did not.
Added option to test client to test connection reuse.
Updated documentation for detail on using UDS.