### PR TITLE
Support multiple grpc dial options for agent -> server connection

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -77,13 +77,13 @@ type GrpcProxyAgentOptions struct {
 	serviceAccountTokenPath string
 }
 
-func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOption grpc.DialOption) *agent.ClientSetConfig {
+func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) *agent.ClientSetConfig {
 	return &agent.ClientSetConfig{
 		Address:                 fmt.Sprintf("%s:%d", o.proxyServerHost, o.proxyServerPort),
 		AgentID:                 o.agentID,
 		SyncInterval:            o.syncInterval,
 		ProbeInterval:           o.probeInterval,
-		DialOption:              dialOption,
+		DialOptions:             dialOptions,
 		ServiceAccountTokenPath: o.serviceAccountTokenPath,
 	}
 }

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -43,7 +43,7 @@ type ClientSet struct {
 	// proxy server.
 	probeInterval time.Duration // The interval by which the agent
 	// periodically checks if its connections to the proxy server is ready.
-	dialOption grpc.DialOption
+	dialOptions []grpc.DialOption
 	// file path contains service account token
 	serviceAccountTokenPath string
 	// channel to signal shutting down the client set. Primarily for test.
@@ -110,7 +110,7 @@ type ClientSetConfig struct {
 	AgentID                 string
 	SyncInterval            time.Duration
 	ProbeInterval           time.Duration
-	DialOption              grpc.DialOption
+	DialOptions             []grpc.DialOption
 	ServiceAccountTokenPath string
 }
 
@@ -121,14 +121,14 @@ func (cc *ClientSetConfig) NewAgentClientSet(stopCh <-chan struct{}) *ClientSet 
 		address:                 cc.Address,
 		syncInterval:            cc.SyncInterval,
 		probeInterval:           cc.ProbeInterval,
-		dialOption:              cc.DialOption,
+		dialOptions:             cc.DialOptions,
 		serviceAccountTokenPath: cc.ServiceAccountTokenPath,
 		stopCh:                  stopCh,
 	}
 }
 
 func (cs *ClientSet) newAgentClient() (*AgentClient, int, error) {
-	return newAgentClient(cs.address, cs.agentID, cs, cs.dialOption)
+	return newAgentClient(cs.address, cs.agentID, cs, cs.dialOptions...)
 }
 
 func (cs *ClientSet) resetBackoff() *wait.Backoff {

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -364,7 +364,7 @@ func runAgentWithID(agentID, addr string, stopCh <-chan struct{}) *agent.ClientS
 		AgentID:       agentID,
 		SyncInterval:  100 * time.Millisecond,
 		ProbeInterval: 100 * time.Millisecond,
-		DialOption:    grpc.WithInsecure(),
+		DialOptions:   []grpc.DialOption{grpc.WithInsecure()},
 	}
 	client := cc.NewAgentClientSet(stopCh)
 	client.Serve()


### PR DESCRIPTION
grpc supports multiple dial options but currently agent -> server dials (cmd/agent/main.go) only supports 1 dial option as a parameter. Refactor the code to support multiple.

This might be helpful for https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/152

/assign @cheftako 