### PR TITLE
Always remove client when Serve() returns

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -243,7 +243,6 @@ func (a *Client) Send(pkt *client.Packet) error {
 	err := a.stream.Send(pkt)
 	if err != nil && err != io.EOF {
 		metrics.Metrics.ObserveFailure(metrics.DirectionToServer)
-		a.cs.RemoveClient(a.serverID)
 	}
 	return err
 }
@@ -255,7 +254,6 @@ func (a *Client) Recv() (*client.Packet, error) {
 	pkt, err := a.stream.Recv()
 	if err != nil && err != io.EOF {
 		metrics.Metrics.ObserveFailure(metrics.DirectionFromServer)
-		a.cs.RemoveClient(a.serverID)
 	}
 	return pkt, err
 }
@@ -314,6 +312,7 @@ func (a *Client) initializeAuthContext(ctx context.Context) (context.Context, er
 // The requests include things like opening a connection to a server,
 // streaming data and close the connection.
 func (a *Client) Serve() {
+	defer a.cs.RemoveClient(a.serverID)
 	defer func() {
 		// close all of conns with remote when Client exits
 		for _, connCtx := range a.connManager.List() {

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -243,6 +243,7 @@ func (a *Client) Send(pkt *client.Packet) error {
 	err := a.stream.Send(pkt)
 	if err != nil && err != io.EOF {
 		metrics.Metrics.ObserveFailure(metrics.DirectionToServer)
+		a.cs.RemoveClient(a.serverID)
 	}
 	return err
 }

--- a/tests/reconnect_test.go
+++ b/tests/reconnect_test.go
@@ -1,0 +1,66 @@
+package tests
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
+	agentproto "sigs.k8s.io/apiserver-network-proxy/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/header"
+)
+
+func TestClientReconnects(t *testing.T) {
+	connections := make(chan struct{})
+	s := &testAgentServerImpl{
+		onConnect: func(stream agent.AgentService_ConnectServer) error {
+			stream.SetHeader(metadata.New(map[string]string{
+				header.ServerID:    uuid.Must(uuid.NewRandom()).String(),
+				header.ServerCount: "1",
+			}))
+			connections <- struct{}{}
+			return nil
+		},
+	}
+
+	svr := grpc.NewServer()
+	agentproto.RegisterAgentServiceServer(svr, s)
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		svr.Serve(lis)
+	}()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	runAgentWithID("test-id", lis.Addr().String(), stopCh)
+
+	<-connections
+	svr.Stop()
+
+	lis2, err := net.Listen("tcp", lis.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svr2 := grpc.NewServer()
+	agentproto.RegisterAgentServiceServer(svr2, s)
+	go func() {
+		if err := svr2.Serve(lis2); err != nil {
+			panic(err)
+		}
+	}()
+
+	<-connections
+}
+
+type testAgentServerImpl struct {
+	onConnect func(agent.AgentService_ConnectServer) error
+}
+
+func (t *testAgentServerImpl) Connect(svr agent.AgentService_ConnectServer) error {
+	return t.onConnect(svr)
+}


### PR DESCRIPTION
Currently a client will be removed from the clientset when sending/receiving over it returns a non-EOF error, or when the probe observes `conn.GetState() != connectivity.Ready`. On EOF, the `Serve` loop will return without removing the client, but the probe will typically fail soon after so it gets cleaned up eventually.

But the client will never be cleaned up in cases where the probe doesn't fail. And since `Serve` is no longer running the client will count against the number of expected clients without actually being able to proxy connections. This occurs any time a connection is broken and reestablished by the underlying grpc client before the next probe.

I personally find the way connections are removed from the clientset confusing and error prone, so I'm proposing we defer a call to `RemoveClient` at the beginning of `Serve` and remove the (now unnecessary) existing calls in `Recv`/`Send`.