### PR TITLE
Fix frontend cleanup for backend disconnect for HA servers

### DIFF
--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -79,6 +79,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		HTTP:      conn,
 		connected: connected,
 		start:     time.Now(),
+		backend:   backend,
 	}
 	t.Server.PendingDial.Add(random, connection)
 	if err := backend.Send(dialRequest); err != nil {

--- a/tests/agent_disconnect_test.go
+++ b/tests/agent_disconnect_test.go
@@ -136,7 +136,6 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 			}
 
 			_, err = clientRequest(c, server.URL)
-
 			if err != nil {
 				t.Errorf("expected no error on proxy request, got %v", err)
 			}

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -59,10 +59,11 @@ type singleTimeManager struct {
 	used     map[string]struct{}
 }
 
-func (s *singleTimeManager) AddBackend(agentID string, conn agent.AgentService_ConnectServer) {
+func (s *singleTimeManager) AddBackend(agentID string, conn agent.AgentService_ConnectServer) server.Backend {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.backends[agentID] = conn
+	return conn
 }
 
 func (s *singleTimeManager) RemoveBackend(agentID string, conn agent.AgentService_ConnectServer) {


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/125#discussion_r460320297. Check to ensure that we have the right backend (may be multiple with the same agentID) before removing frontend connections. I avoided tracking frontends via streams because we will have one stream per backend almost all the time except when agents are establishing their connections, and we can avoid the additional complexity.

Also fixes a race condition on https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/master/pkg/server/server.go#L495 where the `frontends[agentID]` map could be modified while iterating through the loop.

Adding the backend object to the frontend ProxyClientConnection also allows PendingDial to keep track of the backend if it needs to be closed, providing an easy fix for https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/126 in a follow up.