### PR TITLE
Represent connection state in a pod condition

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -139,7 +139,9 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.kubeconfigPath, "kubeconfig", o.kubeconfigPath, "Absolute path to the kubeconfig file. Only required when --update-pod-status is set.")
 	flags.Float32Var(&o.kubeconfigQPS, "kubeconfig-qps", o.kubeconfigQPS, "Maximum client QPS")
 	flags.IntVar(&o.kubeconfigBurst, "kubeconfig-burst", o.kubeconfigBurst, "Maximum client burst")
-	flags.BoolVar(&o.enablePodCondition, "enable-pod-condition", o.enablePodCondition, "When set, manage a condition to represent connection status in the pod specified by POD_NAME and POD_NAMESPACE")
+	flags.BoolVar(&o.enablePodCondition, "enable-pod-condition", o.enablePodCondition, "When set, manage a condition to represent connection status in the pod specified by --pod-name and --pod-namespace ")
+	flags.StringVar(&o.podName, "pod-name", o.podName, "Name of the pod containing this process. Only required when --enable-pod-condition is set. Defaults to POD_NAME")
+	flags.StringVar(&o.podNamespace, "pod-namespace", o.podNamespace, "Namespace of the pod containing this process. Only required when --enable-pod-condition is set. Defaults to POD_NAMESPACE")
 	return flags
 }
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -210,6 +210,12 @@ func (o *GrpcProxyAgentOptions) Validate() error {
 			return fmt.Errorf("error checking service account token path %s, got %v", o.serviceAccountTokenPath, err)
 		}
 	}
+	if o.enablePodCondition && o.podName == "" {
+		return fmt.Errorf("pod name must be provided when pod condition is enabled")
+	}
+	if o.enablePodCondition && o.podNamespace == "" {
+		return fmt.Errorf("pod namespace must be provided when pod condition is enabled")
+	}
 	if err := validateAgentIdentifiers(o.agentIdentifiers); err != nil {
 		return fmt.Errorf("agent address is invalid: %v", err)
 	}

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -32,10 +32,10 @@ import (
 )
 
 const (
-	connectedPodConditionType      = "k8s.io/apiserver-network-proxy-connected"
-	connectedPodConditionReason    = "Connected"
-	disconnectedPodConditionReason = "Disconnected"
-	partitionPodConditionReason    = "Partition"
+	connectedPodConditionType            = "k8s.io/apiserver-network-proxy-connected"
+	connectedPodConditionReason          = "Connected"
+	partiallyConnectedPodConditionReason = "PartiallyConnected"
+	disconnectedPodConditionReason       = "Disconnected"
 )
 
 // ClientSet consists of clients connected to each instance of an HA proxy server.
@@ -296,7 +296,7 @@ func getPodCondition(current, desired int) *corev1.PodCondition {
 
 	if current < desired {
 		condition.Status = corev1.ConditionFalse
-		condition.Reason = partitionPodConditionReason
+		condition.Reason = partiallyConnectedPodConditionReason
 		condition.Message = fmt.Sprintf("connected to %d of %d servers", current, desired)
 		return condition
 	}

--- a/pkg/agent/clientset_test.go
+++ b/pkg/agent/clientset_test.go
@@ -1,0 +1,222 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var syncPodStatusTable = []struct {
+	Name            string
+	ExpectCondition bool
+	MutateClientSet func(*ClientSet)
+}{
+	{
+		Name:            "happy-path",
+		ExpectCondition: true,
+	},
+	{
+		Name:            "missing-kubeconfig",
+		ExpectCondition: false,
+		MutateClientSet: func(cs *ClientSet) {
+			cs.k8sClient = nil
+		},
+	},
+	{
+		Name:            "disabled",
+		ExpectCondition: false,
+		MutateClientSet: func(cs *ClientSet) {
+			cs.enablePodCondition = false
+		},
+	},
+	{
+		Name:            "missing-pod-name",
+		ExpectCondition: false,
+		MutateClientSet: func(cs *ClientSet) {
+			cs.podName = ""
+		},
+	},
+	{
+		Name:            "missing-pod-namespace",
+		ExpectCondition: false,
+		MutateClientSet: func(cs *ClientSet) {
+			cs.podNamespace = ""
+		},
+	},
+}
+
+func TestClientSetSyncPodStatus(t *testing.T) {
+	for _, tc := range syncPodStatusTable {
+		t.Run(tc.Name, func(t *testing.T) {
+			k8sClient := fake.NewSimpleClientset()
+
+			pod := &corev1.Pod{}
+			pod.Name = "test-pod"
+			pod.Namespace = "default"
+			pod.Status.Conditions = []corev1.PodCondition{{
+				Type: "AnotherType",
+			}}
+			_, err := k8sClient.CoreV1().Pods(pod.Namespace).Create(pod)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			cs := &ClientSet{
+				k8sClient:          k8sClient,
+				enablePodCondition: true,
+				podNamespace:       pod.Namespace,
+				podName:            pod.Name,
+			}
+			if tc.MutateClientSet != nil {
+				tc.MutateClientSet(cs)
+			}
+			cs.syncPodStatus()
+
+			actual, err := k8sClient.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected := len(pod.Status.Conditions)
+			if tc.ExpectCondition {
+				expected++
+			}
+			if l := len(actual.Status.Conditions); l != expected {
+				t.Fatalf("expected %d conditions, got %d", expected, l)
+			}
+			firstUpdateVersion := actual.ResourceVersion
+
+			cs.syncPodStatus()
+			actual, err = k8sClient.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if actual.ResourceVersion != firstUpdateVersion {
+				t.Fatal("expected syncPodStatus to be idempotent")
+			}
+		})
+	}
+}
+
+func TestClientSetAppendPodCondition(t *testing.T) {
+	cs := &ClientSet{}
+	initialPod := &corev1.Pod{}
+	condition := &corev1.PodCondition{Type: "test"}
+
+	var pod *corev1.Pod
+	assert := func() {
+		if initialPod == pod {
+			t.Error("expected a copy of the pod to be returned")
+		}
+		if l := len(pod.Status.Conditions); l != 1 {
+			t.Fatalf("expected one condition, got %d", l)
+		}
+		if !reflect.DeepEqual(&pod.Status.Conditions[0], condition) {
+			t.Errorf("expected condition to be in sync, got: %+v", pod.Status.Conditions[0])
+		}
+	}
+
+	t.Run("insert", func(t *testing.T) {
+		pod = cs.appendPodCondition(initialPod, condition)
+		assert()
+	})
+
+	t.Run("noop", func(t *testing.T) {
+		if cs.appendPodCondition(pod, condition) != nil {
+			t.Error("expected nil when condition is in sync")
+		}
+	})
+
+	t.Run("update-status", func(t *testing.T) {
+		condition.Status = "test-status"
+		pod = cs.appendPodCondition(pod, condition)
+		assert()
+	})
+
+	t.Run("update-reason", func(t *testing.T) {
+		condition.Reason = "test-reason"
+		pod = cs.appendPodCondition(pod, condition)
+		assert()
+	})
+
+	t.Run("update-message", func(t *testing.T) {
+		condition.Message = "test-reason"
+		pod = cs.appendPodCondition(pod, condition)
+		assert()
+	})
+}
+
+var getPodConditionTests = []struct {
+	Name    string
+	Current int
+	Desired int
+	Status  corev1.ConditionStatus
+	Reason  string
+}{
+	{
+		Name:    "zeros",
+		Current: 0,
+		Desired: 0,
+		Status:  corev1.ConditionFalse,
+		Reason:  disconnectedPodConditionReason,
+	},
+	{
+		Name:    "connected",
+		Current: 1,
+		Desired: 1,
+		Status:  corev1.ConditionTrue,
+		Reason:  connectedPodConditionReason,
+	},
+	{
+		Name:    "disconnected",
+		Current: 0,
+		Desired: 1,
+		Status:  corev1.ConditionFalse,
+		Reason:  disconnectedPodConditionReason,
+	},
+	{
+		Name:    "ha-connected",
+		Current: 3,
+		Desired: 3,
+		Status:  corev1.ConditionTrue,
+		Reason:  connectedPodConditionReason,
+	},
+	{
+		Name:    "ha-partition",
+		Current: 2,
+		Desired: 3,
+		Status:  corev1.ConditionFalse,
+		Reason:  partitionPodConditionReason,
+	},
+	{
+		Name:    "ha-disconnected",
+		Current: 0,
+		Desired: 3,
+		Status:  corev1.ConditionFalse,
+		Reason:  disconnectedPodConditionReason,
+	},
+}
+
+func TestGetPodCondition(t *testing.T) {
+	for _, tc := range getPodConditionTests {
+		t.Run(tc.Name, func(t *testing.T) {
+			condition := getPodCondition(tc.Current, tc.Desired)
+
+			zeroTime := time.Time{}
+			if condition.LastTransitionTime.Time == zeroTime {
+				t.Errorf("expected last transition time to be set")
+			}
+			condition.LastTransitionTime = metav1.Time{}
+
+			if condition.Status != tc.Status {
+				t.Errorf("got status %s, expected %s", condition.Status, tc.Status)
+			}
+			if condition.Reason != tc.Reason {
+				t.Errorf("got reason %s, expected %s", condition.Reason, tc.Reason)
+			}
+		})
+	}
+}

--- a/pkg/agent/clientset_test.go
+++ b/pkg/agent/clientset_test.go
@@ -185,11 +185,11 @@ var getPodConditionTests = []struct {
 		Reason:  connectedPodConditionReason,
 	},
 	{
-		Name:    "ha-partition",
+		Name:    "ha-partial",
 		Current: 2,
 		Desired: 3,
 		Status:  corev1.ConditionFalse,
-		Reason:  partitionPodConditionReason,
+		Reason:  partiallyConnectedPodConditionReason,
 	},
 	{
 		Name:    "ha-disconnected",

--- a/tests/pod_condition_update_test.go
+++ b/tests/pod_condition_update_test.go
@@ -1,0 +1,90 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent"
+)
+
+func TestPodConditionUpdate(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	pod := &corev1.Pod{}
+	pod.Name = "test-pod"
+	pod.Namespace = "default"
+	k8sClient := fake.NewSimpleClientset()
+	pod, err := k8sClient.CoreV1().Pods(pod.Namespace).Create(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy, cleanups := setupHAProxyServer(t)
+	defer func() {
+		for _, cleanup := range cleanups {
+			cleanup()
+		}
+	}()
+
+	lb := tcpLB{
+		backends: []string{
+			proxy[0].agent,
+			proxy[1].agent,
+			proxy[2].agent,
+		},
+		t: t,
+	}
+	lbAddr := lb.serve(stopCh)
+
+	csc := agent.ClientSetConfig{
+		Address:            lbAddr,
+		AgentID:            uuid.New().String(),
+		SyncInterval:       50 * time.Millisecond,
+		ProbeInterval:      50 * time.Millisecond,
+		DialOptions:        []grpc.DialOption{grpc.WithInsecure()},
+		EnablePodCondition: true,
+		PodNamespace:       pod.Namespace,
+		PodName:            pod.Name,
+	}
+	clientset := csc.NewAgentClientSet(stopCh, k8sClient)
+	clientset.Serve()
+
+	waitForTransition := func(target corev1.ConditionStatus, reason string) {
+		t.Helper()
+		for i := 0; i < 100; i++ {
+			time.Sleep(time.Millisecond * 25)
+			pod, err = k8sClient.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == "k8s.io/apiserver-network-proxy-connected" &&
+					cond.Status == target && cond.Reason == reason {
+					return
+				}
+			}
+		}
+		t.Fatalf("timeout while waiting for transition to state %s", target)
+	}
+
+	// Connected to all servers
+	waitForTransition(corev1.ConditionTrue, "Connected")
+
+	// Connected to 2 servers
+	lb.removeBackend(proxy[0].agent)
+	cleanups[0]()
+	waitForTransition(corev1.ConditionFalse, "Partition")
+
+	// Connected to 0 servers
+	lb.removeBackend(proxy[1].agent)
+	cleanups[1]()
+	lb.removeBackend(proxy[2].agent)
+	cleanups[2]()
+	waitForTransition(corev1.ConditionFalse, "Disconnected")
+}

--- a/tests/pod_condition_update_test.go
+++ b/tests/pod_condition_update_test.go
@@ -79,7 +79,7 @@ func TestPodConditionUpdate(t *testing.T) {
 	// Connected to 2 servers
 	lb.removeBackend(proxy[0].agent)
 	cleanups[0]()
-	waitForTransition(corev1.ConditionFalse, "Partition")
+	waitForTransition(corev1.ConditionFalse, "PartiallyConnected")
 
 	// Connected to 0 servers
 	lb.removeBackend(proxy[1].agent)

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -366,7 +366,7 @@ func runAgentWithID(agentID, addr string, stopCh <-chan struct{}) *agent.ClientS
 		ProbeInterval: 100 * time.Millisecond,
 		DialOptions:   []grpc.DialOption{grpc.WithInsecure()},
 	}
-	client := cc.NewAgentClientSet(stopCh)
+	client := cc.NewAgentClientSet(stopCh, nil)
 	client.Serve()
 	return client
 }


### PR DESCRIPTION
Resolves #196 

Provide signal to users and other controllers by managing a pod condition that contains the current server connection state.