### PR TITLE
Make dial request processing asynchonous.

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -38,6 +38,8 @@ import (
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
+const dialTimeout = 5 * time.Second
+
 // connContext tracks a connection from agent to node network.
 type connContext struct {
 	conn      net.Conn
@@ -361,7 +363,7 @@ func (a *Client) Serve() {
 			resp.GetDialResponse().Random = dialReq.Random
 
 			start := time.Now()
-			conn, err := net.Dial(dialReq.Protocol, dialReq.Address)
+			conn, err := net.DialTimeout(dialReq.Protocol, dialReq.Address, dialTimeout)
 			if err != nil {
 				resp.GetDialResponse().Error = err.Error()
 				if err := a.Send(resp); err != nil {


### PR DESCRIPTION
This pull request fixes the issue if the net.Dial call based on a dial request blocks the receive loop and with that all communication from the proxy server. We have seen instances where all traffic was blocked for roughly 10 minutes.
The problem is solved by first making the dial request processing asynchronous. Secondly, we added a timeout to the net.Dial call to the target.