### PR TITLE
Include KEP in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Created due to https://github.com/kubernetes/org/issues/715.
 
-See [The KEP proposal for architecture and details](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1281-network-proxy#proposal).
+See [the KEP proposal for architecture and details](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1281-network-proxy#proposal).
 
 ## Community, discussion, contribution, and support
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Created due to https://github.com/kubernetes/org/issues/715.
 
+See [The KEP proposal for architecture and details](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1281-network-proxy#proposal).
+
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).


### PR DESCRIPTION
The GitHub issue in the readme links to a broken KEP link (https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190226-network-proxy.md).

Adding the KEP directly in the readme as it is a great resource to understanding the intent and architecture.