### PR TITLE
Improve Makefile and README.md for new users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,20 +85,30 @@ lint:
 	$(INSTALL_LOCATION)/golangci-lint run --no-config --disable-all --enable=gofmt,golint,gosec --fix --verbose --timeout 3m
 
 ## --------------------------------------
+## Go
+## --------------------------------------
+
+.PHONY: mod-download
+mod-download:
+	go mod download
+
+## --------------------------------------
 ## Proto
 ## --------------------------------------
 
 .PHONY: gen
-gen: proto/agent/agent.pb.go konnectivity-client/proto/client/client.pb.go mock_gen
+gen: mod-download proto/agent/agent.pb.go konnectivity-client/proto/client/client.pb.go mock_gen
 
 konnectivity-client/proto/client/client.pb.go: konnectivity-client/proto/client/client.proto
+	mkdir -p ${GOPATH}/src
 	protoc -I . konnectivity-client/proto/client/client.proto --go_out=plugins=grpc:${GOPATH}/src
-	cat hack/go-license-header.txt konnectivity-client/proto/client/client.pb.go > konnectivity-client/proto/client/client.licensed.go
+	cat hack/go-license-header.txt ${GOPATH}/src/sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client/client.pb.go > konnectivity-client/proto/client/client.licensed.go
 	mv konnectivity-client/proto/client/client.licensed.go konnectivity-client/proto/client/client.pb.go
 
 proto/agent/agent.pb.go: proto/agent/agent.proto
+	mkdir -p ${GOPATH}/src
 	protoc -I . proto/agent/agent.proto --go_out=plugins=grpc:${GOPATH}/src
-	cat hack/go-license-header.txt proto/agent/agent.pb.go > proto/agent/agent.licensed.go
+	cat hack/go-license-header.txt ${GOPATH}/src/sigs.k8s.io/apiserver-network-proxy/proto/agent/agent.pb.go > proto/agent/agent.licensed.go
 	mv proto/agent/agent.licensed.go proto/agent/agent.pb.go
 
 ## --------------------------------------

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ For image builds these determine the location of your image.
 For GCE the registry should be gcr.io and PROJECT_ID should be the project you
 want to use the images in.
 
+### Mockgen
+
+The [```mockgen```](https://github.com/golang/mock) tool must be installed on your system.
+
 ### Protoc
 
 Proto definitions are compiled with `protoc`. Please ensure you have protoc installed ([Instructions](https://grpc.io/docs/protoc-installation/)) and the `proto-gen-go` library at the appropriate version.


### PR DESCRIPTION
The README.md lists mockgen as an explicit dependency
The Makefile has the following changes:

- Create $GOPATH/src if it doesn't exist. Without the dir, protoc fails
- ```make gen``` uses the protoc output .go files to build the licensed file. ```make clean``` deletes them from the repo and thus ```make gen``` never succeeded.
- Performs "go mod download" before generating files.
