### PR TITLE
support helm deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,3 +309,47 @@ release-alias-tag: # Adds the tag to the last build tag. BASE_REF comes from the
 clean:
 	go clean -testcache
 	rm -rf proto/agent/agent.pb.go konnectivity-client/proto/client/client.pb.go easy-rsa.tar.gz easy-rsa cfssl cfssljson certs bin proto/agent/mocks
+
+
+.PHONY: deploy-kind
+deploy-kind: export PATH := $(shell pwd):$(PATH)
+deploy-kind: easy-rsa-master cfssl cfssljson
+	cp -rf easy-rsa-master/easyrsa3 easy-rsa-master/k8smaster
+	cp -rf easy-rsa-master/easyrsa3 easy-rsa-master/k8sagent
+	mkdir -p certs
+	# create the client <-> server-proxy connection certs
+	cd easy-rsa-master/k8smaster; \
+	./easyrsa init-pki; \
+	./easyrsa --batch "--req-cn=127.0.0.1@$(date +%s)" build-ca nopass; \
+	./easyrsa --subject-alt-name="DNS:konnectivity-proxyserver,DNS:localhost,IP:127.0.0.1" build-server-full "proxyserver" nopass; \
+	./easyrsa build-client-full "proxyclient" nopass; \
+	echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","client auth"]}}}' > "ca-config.json"; \
+	echo '{"CN":"proxy","names":[{"O":"system:nodes"}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=pki/ca.crt -ca-key=pki/private/ca.key -config=ca-config.json - | cfssljson -bare proxy
+
+	cp -r easy-rsa-master/k8smaster/pki/private/proxyserver.key certs/
+	cp -r easy-rsa-master/k8smaster/pki/private/proxyclient.key certs/
+	cp easy-rsa-master/k8smaster/pki/private/ca.key certs/proxyca.key
+	cp -r easy-rsa-master/k8smaster/pki/issued/* certs/
+	cp easy-rsa-master/k8smaster/pki/ca.crt certs/proxyca.crt
+
+	# create the agent <-> server-proxy connection certs
+	cd easy-rsa-master/k8sagent; \
+	./easyrsa init-pki; \
+	./easyrsa --batch "--req-cn=127.0.0.1@$(date +%s)" build-ca nopass; \
+	./easyrsa --subject-alt-name="DNS:konnectivity-agentserver,DNS:kubernetes,DNS:localhost,IP:127.0.0.1" build-server-full "agentserver" nopass; \
+	./easyrsa build-client-full "agentclient" nopass; \
+	echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","agent auth"]}}}' > "ca-config.json"; \
+	echo '{"CN":"proxy","names":[{"O":"system:nodes"}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=pki/ca.crt -ca-key=pki/private/ca.key -config=ca-config.json - | cfssljson -bare proxy
+
+	cp -r easy-rsa-master/k8sagent/pki/private/agentserver.key certs/
+	cp -r easy-rsa-master/k8sagent/pki/private/agentclient.key certs/
+	cp easy-rsa-master/k8sagent/pki/private/ca.key certs/agentca.key
+	cp -r easy-rsa-master/k8sagent/pki/issued/* certs/
+	cp easy-rsa-master/k8sagent/pki/ca.crt certs/agentca.crt
+
+	ARCH=$(ARCH) TAG=${TAG} AGENT_FULL_IMAGE=${AGENT_FULL_IMAGE} SERVER_FULL_IMAGE=$(SERVER_FULL_IMAGE) TEST_CLIENT_FULL_IMAGE=$(TEST_CLIENT_FULL_IMAGE) TEST_SERVER_FULL_IMAGE=$(TEST_SERVER_FULL_IMAGE) KIND_LOAD_IMAGE=y FORCE_DEPLOY=y ./scripts/deploy-asnp.sh
+
+.PHONY: delete-kind
+delete-kind:
+	rm -rf easy-rsa-master certs
+

--- a/examples/konnectivity/Chart.yaml
+++ b/examples/konnectivity/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: konnectivity
+description: A Helm chart for apiserver-network-proxy.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.0.15

--- a/examples/konnectivity/README.md
+++ b/examples/konnectivity/README.md
@@ -1,0 +1,34 @@
+
+A helm chart for `apiserver-network-proxy`, make it easy deploy and test.
+
+## User Guide
+
+
+### build image
+
+```
+export REGISTRY=gcr.io/apiserver-network-proxy
+make docker-build
+```
+
+### download binaries
+
+```
+./scripts/download-binaries.sh
+```
+
+### create kind cluster
+
+```shell
+export PATH=$(pwd)/bin:${PATH}
+
+kind create cluster
+
+make deploy-kind
+```
+
+### uninstall
+
+```shell
+make delete-kind
+```

--- a/examples/konnectivity/templates/_helpers.tpl
+++ b/examples/konnectivity/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "charts.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/examples/konnectivity/templates/agent.yaml
+++ b/examples/konnectivity/templates/agent.yaml
@@ -1,0 +1,84 @@
+{{- if and .Values.agent.enabled }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konnectivity-agent
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konnectivity-agent
+  labels:
+    app: konnectivity-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: konnectivity-agent
+  template:
+    metadata:
+      labels:
+        app: konnectivity-agent
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- if .Values.udsName }}
+      hostNetwork: true
+{{- end }}
+
+      containers:
+      - name: konnectivity-agent-container
+        image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
+        imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+        command: [ "/proxy-agent"]
+        args: [
+          "--v=3",
+          "--logtostderr=true",
+          "--ca-cert=/opt/pki/agentca/tls.crt",
+          "--agent-cert=/opt/pki/agentclient/tls.crt",
+          "--agent-key=/opt/pki/agentclient/tls.key",
+          # grpc tls will verify it
+          "--proxy-server-host=konnectivity-agentserver",
+          "--proxy-server-port=8091",
+          "--service-account-token-path=",
+          ]
+        env:
+{{- if and .Values.agent.debug }}
+          - name: GRPC_VERBOSITY
+            value: debug
+          - name: GRPC_TRACE
+            value: tcp,http,api
+          - name: GODEBUG
+            value: http2debug=2
+{{- end }}
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            port: 8093
+            path: /healthz
+          initialDelaySeconds: 15
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 50m
+            memory: 30Mi
+        volumeMounts:
+        - name: agentclient
+          mountPath: /opt/pki/agentclient
+          readOnly: true
+        - name: agentca
+          mountPath: /opt/pki/agentca
+          readOnly: true
+      serviceAccountName: konnectivity-agent
+      volumes:
+      - name: agentclient
+        secret:
+          secretName: konnectivity-agentclient
+      - name: agentca
+        secret:
+          secretName: konnectivity-agentca
+{{- end }}

--- a/examples/konnectivity/templates/kubia.yaml
+++ b/examples/konnectivity/templates/kubia.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.kubia.enabled }}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konnectivity-kubia
+  labels:
+    app: konnectivity-kubia
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: konnectivity-kubia
+  template:
+    metadata:
+      labels:
+        app: konnectivity-kubia
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- if .Values.udsName }}
+      hostNetwork: true
+{{- end }}
+      containers:
+        - name: konnectivity-kubia
+          image: "{{ .Values.kubia.image.repository }}:{{ .Values.kubia.image.tag }}"
+          imagePullPolicy: {{ .Values.kubia.image.pullPolicy }}
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubia
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: konnectivity-kubia
+
+{{- end }}

--- a/examples/konnectivity/templates/server.yaml
+++ b/examples/konnectivity/templates/server.yaml
@@ -1,0 +1,115 @@
+{{- if and .Values.server.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konnectivity-server
+  labels:
+    app: konnectivity-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: konnectivity-server
+  template:
+    metadata:
+      labels:
+        app: konnectivity-server
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- if .Values.udsName }}
+      hostNetwork: true
+{{- end }}
+      containers:
+        - name: konnectivity-server-container
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          resources:
+            requests:
+              cpu: 1m
+          command: [ "/proxy-server"]
+          env:
+{{- if and .Values.server.debug }}
+            - name: GRPC_VERBOSITY
+              value: debug
+            - name: GRPC_TRACE
+              value: all
+            - name: GODEBUG
+              value: http2debug=2
+{{- end }}
+          args: [
+            "--logtostderr=true",
+            {{- if .Values.udsName -}}
+            "--uds-name=/etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket",
+            {{- end -}}
+            {{- if not .Values.udsName -}}
+            "--server-ca-cert=/opt/pki/proxyca/tls.crt",
+            "--server-cert=/opt/pki/proxyserver/tls.crt",
+            "--server-key=/opt/pki/proxyserver/tls.key",
+            "--server-port=8090",
+            {{- end -}}
+            "--cluster-ca-cert=/opt/pki/agentca/tls.crt",
+            "--cluster-cert=/opt/pki/agentserver/tls.crt",
+            "--cluster-key=/opt/pki/agentserver/tls.key",
+            "--agent-port=8091",
+            "--health-port=8092",
+            "--admin-port=8093",
+            "--keepalive-time=1h",
+            "--mode={{ .Values.connectMode}}",
+            {{- if .Values.server.authAgent -}}
+            "--agent-namespace=kube-system",
+            "--agent-service-account=konnectivity-server",
+            "--kubeconfig=/etc/srv/kubernetes/konnectivity-server/kubeconfig",
+            "--authentication-audience=system:konnectivity-server",
+            {{- end -}}
+          ]
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              host: 127.0.0.1
+              port: 8092
+              path: /healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 60
+          ports:
+            - name: serverport
+              containerPort: 8090
+              hostPort: 8090
+            - name: agentport
+              containerPort: 8091
+              hostPort: 8091
+            - name: healthport
+              containerPort: 8092
+              hostPort: 8092
+            - name: adminport
+              containerPort: 8093
+              hostPort: 8093
+          volumeMounts:
+            - name: agentserver
+              mountPath: /opt/pki/agentserver
+              readOnly: true
+            - name: proxyserver
+              mountPath: /opt/pki/proxyserver
+              readOnly: true
+            - name: proxyca
+              mountPath: /opt/pki/proxyca
+              readOnly: true
+            - name: agentca
+              mountPath: /opt/pki/agentca
+              readOnly: true
+      volumes:
+        - name: agentserver
+          secret:
+            secretName: konnectivity-agentserver
+        - name: proxyca
+          secret:
+            secretName: konnectivity-proxyca
+        - name: proxyserver
+          secret:
+            secretName: konnectivity-proxyserver
+        - name: agentca
+          secret:
+            secretName: konnectivity-agentca
+{{- end }}

--- a/examples/konnectivity/templates/service.yaml
+++ b/examples/konnectivity/templates/service.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.server.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: konnectivity-proxyserver
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8090
+      targetPort: 8090
+      protocol: TCP
+      name: proxyserver
+    - port: 8092
+      targetPort: 8092
+      protocol: TCP
+      name: health
+    - port: 8093
+      targetPort: 8093
+      protocol: TCP
+      name: admin
+  selector:
+    app: konnectivity-server
+
+---
+# agent connect's server
+apiVersion: v1
+kind: Service
+metadata:
+  name: konnectivity-agentserver
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8091
+      targetPort: 8091
+      protocol: TCP
+      name: agentserver
+  selector:
+    app: konnectivity-server
+{{- end }}

--- a/examples/konnectivity/templates/test-client.yaml
+++ b/examples/konnectivity/templates/test-client.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.testclient.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konnectivity-test-client
+  labels:
+    app: konnectivity-test-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: konnectivity-test-client
+  template:
+    metadata:
+      labels:
+        app: konnectivity-test-client
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- if .Values.udsName }}
+      hostNetwork: true
+{{- end }}
+      containers:
+        - name: client
+          image: "{{ .Values.testclient.image.repository }}:{{ .Values.testclient.image.tag }}"
+          imagePullPolicy: {{ .Values.testclient.image.pullPolicy }}
+          resources:
+            requests:
+              cpu: 1m
+          env:
+            - name: GRPC_VERBOSITY
+              value: debug
+            - name: GRPC_TRACE
+              value: tcp,http,api
+            - name: GODEBUG
+              value: http2debug=2
+          command: [ "/proxy-test-client"]
+          args: [
+              "--logtostderr=true",
+              {{- if .Values.udsName -}}
+              "--proxy-uds=/etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket",
+              {{- end -}}
+              "--proxy-host=konnectivity-proxyserver",
+              "--proxy-port=8090",
+              "--mode={{ .Values.connectMode}}",
+              "--request-port=80",
+              "--request-host=kubia",
+              "--ca-cert=/opt/pki/proxyca/tls.crt",
+              "--client-cert=/opt/pki/proxyclient/tls.crt",
+              "--client-key=/opt/pki/proxyclient/tls.key"
+          ]
+          volumeMounts:
+          - name: proxyca
+            mountPath: /opt/pki/proxyca
+            readOnly: true
+          - name: proxyclient
+            mountPath: /opt/pki/proxyclient
+            readOnly: true
+      volumes:
+      - name: proxyca
+        secret:
+          secretName: konnectivity-proxyca
+      - name: proxyclient
+        secret:
+          secretName: konnectivity-proxyclient
+{{- end }}

--- a/examples/konnectivity/templates/test-server.yaml
+++ b/examples/konnectivity/templates/test-server.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.testserver.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konnectivity-test-server
+  labels:
+    app: konnectivity-test-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: konnectivity-test-server
+  template:
+    metadata:
+      labels:
+        app: konnectivity-test-server
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- if .Values.udsName }}
+      hostNetwork: true
+{{- end }}
+      containers:
+        - name: konnectivity-server-container
+          image: "{{ .Values.testserver.image.repository }}:{{ .Values.testserver.image.tag }}"
+          imagePullPolicy: {{ .Values.testserver.image.pullPolicy }}
+          resources:
+            requests:
+              cpu: 1m
+          command: [ "/http-test-server"]
+{{- end }}

--- a/examples/konnectivity/values.yaml
+++ b/examples/konnectivity/values.yaml
@@ -1,0 +1,44 @@
+
+udsName: false
+
+connectMode: http-connect
+
+imagePullSecrets: []
+
+agent:
+  enabled: true
+  debug: true
+  image:
+    repository: gcr.io/apiserver-network-proxy/proxy-agent-amd64
+    tag: v0.0.15
+    pullPolicy: IfNotPresent
+
+server:
+  enabled: true
+  debug: true
+  authAgent: false
+  image:
+    repository: gcr.io/apiserver-network-proxy/proxy-server-amd64
+    tag: v0.0.15
+    pullPolicy: IfNotPresent
+
+testclient:
+  enabled: true
+  image:
+    repository: gcr.io/apiserver-network-proxy/proxy-test-client-amd64
+    tag: v0.0.15
+    pullPolicy: IfNotPresent
+
+testserver:
+  enabled: true
+  image:
+    repository: gcr.io/apiserver-network-proxy/http-test-server-amd64
+    tag: v0.0.15
+    pullPolicy: IfNotPresent
+
+kubia:
+  enabled: true
+  image:
+    repository: luksa/kubia
+    tag: latest
+    pullPolicy: IfNotPresent

--- a/scripts/delete-asnp.sh
+++ b/scripts/delete-asnp.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+helm uninstall test-asnp  || true
+kubectl delete secret konnectivity-agentca || true
+kubectl delete secret konnectivity-agentclient || true
+kubectl delete secret konnectivity-agentserver || true
+kubectl delete secret konnectivity-proxyca || true
+kubectl delete secret konnectivity-proxyserver || true
+kubectl delete secret konnectivity-proxyclient || true

--- a/scripts/deploy-asnp.sh
+++ b/scripts/deploy-asnp.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# shellcheck source=util.sh
+source "${BASH_SOURCE%/*}/util.sh"
+
+check-command-installed kubectl
+check-command-installed helm
+check-command-installed kind
+
+# Use KIND_LOAD_IMAGE=y ./scripts/deploy-kubefed.sh <image> to load
+# the built docker image into kind before deploying.
+if [[ "${KIND_LOAD_IMAGE:-}" == "y" ]]; then
+    kind load docker-image "${SERVER_FULL_IMAGE}-${ARCH}:${TAG}" --name="${KIND_CLUSTER_NAME:-kind}"
+    kind load docker-image "${AGENT_FULL_IMAGE}-${ARCH}:${TAG}" --name="${KIND_CLUSTER_NAME:-kind}"
+    kind load docker-image "${TEST_CLIENT_FULL_IMAGE}-${ARCH}:${TAG}" --name="${KIND_CLUSTER_NAME:-kind}"
+    kind load docker-image "${TEST_SERVER_FULL_IMAGE}-${ARCH}:${TAG}" --name="${KIND_CLUSTER_NAME:-kind}"
+fi
+
+if [[ "${FORCE_DEPLOY:-}" == "y" ]]; then
+  ${BASH_SOURCE%/*}/delete-asnp.sh
+fi
+
+kubectl create secret tls konnectivity-proxyca --cert=certs/proxyca.crt --key=certs/proxyca.key
+kubectl create secret tls konnectivity-proxyserver --cert=certs/proxyserver.crt --key=certs/proxyserver.key
+kubectl create secret tls konnectivity-proxyclient --cert=certs/proxyclient.crt --key=certs/proxyclient.key
+kubectl create secret tls konnectivity-agentca --cert=certs/agentca.crt --key=certs/agentca.key
+kubectl create secret tls konnectivity-agentserver --cert=certs/agentserver.crt --key=certs/agentserver.key
+kubectl create secret tls konnectivity-agentclient --cert=certs/agentclient.crt --key=certs/agentclient.key
+
+helm install test-asnp ./examples/konnectivity \
+  --set agent.image.repository=${AGENT_FULL_IMAGE}-${ARCH} \
+  --set agent.image.tag=${TAG} \
+  --set server.image.repository=${SERVER_FULL_IMAGE}-${ARCH} \
+  --set server.image.tag=${TAG} \
+  --set testclient.image.repository=${TEST_CLIENT_FULL_IMAGE}-${ARCH} \
+  --set testclient.image.tag=${TAG} \
+  --set testserver.image.repository=${TEST_SERVER_FULL_IMAGE}-${ARCH} \
+  --set testserver.image.tag=${TAG} \

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script automates the download of binaries used by deployment
+# and testing of KubeFed.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Use DEBUG=1 ./scripts/download-binaries.sh to get debug output
+curl_args="-fsSL"
+[[ -z "${DEBUG:-""}" ]] || {
+  set -x
+  curl_args="-fL"
+}
+
+logEnd() {
+  local msg='done.'
+  [ "$1" -eq 0 ] || msg='Error downloading assets'
+  echo "$msg"
+}
+trap 'logEnd $?' EXIT
+
+echo "About to download some binaries. This might take a while..."
+
+root_dir="$(cd "$(dirname "$0")/.." ; pwd)"
+dest_dir="${root_dir}/bin"
+mkdir -p "${dest_dir}"
+
+platform=$(uname -s|tr A-Z a-z)
+
+# helm
+helm_version="3.3.4"
+helm_tgz="helm-v${helm_version}-${platform}-amd64.tar.gz"
+helm_url="https://get.helm.sh/$helm_tgz"
+curl "${curl_args}" "${helm_url}" \
+    | tar xzP -C "${dest_dir}" --strip-components=1 "${platform}-amd64/helm"
+
+# kubectl
+kubectl_version=v1.20.0
+kubectl_path="${dest_dir}/kubectl"
+kubectl_url=https://dl.k8s.io/release/v1.20.0/bin/${platform}/amd64/kubectl
+curl -fLo "${kubectl_path}" "${kubectl_url}" && chmod +x "${kubectl_path}"
+# kind
+kind_version="v0.9.0"
+kind_path="${dest_dir}/kind"
+kind_url="https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-${platform}-amd64"
+curl -fLo "${kind_path}" "${kind_url}" && chmod +x "${kind_path}"
+
+echo    "# destination:"
+echo    "#   ${dest_dir}"
+echo    "# versions:"
+echo -n "#   kubectl:        "; "${dest_dir}/kubectl" version --client --short
+echo -n "#   helm:           "; "${dest_dir}/helm" version --client --short
+echo    "# kind installation:  ${kind_path}"

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -1,0 +1,10 @@
+
+function check-command-installed() {
+  local cmdName="${1}"
+
+  command -v "${cmdName}" >/dev/null 2>&1 || 
+  {
+    echo "${cmdName} command not found. Please download dependencies using ${BASH_SOURCE%/*}/download-binaries.sh and install it in your PATH." >&2
+    exit 1
+  }
+}


### PR DESCRIPTION
What this PR does / why we need it:

1) `examples/kubernetes` contains k8s deploy demo, need gke support;
2) `apiserver-network-proxy` has many parameters and certs, it difficulty to deploy;

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

It provider a helm package, make `apiserver-network-proxy` easy deploy to any k8s cluster. Current support `http-connect` mode, and tls server.

User guide specify in file `examples/konnectivity/README.md`.
