### PR TITLE
Allow agent to set ALPN protocol

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -69,6 +69,7 @@ type GrpcProxyAgentOptions struct {
 	// Configuration for connecting to the proxy-server
 	proxyServerHost string
 	proxyServerPort int
+	alpnProtos      []string
 
 	// Ports for the health and admin server
 	healthServerPort int
@@ -104,6 +105,7 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.caCert, "ca-cert", o.caCert, "If non-empty the CAs we use to validate clients.")
 	flags.StringVar(&o.proxyServerHost, "proxy-server-host", o.proxyServerHost, "The hostname to use to connect to the proxy-server.")
 	flags.IntVar(&o.proxyServerPort, "proxy-server-port", o.proxyServerPort, "The port the proxy server is listening on.")
+	flags.StringSliceVar(&o.alpnProtos, "alpn-proto", o.alpnProtos, "Additional ALPN protocols to be presented when connecting to the server. Useful to distinguish between network proxy and apiserver connections that share the same destination address.")
 	flags.IntVar(&o.healthServerPort, "health-server-port", o.healthServerPort, "The port the health server is listening on.")
 	flags.IntVar(&o.adminServerPort, "admin-server-port", o.adminServerPort, "The port the admin server is listening on.")
 	flags.StringVar(&o.agentID, "agent-id", o.agentID, "The unique ID of this agent. Default to a generated uuid if not set.")
@@ -121,6 +123,7 @@ func (o *GrpcProxyAgentOptions) Print() {
 	klog.V(1).Infof("CACert set to %q.\n", o.caCert)
 	klog.V(1).Infof("ProxyServerHost set to %q.\n", o.proxyServerHost)
 	klog.V(1).Infof("ProxyServerPort set to %d.\n", o.proxyServerPort)
+	klog.V(1).Infof("ALPNProtos set to %+s.\n", o.alpnProtos)
 	klog.V(1).Infof("HealthServerPort set to %d.\n", o.healthServerPort)
 	klog.V(1).Infof("AdminServerPort set to %d.\n", o.adminServerPort)
 	klog.V(1).Infof("AgentID set to %s.\n", o.agentID)
@@ -255,7 +258,7 @@ func (a *Agent) run(o *GrpcProxyAgentOptions) error {
 func (a *Agent) runProxyConnection(o *GrpcProxyAgentOptions, stopCh <-chan struct{}) error {
 	var tlsConfig *tls.Config
 	var err error
-	if tlsConfig, err = util.GetClientTLSConfig(o.caCert, o.agentCert, o.agentKey, o.proxyServerHost); err != nil {
+	if tlsConfig, err = util.GetClientTLSConfig(o.caCert, o.agentCert, o.agentKey, o.proxyServerHost, o.alpnProtos); err != nil {
 		return err
 	}
 	dialOption := grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -358,9 +358,7 @@ func (c *Client) getUDSDialer(o *GrpcProxyClientOptions) (func(ctx context.Conte
 }
 
 func (c *Client) getMTLSDialer(o *GrpcProxyClientOptions) (func(ctx context.Context, network, addr string) (net.Conn, error), error) {
-	var tlsConfig *tls.Config
-	var err error
-	tlsConfig, err = util.GetClientTLSConfig(o.caCert, o.clientCert, o.clientKey, o.proxyHost)
+	tlsConfig, err := util.GetClientTLSConfig(o.caCert, o.clientCert, o.clientKey, o.proxyHost, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/certificates.go
+++ b/pkg/util/certificates.go
@@ -39,7 +39,7 @@ func getCACertPool(caFile string) (*x509.CertPool, error) {
 }
 
 // GetClientTLSConfig returns tlsConfig based on x509 certs
-func GetClientTLSConfig(caFile, certFile, keyFile, serverName string) (*tls.Config, error) {
+func GetClientTLSConfig(caFile, certFile, keyFile, serverName string, protos []string) (*tls.Config, error) {
 	certPool, err := getCACertPool(caFile)
 	if err != nil {
 		return nil, err
@@ -50,6 +50,7 @@ func GetClientTLSConfig(caFile, certFile, keyFile, serverName string) (*tls.Conf
 		tlsConfig := &tls.Config{
 			RootCAs:    certPool,
 			MinVersion: tls.VersionTLS12,
+			NextProtos: protos,
 		}
 		return tlsConfig, nil
 	}
@@ -64,6 +65,7 @@ func GetClientTLSConfig(caFile, certFile, keyFile, serverName string) (*tls.Conf
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      certPool,
 		MinVersion:   tls.VersionTLS12,
+		NextProtos:   protos,
 	}
 	return tlsConfig, nil
 }

--- a/pkg/util/certificates.go
+++ b/pkg/util/certificates.go
@@ -45,13 +45,15 @@ func GetClientTLSConfig(caFile, certFile, keyFile, serverName string, protos []s
 		return nil, err
 	}
 
+	tlsConfig := &tls.Config{
+		RootCAs:    certPool,
+		MinVersion: tls.VersionTLS12,
+	}
+	if len(protos) != 0 {
+		tlsConfig.NextProtos = protos
+	}
 	if certFile == "" && keyFile == "" {
 		// return TLS config based on CA only
-		tlsConfig := &tls.Config{
-			RootCAs:    certPool,
-			MinVersion: tls.VersionTLS12,
-			NextProtos: protos,
-		}
 		return tlsConfig, nil
 	}
 
@@ -60,12 +62,7 @@ func GetClientTLSConfig(caFile, certFile, keyFile, serverName string, protos []s
 		return nil, fmt.Errorf("failed to load X509 key pair %s and %s: %v", certFile, keyFile, err)
 	}
 
-	tlsConfig := &tls.Config{
-		ServerName:   serverName,
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      certPool,
-		MinVersion:   tls.VersionTLS12,
-		NextProtos:   protos,
-	}
+	tlsConfig.ServerName = serverName
+	tlsConfig.Certificates = []tls.Certificate{cert}
 	return tlsConfig, nil
 }

--- a/tests/custom_alpn_test.go
+++ b/tests/custom_alpn_test.go
@@ -1,0 +1,66 @@
+package tests
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
+)
+
+func TestCustomALPN(t *testing.T) {
+	const proto = "test-proto"
+	protoUsed := int32(0)
+
+	svr := httptest.NewUnstartedServer(http.DefaultServeMux)
+	svr.TLS = &tls.Config{NextProtos: []string{proto}, MinVersion: tls.VersionTLS13}
+	svr.Config.TLSNextProto = map[string]func(*http.Server, *tls.Conn, http.Handler){
+		proto: func(svr *http.Server, conn *tls.Conn, handle http.Handler) {
+			atomic.AddInt32(&protoUsed, 1)
+		},
+	}
+	svr.StartTLS()
+
+	ca, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ca.Close()
+	defer os.Remove(ca.Name())
+
+	err = pem.Encode(ca, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: svr.TLS.Certificates[0].Certificate[0],
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ca.Close()
+
+	tlsConfig, err := util.GetClientTLSConfig(ca.Name(), "", "", "", []string{proto})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addr := strings.TrimPrefix(svr.URL, "https://")
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	grpcClient := client.NewProxyServiceClient(conn)
+
+	grpcClient.Proxy(context.Background())
+	if atomic.LoadInt32(&protoUsed) != 1 {
+		t.Error("expected custom ALPN protocol to have been used")
+	}
+}


### PR DESCRIPTION
In some cases it is preferable to use a common network path i.e. load balancer rule to expose both proxy server and kube-apiserver.

It is currently possible to do so by managing two separate DNS records - one for apiserver, one for proxy server - and routing connections between services using a proxy that supports SNI-based "vhost-style" routing. This works well unless something obstructs connections to the (new) proxy hostname.

When agent nodes and apiserver run in separate networks, traffic from nodes to apiserver/proxy server might traverse a firewall. In such cases it's common to use a FQDN rule to allow agent nodes to access apiserver. But most firewalls implement FQDN rules using SNI. So without changes to firewall configurations, proxy agent->server connections using the new hostname will be blocked even if they resolve back to the same address. For managed k8s offerings, it might not be feasible to update any firewalls to allow access, so another option would be preferable.

The only other approach I can think of that doesn't involve reverse proxying all apiserver and proxy requests is to use a custom ALPN protocol. The implementation is simple: expose the TLS config's `NextProtos` field as a CLI flag. Then TCP proxies/load balancers (Envoy included) can make routing decisions given only the TLS client hello while still using a single SNI hostname.