### PR TITLE
Fix conflicting port 8093, problem on local testing.

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -292,7 +292,7 @@ func newProxyRunOptions() *ProxyRunOptions {
 		serverPort:                8090,
 		agentPort:                 8091,
 		healthPort:                8092,
-		adminPort:                 8093,
+		adminPort:                 8095,
 		enableProfiling:           false,
 		enableContentionProfiling: false,
 		serverID:                  uuid.New().String(),


### PR DESCRIPTION
Both agent and server use port 8093.
Agent has been on that port for 9 months.
Server has been on that port for 3 months.
So opting to fix the server as its the more recent to add the port.
The server only uses the port for admin traffic so should be relatively
safe.
Will flag it in slack.
Fixes #140 