### PR TITLE
Trivial: make agent log level more consistent with server.

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -455,7 +455,7 @@ func (a *Client) remoteToProxy(connID int64, ctx *connContext) {
 
 	for {
 		n, err := ctx.conn.Read(buf[:])
-		klog.V(4).InfoS("received data from remote", "bytes", n, "connID", connID)
+		klog.V(5).InfoS("received data from remote", "bytes", n, "connID", connID)
 
 		if err == io.EOF {
 			klog.V(2).Infoln("connection EOF")


### PR DESCRIPTION
Log network bytes detail at level 5, not 4. The default level is 4, and this log can be very noisy.