### PR TITLE
Remove additional docker build before docker push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ docker-push-manifest/http-test-server: ## Push the fat manifest docker image.
 
 .PHONY: release-staging
 release-staging: ## Builds and push container images to the staging bucket.
-	REGISTRY=$(STAGING_REGISTRY) $(MAKE) docker-build-all docker-push-all release-alias-tag
+	REGISTRY=$(STAGING_REGISTRY) $(MAKE) docker-push-all release-alias-tag
 
 .PHONY: release-alias-tag
 release-alias-tag: # Adds the tag to the last build tag. BASE_REF comes from the cloudbuild.yaml


### PR DESCRIPTION
Looking at the image push logs (http://storage.googleapis.com/k8s-staging-kas-network-proxy-gcb/logs/log-66bfaf44-b21f-424a-8128-fe6e371d7fcb.txt), it looks like the same image (eg: proxy-agent-arm64:v20200714-v0.0.10-15-g5afb5f2) is built twice before being pushed to the registry. 

This comes from `make release-staging` calling `docker-build-all docker-push-all` while `docker-push-all` calls another `docker-build` for each push. We should skip the redundant build.

/cc @Sh4d1 
/assign @cheftako 