### PR TITLE
Add keepalive option to agent server

### DIFF
--- a/examples/kubernetes/konnectivity-server.yaml
+++ b/examples/kubernetes/konnectivity-server.yaml
@@ -26,6 +26,7 @@ spec:
       "--agent-port=8091",
       "--health-port=8092",
       "--admin-port=8093",
+      "--keepalive-time=1h",
       "--mode=http-connect",
       "--agent-namespace=kube-system",
       "--agent-service-account=konnectivity-agent",


### PR DESCRIPTION
This is a fix to issue #152.

Sometimes, agent can disconnect without closing connection, and server don't know about it. Disconnected agent is still on the available agents list and server tries to route traffic through it.