### PR TITLE
Test konnectivity-client in make test and fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ mock_gen:
 
 .PHONY: test
 test:
-	GO111MODULE=on go test -race ./...
+	GO111MODULE=on go test -race sigs.k8s.io/apiserver-network-proxy/...
 
 ## --------------------------------------
 ## Binaries

--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -51,6 +51,12 @@ type grpcTunnel struct {
 	connsLock       sync.RWMutex
 }
 
+type clientConn interface {
+	Close() error
+}
+
+var _ clientConn = &grpc.ClientConn{}
+
 // CreateSingleUseGrpcTunnel creates a Tunnel to dial to a remote server through a
 // gRPC based proxy service.
 // Currently, a single tunnel supports a single connection, and the tunnel is closed when the connection is terminated
@@ -79,7 +85,7 @@ func CreateSingleUseGrpcTunnel(address string, opts ...grpc.DialOption) (Tunnel,
 	return tunnel, nil
 }
 
-func (t *grpcTunnel) serve(c *grpc.ClientConn) {
+func (t *grpcTunnel) serve(c clientConn) {
 	defer c.Close()
 
 	for {

--- a/konnectivity-client/pkg/client/client_test.go
+++ b/konnectivity-client/pkg/client/client_test.go
@@ -40,7 +40,7 @@ func TestDial(t *testing.T) {
 		conns:       make(map[int64]*conn),
 	}
 
-	go tunnel.serve()
+	go tunnel.serve(&fakeConn{})
 	go ts.serve()
 
 	_, err := tunnel.Dial("tcp", "127.0.0.1:80")
@@ -70,7 +70,7 @@ func TestData(t *testing.T) {
 		conns:       make(map[int64]*conn),
 	}
 
-	go tunnel.serve()
+	go tunnel.serve(&fakeConn{})
 	go ts.serve()
 
 	conn, err := tunnel.Dial("tcp", "127.0.0.1:80")
@@ -127,7 +127,7 @@ func TestClose(t *testing.T) {
 		conns:       make(map[int64]*conn),
 	}
 
-	go tunnel.serve()
+	go tunnel.serve(&fakeConn{})
 	go ts.serve()
 
 	conn, err := tunnel.Dial("tcp", "127.0.0.1:80")
@@ -155,6 +155,15 @@ type fakeStream struct {
 	r <-chan *client.Packet
 	w chan<- *client.Packet
 }
+
+type fakeConn struct {
+}
+
+func (f *fakeConn) Close() error {
+	return nil
+}
+
+var _ clientConn = &fakeConn{}
 
 var _ client.ProxyService_ProxyClient = &fakeStream{}
 


### PR DESCRIPTION
`go test ./...` only tests the root module, and skips the konnectivity-client submodule tests.
(https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/117 and https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/116)

This PR fixes the `make test` command as well as the current failing konnectivity-client tests.

/assign @caesarxuchao 
/assign @cheftako 