### PR TITLE
Fix concurrent client test to use proper backend struct

### DIFF
--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -61,8 +61,8 @@ func TestAddRemoveBackends(t *testing.T) {
 	// This is invalid. agent1 doesn't have conn3. This should be a no-op.
 	p.RemoveBackend("agent1", conn3)
 	expectedBackends = map[string][]*backend{
-		"agent1": []*backend{newBackend(conn12)},
-		"agent3": []*backend{newBackend(conn3)},
+		"agent1": []*backend{newBackend("agent1", conn12)},
+		"agent3": []*backend{newBackend("agent3", conn3)},
 	}
 	expectedAgentIDs = []string{"agent1", "agent3"}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {


### PR DESCRIPTION
A refactor was done a while ago to use the Backend object in Backend Manager instead of directly manipulating the conn object. This PR fixes the test to follow the new conventions.

Unfortunately this results in a decent amount of duplicate code, but the alternative is to make the (lowercase) backend struct public which is not ideal either.

The PR also adds an AgentID() method to the Backend interface which will be used in a follow up PR.

/assign @caesarxuchao 
/cc @cheftako 