### PR TITLE
replace 127.0.0.1 by PROXY_SERVER_IP in agent and server-proxy's certs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ TAG ?= $(shell git rev-parse HEAD)
 
 DOCKER_CMD ?= docker
 DOCKER_CLI_EXPERIMENTAL ?= enabled
-
+PROXY_SERVER_IP ?= 127.0.0.1
 ## --------------------------------------
 ## Testing
 ## --------------------------------------
@@ -155,8 +155,8 @@ certs: easy-rsa-master cfssl cfssljson
 	# create the agent <-> server-proxy connection certs
 	cd easy-rsa-master/agent; \
 	./easyrsa init-pki; \
-	./easyrsa --batch "--req-cn=127.0.0.1@$(date +%s)" build-ca nopass; \
-	./easyrsa --subject-alt-name="DNS:kubernetes,DNS:localhost,IP:127.0.0.1" build-server-full "proxy-master" nopass; \
+	./easyrsa --batch "--req-cn=$(PROXY_SERVER_IP)@$(date +%s)" build-ca nopass; \
+	./easyrsa --subject-alt-name="DNS:kubernetes,DNS:localhost,IP:$(PROXY_SERVER_IP)" build-server-full "proxy-master" nopass; \
 	./easyrsa build-client-full proxy-agent nopass; \
 	echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","agent auth"]}}}' > "ca-config.json"; \
 	echo '{"CN":"proxy","names":[{"O":"system:nodes"}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=pki/ca.crt -ca-key=pki/private/ca.key -config=ca-config.json - | cfssljson -bare proxy


### PR DESCRIPTION
In some scenarios,  proxy server and proxy-agent are not installed in the same host. So the IP of proxy-server in certs is not 127.0.0.1. We can set a variable named "PROXY_SERVER_IP" to define the ip. And when "PROXY_SERVER_IP" is not set, its default value is 127.0.0.1