### PR TITLE
Set default logging to v4

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -44,6 +44,7 @@ func main() {
 	flags.AddFlagSet(o.Flags())
 	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(local)
+	local.Set("v", "4")
 	local.VisitAll(func(fl *flag.Flag) {
 		fl.Name = util.Normalize(fl.Name)
 		flags.AddGoFlag(fl)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -60,6 +60,7 @@ func main() {
 	flags.AddFlagSet(o.Flags())
 	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(local)
+	local.Set("v", "4")
 	local.VisitAll(func(fl *flag.Flag) {
 		fl.Name = util.Normalize(fl.Name)
 		flags.AddGoFlag(fl)
@@ -549,7 +550,7 @@ func (p *Proxy) runAgentServer(o *ProxyRunOptions, server *server.ProxyServer) e
 	}
 
 	addr := fmt.Sprintf(":%d", o.agentPort)
-	serverOptions := []grpc.ServerOption {
+	serverOptions := []grpc.ServerOption{
 		grpc.Creds(credentials.NewTLS(tlsConfig)),
 		grpc.KeepaliveParams(keepalive.ServerParameters{Time: o.keepaliveTime}),
 	}


### PR DESCRIPTION
Refer to https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/156

I'm not sure if v4 is the right number, but it should definitely be higher than what it is currently (v0)

V(5) logs the individual packets which is a bit excessive, but V(4) seems to have all the important bits without being too verbose.

/assign @cheftako 