### PR TITLE
Disconnect frontend if backend drops

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -183,6 +183,16 @@ func (s *ProxyServer) getFrontend(agentID string, connID int64) (*ProxyClientCon
 	return conn, nil
 }
 
+func (s *ProxyServer) getFrontends(agentID string) (map[int64]*ProxyClientConnection, error) {
+	s.fmu.RLock()
+	defer s.fmu.RUnlock()
+	conns, ok := s.frontends[agentID]
+	if !ok {
+		return nil, fmt.Errorf("can't find agentID %s in the frontends", agentID)
+	}
+	return conns, nil
+}
+
 // NewProxyServer creates a new ProxyServer instance
 func NewProxyServer(serverID string, serverCount int, agentAuthenticationOptions *AgentTokenAuthenticationOptions) *ProxyServer {
 	bm := NewDefaultBackendManager()
@@ -301,8 +311,9 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			if err := backend.Send(pkt); err != nil {
 				// TODO: retry with other backends connecting to this agent.
 				klog.Warningf(">>> DATA to Backend failed: %v", err)
+				continue
 			}
-			klog.Info(">>> DATA sent to backend")
+			klog.Info(">>> DATA sent to Backend")
 
 		default:
 			klog.Infof(">>> Ignore %v packet coming from frontend", pkt.Type)
@@ -480,7 +491,7 @@ func (s *ProxyServer) serveRecvBackend(stream agent.AgentService_ConnectServer, 
 			resp := pkt.GetDialResponse()
 			klog.Infof("<<< Received DIAL_RSP(rand=%d), agentID %s, connID %d)", resp.Random, agentID, resp.ConnectID)
 
-			if client, ok := s.PendingDial.Get(resp.Random); !ok {
+			if frontend, ok := s.PendingDial.Get(resp.Random); !ok {
 				klog.Warning("<<< DialResp not recognized; dropped")
 			} else {
 				dialErr := false
@@ -488,33 +499,32 @@ func (s *ProxyServer) serveRecvBackend(stream agent.AgentService_ConnectServer, 
 					klog.Warningf("<<< DIAL_RSP contains error: %v", resp.Error)
 					dialErr = true
 				}
-				err := client.send(pkt)
+				err := frontend.send(pkt)
 				s.PendingDial.Remove(resp.Random)
 				if err != nil {
-					klog.Warningf("<<< DIAL_RSP send to client stream error: %v", err)
+					klog.Warningf("<<< DIAL_RSP send to frontend stream error: %v", err)
 					dialErr = true
 				}
 				// Avoid adding the frontend if there was an error dialing the destination
 				if dialErr == true {
 					break
 				}
-
-				client.connectID = resp.ConnectID
-				client.agentID = agentID
-				s.addFrontend(agentID, resp.ConnectID, client)
-				close(client.connected)
-				metrics.Metrics.ObserveDialLatency(time.Since(client.start))
+				frontend.connectID = resp.ConnectID
+				frontend.agentID = agentID
+				s.addFrontend(agentID, resp.ConnectID, frontend)
+				close(frontend.connected)
+				metrics.Metrics.ObserveDialLatency(time.Since(frontend.start))
 			}
 
 		case client.PacketType_DATA:
 			resp := pkt.GetData()
 			klog.Infof("<<< Received %d bytes of DATA from agentID %s, connID %d", len(resp.Data), agentID, resp.ConnectID)
-			client, err := s.getFrontend(agentID, resp.ConnectID)
+			frontend, err := s.getFrontend(agentID, resp.ConnectID)
 			if err != nil {
 				klog.Warning(err)
 				break
 			}
-			if err := client.send(pkt); err != nil {
+			if err := frontend.send(pkt); err != nil {
 				klog.Warningf("<<< DATA send to client stream error: %v", err)
 			} else {
 				klog.V(6).Infof("<<< DATA sent to frontend")
@@ -523,12 +533,12 @@ func (s *ProxyServer) serveRecvBackend(stream agent.AgentService_ConnectServer, 
 		case client.PacketType_CLOSE_RSP:
 			resp := pkt.GetCloseResponse()
 			klog.Infof("<<< Received CLOSE_RSP(id=%d)", resp.ConnectID)
-			client, err := s.getFrontend(agentID, resp.ConnectID)
+			frontend, err := s.getFrontend(agentID, resp.ConnectID)
 			if err != nil {
 				klog.Warning(err)
 				break
 			}
-			if err := client.send(pkt); err != nil {
+			if err := frontend.send(pkt); err != nil {
 				// Normal when frontend closes it.
 				klog.Infof("<<< CLOSE_RSP send to client stream error: %v", err)
 			} else {
@@ -542,4 +552,25 @@ func (s *ProxyServer) serveRecvBackend(stream agent.AgentService_ConnectServer, 
 		}
 	}
 	klog.Infof("<<< Close backend %v of agent %s", stream, agentID)
+
+	// Close all connected frontends when the agent connection is closed
+	// TODO(#126): Frontends in PendingDial state that have not been added to the
+	//             list of frontends should also be closed.
+	frontends, _ := s.getFrontends(agentID)
+	klog.Infof("<<< Close %d frontends connected to agent %s", len(frontends), agentID)
+
+	for _, frontend := range frontends {
+		s.removeFrontend(agentID, frontend.connectID)
+		pkt := &client.Packet{
+			Type: client.PacketType_CLOSE_RSP,
+			Payload: &client.Packet_CloseResponse{
+				CloseResponse: &client.CloseResponse{},
+			},
+		}
+		pkt.GetCloseResponse().ConnectID = frontend.connectID
+		if err := frontend.send(pkt); err != nil {
+			klog.Warningf("<<< CLOSE_RSP to frontend failed: %v", err)
+		}
+	}
+
 }

--- a/tests/agent_disconnect_test.go
+++ b/tests/agent_disconnect_test.go
@@ -1,0 +1,249 @@
+package tests
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
+)
+
+func TestProxy_Agent_Disconnect_HTTP_Persistent_Connection(t *testing.T) {
+	testcases := []struct {
+		name                string
+		proxyServerFunction func() (proxy, func(), error)
+		clientFunction      func(string, string) (*http.Client, error)
+	}{
+		{
+			name:                "grpc",
+			proxyServerFunction: runGRPCProxyServer,
+			clientFunction:      createGrpcTunnelClient,
+		},
+		{
+			name:                "http-connect",
+			proxyServerFunction: runHTTPConnProxyServer,
+			clientFunction:      createHTTPConnectClient,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(newEchoServer("hello"))
+			defer server.Close()
+
+			stopCh := make(chan struct{})
+
+			proxy, cleanup, err := tc.proxyServerFunction()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+
+			runAgent(proxy.agent, stopCh)
+
+			// Wait for agent to register on proxy server
+			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+
+				ready, _ := proxy.server.Readiness.Ready()
+				return ready, nil
+			})
+
+			// run test client
+
+			c, err := tc.clientFunction(proxy.front, server.URL)
+			if err != nil {
+				t.Errorf("error obtaining client: %v", err)
+			}
+
+			_, err = clientRequest(c, server.URL)
+
+			if err != nil {
+				t.Errorf("expected no error on proxy request, got %v", err)
+			}
+			close(stopCh)
+
+			// Wait for the agent to disconnect
+			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+				ready, _ := proxy.server.Readiness.Ready()
+				return !ready, nil
+			})
+
+			// Reuse same client to make the request
+			_, err = clientRequest(c, server.URL)
+			if err == nil {
+				t.Errorf("expect request using http persistent connections to fail after dialing on a broken connection")
+			} else if os.IsTimeout(err) {
+				t.Errorf("expect request using http persistent connections to fail with error use of closed network connection. Got timeout")
+			}
+		})
+	}
+}
+
+func TestProxy_Agent_Reconnect(t *testing.T) {
+	testcases := []struct {
+		name                string
+		proxyServerFunction func() (proxy, func(), error)
+		clientFunction      func(string, string) (*http.Client, error)
+	}{
+		{
+			name:                "grpc",
+			proxyServerFunction: runGRPCProxyServer,
+			clientFunction:      createGrpcTunnelClient,
+		},
+		{
+			name:                "http-connect",
+			proxyServerFunction: runHTTPConnProxyServer,
+			clientFunction:      createHTTPConnectClient,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			server := httptest.NewServer(newEchoServer("hello"))
+			defer server.Close()
+
+			stopCh := make(chan struct{})
+
+			proxy, cleanup, err := tc.proxyServerFunction()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cleanup()
+
+			runAgent(proxy.agent, stopCh)
+
+			// Wait for agent to register on proxy server
+			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+				ready, _ := proxy.server.Readiness.Ready()
+				return ready, nil
+			})
+
+			// run test client
+
+			c, err := tc.clientFunction(proxy.front, server.URL)
+			if err != nil {
+				t.Errorf("error obtaining client: %v", err)
+			}
+
+			_, err = clientRequest(c, server.URL)
+
+			if err != nil {
+				t.Errorf("expected no error on proxy request, got %v", err)
+			}
+			close(stopCh)
+
+			// Wait for the agent to disconnect
+			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+				ready, _ := proxy.server.Readiness.Ready()
+				return !ready, nil
+			})
+
+			// Reconnect agent
+			stopCh2 := make(chan struct{})
+			runAgent(proxy.agent, stopCh2)
+			defer close(stopCh2)
+
+			// Wait for agent to register on proxy server
+			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+				ready, _ := proxy.server.Readiness.Ready()
+				return ready, nil
+			})
+
+			// Proxy requests should work again after agent reconnects
+			c2, err := tc.clientFunction(proxy.front, server.URL)
+			if err != nil {
+				t.Errorf("error obtaining client: %v", err)
+			}
+
+			_, err = clientRequest(c2, server.URL)
+
+			if err != nil {
+				t.Errorf("expected no error on proxy request, got %v", err)
+			}
+		})
+	}
+}
+
+func clientRequest(c *http.Client, addr string) ([]byte, error) {
+	r, err := c.Get(addr)
+
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	defer r.Body.Close()
+
+	return data, nil
+}
+
+func createGrpcTunnelClient(proxyAddr, addr string) (*http.Client, error) {
+	tunnel, err := client.CreateSingleUseGrpcTunnel(proxyAddr, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+
+	c := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Dial: tunnel.Dial,
+		},
+	}
+
+	return c, nil
+}
+
+func createHTTPConnectClient(proxyAddr, addr string) (*http.Client, error) {
+	conn, err := net.Dial("tcp", proxyAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, _ := url.Parse(addr)
+
+	// Send HTTP-Connect request
+	_, err = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", serverURL.Host, "127.0.0.1")
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the HTTP response for Connect
+	br := bufio.NewReader(conn)
+	res, err := http.ReadResponse(br, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reading HTTP response from CONNECT: %v", err)
+	}
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("expect 200; got %d", res.StatusCode)
+	}
+	if br.Buffered() > 0 {
+		return nil, fmt.Errorf("unexpected extra buffer")
+	}
+
+	dialer := func(network, addr string) (net.Conn, error) {
+		return conn, nil
+	}
+
+	c := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Dial: dialer,
+		},
+	}
+
+	return c, nil
+}

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -253,8 +253,9 @@ func localAddr(addr net.Addr) string {
 }
 
 type proxy struct {
-	front string
-	agent string
+	server *server.ProxyServer
+	front  string
+	agent  string
 }
 
 func runGRPCProxyServer() (proxy, func(), error) {
@@ -298,6 +299,7 @@ func runGRPCProxyServerWithServerCount(serverCount int) (proxy, *server.ProxySer
 		agentServer.Serve(lis2)
 	}()
 	proxy.agent = localAddr(lis2.Addr())
+	proxy.server = server
 
 	return proxy, server, cleanup, nil
 }
@@ -341,6 +343,7 @@ func runHTTPConnProxyServer() (proxy, func(), error) {
 		lis2.Close()
 		httpServer.Shutdown(context.Background())
 	}
+	proxy.server = s
 
 	return proxy, cleanup, nil
 }


### PR DESCRIPTION
Created to address https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/123

The proxy server generates a mapping between a frontend (kube-apiserver client connection) and a backend (particular agentID connection) whenever a connection is established. When the agent connection is broken and a reconnect occurs, this backend still points to the old agent connection which is broken. This is the expected behavior ever since we removed reconnects. However, the frontend has no awareness that the backend is gone and will keep sending packets.

This PR disconnects the frontend connection (more technically sends a close rsp to the frontend to close the connection) if its corresponding agent connection is dropped. This prevents the client from getting stuck (https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/123#issuecomment-657328196) and immediately surfaces an error.

This is similar to how we send a close_req to the backend to terminate the agent -> destination connection when the frontend disconnects (https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/master/pkg/server/server.go#L312-L330)