### PR TITLE
Update EasyRSA to 3.0.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,10 +106,11 @@ proto/agent/agent.pb.go: proto/agent/agent.proto
 ## --------------------------------------
 
 easy-rsa.tar.gz:
-	curl -L -O --connect-timeout 20 --retry 6 --retry-delay 2 https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz
+	curl -L -o easy-rsa.tar.gz --connect-timeout 20 --retry 6 --retry-delay 2 https://github.com/OpenVPN/easy-rsa/archive/refs/tags/v3.0.8.tar.gz
 
 easy-rsa-master: easy-rsa.tar.gz
 	tar xvf easy-rsa.tar.gz
+	mv easy-rsa-3.0.8 easy-rsa-master
 
 cfssl:
 	@if ! command -v cfssl &> /dev/null; then \


### PR DESCRIPTION
Move the archive location from Google Storage to Github Archive
This allows ```make cert``` to run on OS with LibreSSL instead of OpenSSL.

See 182 for details.

Tested on macOS Big Sur 11.2.3