### PR TITLE
fix request hangs up when agent failed to return PacketType_DIAL_RSP

### DIFF
--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -103,6 +103,11 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case <-connection.connected: // Waiting for response before we begin full communication.
 	}
 
+	if connection.connectID == 0 {
+		klog.Errorf("wait for dial response timeout with random %d", random)
+		return
+	}
+
 	defer func() {
 		packet := &client.Packet{
 			Type: client.PacketType_CLOSE_REQ,


### PR DESCRIPTION
- background:
at present if agent does not return response for some reason, the request will be hang up in tunnel serve. so we need to add timeout process for pending client connection. 

- solution:
 when anp agent doesn't return response after 15seconds, tunnel server will take timeout process for proxy client connection to release client connection.