### PR TITLE
Clean up client testing.

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -427,6 +427,7 @@ func (a *Client) Serve() {
 			if ok {
 				ctx.cleanup()
 			} else {
+				klog.V(4).InfoS("Failed to find connection context for close", "connectionID", connID)
 				resp := &client.Packet{
 					Type:    client.PacketType_CLOSE_RSP,
 					Payload: &client.Packet_CloseResponse{CloseResponse: &client.CloseResponse{}},
@@ -455,7 +456,7 @@ func (a *Client) remoteToProxy(connID int64, ctx *connContext) {
 
 	for {
 		n, err := ctx.conn.Read(buf[:])
-		klog.V(5).InfoS("received data from remote", "bytes", n, "connID", connID)
+		klog.V(5).InfoS("received data from remote", "bytes", n, "connectionID", connID)
 
 		if err == io.EOF {
 			klog.V(2).Infoln("connection EOF")
@@ -484,13 +485,14 @@ func (a *Client) proxyToRemote(connID int64, ctx *connContext) {
 		for {
 			n, err := ctx.conn.Write(d[pos:])
 			if err == nil {
-				klog.V(4).InfoS("write to remote", "connID", connID, "lastData", n)
+				klog.V(4).InfoS("write to remote", "connectionID", connID, "lastData", n)
 				break
 			} else if n > 0 {
-				klog.ErrorS(err, "write to remote with failure", "connID", connID, "lastData", n)
+				// https://golang.org/pkg/io/#Writer specifies return non nil error if n < len(d)
+				klog.ErrorS(err, "write to remote with failure", "connectionID", connID, "lastData", n)
 				pos += n
 			} else {
-				klog.ErrorS(err, "conn write failure")
+				klog.ErrorS(err, "conn write failure", "connectionID", connID)
 				return
 			}
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -693,7 +693,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 			klog.V(5).InfoS("Received data from agent", "bytes", len(resp.Data), "agentID", agentID, "connectionID", resp.ConnectID)
 			frontend, err := s.getFrontend(agentID, resp.ConnectID)
 			if err != nil {
-				klog.ErrorS(err, "could not get frontent client")
+				klog.ErrorS(err, "could not get frontend client", "connectionID", resp.ConnectID)
 				break
 			}
 			if err := frontend.send(pkt); err != nil {
@@ -707,14 +707,14 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 			klog.V(5).InfoS("Received CLOSE_RSP", "connectionID", resp.ConnectID)
 			frontend, err := s.getFrontend(agentID, resp.ConnectID)
 			if err != nil {
-				klog.ErrorS(err, "could not get frontent client")
+				klog.ErrorS(err, "could not get frontend client", "connectionID", resp.ConnectID)
 				break
 			}
 			if err := frontend.send(pkt); err != nil {
 				// Normal when frontend closes it.
-				klog.ErrorS(err, "CLOSE_RSP send to client stream error")
+				klog.ErrorS(err, "CLOSE_RSP send to client stream error", "connectionID", resp.ConnectID)
 			} else {
-				klog.V(5).Infoln("CLOSE_RSP sent to frontend")
+				klog.V(5).Infoln("CLOSE_RSP sent to frontend", "connectionID", resp.ConnectID)
 			}
 			s.removeFrontend(agentID, resp.ConnectID)
 			klog.V(5).InfoS("Close streaming", "agentID", agentID, "connectionID", resp.ConnectID)

--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -113,7 +113,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err = backend.Send(packet); err != nil {
-			klog.V(2).InfoS("failed to send close request packet", "host", r.Host, "agentID", connection.agentID, "connID", connection.connectID)
+			klog.V(2).InfoS("failed to send close request packet", "host", r.Host, "agentID", connection.agentID, "connectionID", connection.connectID)
 		}
 		conn.Close()
 	}()


### PR DESCRIPTION
pprof shows a leak during testing with built in client.
However the leak seems to be caused by a failure to call
CloseIdleConnections.
Also made sure we sent close message in client at the correct time.
Enhanced client to support parallel requests.
Added connectionId to a few close cases.
Standardized on the "connectionID" label in log messages.