### PR TITLE
Fix destHost context key

### DIFF
--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -42,7 +42,7 @@ func (dibm *DestHostBackendManager) Backend(ctx context.Context) (Backend, error
 	if len(dibm.backends) == 0 {
 		return nil, &ErrNotFound{}
 	}
-	destHost := ctx.Value("destHost").(string)
+	destHost := ctx.Value(destHost).(string)
 	if destHost != "" {
 		bes, exist := dibm.backends[destHost]
 		if exist && len(bes) > 0 {


### PR DESCRIPTION
This PR is supposed to fix a mismatch between the key used to store and retrieve the `destHost` in the context.

```
I0301 17:11:43.930678       1 tunnel.go:37] "Received request for host" method="CONNECT" host="10.124.179.1:9091" userAgent=""
I0301 17:11:43.930723       1 tunnel.go:39] "TLS" commonName="konnectivity-client"
I0301 17:11:43.930861       1 tunnel.go:71] Set pending(rand=3916589616287113937) to &{0xc00018a140 0xc0000f4100 {} 0x4a0aa0 true false false false 0 {0 0} <nil> {0xc00015a700 map[] true true} map[] false 0 -1 200 false false [] 0 [77 111 110 44 32 48 49 32 77 97 114 32 50 48 50 49 32 49 55 58 49 49 58 52 51 32 71 77 84] [0 0 0 0 0 0 0 0 0 0] [50 48 48] 0xc000162fc0 0}
2021/03/01 17:11:43 http: panic serving 172.30.71.160:42206: interface conversion: interface {} is nil, not string
goroutine 59 [running]:
net/http.(*conn).serve.func1(0xc00018a140)
	/home/travis/.gimme/versions/go1.15.7.linux.amd64/src/net/http/server.go:1801 +0x147
panic(0x146f5c0, 0xc0001d0e40)
	/home/travis/.gimme/versions/go1.15.7.linux.amd64/src/runtime/panic.go:975 +0x47a
sigs.k8s.io/apiserver-network-proxy/pkg/server.(*DestHostBackendManager).Backend(0xc000214a40, 0x17c52c0, 0xc0001d0e10, 0x0, 0x0, 0x0, 0x0)
	/home/travis/gopath/src/github.ibm.com/alchemy-containers/armada-konnectivity-community-build/apiserver-network-proxy/pkg/server/desthost_backend_manager.go:45 +0x3e6
sigs.k8s.io/apiserver-network-proxy/pkg/server.(*ProxyServer).getBackend(0xc000286870, 0xc000121d27, 0x11, 0x0, 0x160eeb8, 0x1a, 0xc000585b80)
	/home/travis/gopath/src/github.ibm.com/alchemy-containers/armada-konnectivity-community-build/apiserver-network-proxy/pkg/server/server.go:168 +0xcf
sigs.k8s.io/apiserver-network-proxy/pkg/server.(*Tunnel).ServeHTTP(0xc0001160a8, 0x17c3380, 0xc00015a700, 0xc0000f4100)
	/home/travis/gopath/src/github.ibm.com/alchemy-containers/armada-konnectivity-community-build/apiserver-network-proxy/pkg/server/tunnel.go:72 +0x59a
net/http.serverHandler.ServeHTTP(0xc00015a620, 0x17c3380, 0xc00015a700, 0xc0000f4100)
	/home/travis/.gimme/versions/go1.15.7.linux.amd64/src/net/http/server.go:2843 +0xa3
net/http.(*conn).serve(0xc00018a140, 0x17c5200, 0xc00021bb00)
	/home/travis/.gimme/versions/go1.15.7.linux.amd64/src/net/http/server.go:1925 +0x8ad
created by net/http.(*Server).Serve
	/home/travis/.gimme/versions/go1.15.7.linux.amd64/src/net/http/server.go:2969 +0x36c
```