### PR TITLE
Decouple the Backend method from the other methods of the BackendManager

### DIFF
--- a/pkg/server/readiness_manager.go
+++ b/pkg/server/readiness_manager.go
@@ -26,11 +26,8 @@ type ReadinessManager interface {
 var _ ReadinessManager = &DefaultBackendManager{}
 
 func (s *DefaultBackendManager) Ready() (bool, string) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if len(s.backends) == 0 {
+	if s.NumBackends() == 0 {
 		return false, "no connection to any proxy agent"
 	}
 	return true, ""
-
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -270,7 +270,7 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			// the address, then we can send the Dial_REQ to the
 			// same agent. That way we save the agent from creating
 			// a new connection to the address.
-			backend, err = s.BackendManager.Backend()
+			backend, err = s.BackendManager.Backend(context.TODO())
 			if err != nil {
 				klog.Errorf(">>> failed to get a backend: %v", err)
 				continue

--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
@@ -68,7 +69,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	klog.Infof("Set pending(rand=%d) to %v", random, w)
-	backend, err := t.Server.BackendManager.Backend()
+	backend, err := t.Server.BackendManager.Backend(context.TODO())
 	if err != nil {
 		http.Error(w, fmt.Sprintf("currently no tunnels available: %v", err), http.StatusInternalServerError)
 		return

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -79,7 +80,7 @@ func (s *singleTimeManager) RemoveBackend(agentID string, conn agent.AgentServic
 	delete(s.backends, agentID)
 }
 
-func (s *singleTimeManager) Backend() (server.Backend, error) {
+func (s *singleTimeManager) Backend(_ context.Context) (server.Backend, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for k, v := range s.backends {
@@ -89,6 +90,14 @@ func (s *singleTimeManager) Backend() (server.Backend, error) {
 		}
 	}
 	return nil, fmt.Errorf("cannot find backend to a new agent")
+}
+
+func (s *singleTimeManager) GetBackend(agentID string) server.Backend {
+	return nil
+}
+
+func (s *singleTimeManager) NumBackends() int {
+	return 0
 }
 
 func newSingleTimeGetter(m *server.DefaultBackendManager) *singleTimeManager {


### PR DESCRIPTION
1. Using the BackendStorage interface to decouple backend CRUD operations from the BackendManager
2. Implement the DesignatingBackendManager, which retrieves the backend associating to the given agentID 
resolve #142 
3. Change test cases
