### PR TITLE
Prevent panic if DialRsp is returned multiple times

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -93,6 +93,11 @@ func CreateSingleUseGrpcTunnel(address string, opts ...grpc.DialOption) (Tunnel,
 
 func (t *grpcTunnel) serve(c clientConn) {
 	defer c.Close()
+	defer func() {
+		if err := recover(); err != nil {
+			klog.V(1).InfoS("error in konnectivity serve", "err", err)
+		}
+	}()
 
 	for {
 		pkt, err := t.stream.Recv()


### PR DESCRIPTION
Manually verified by forcing the proxy server to send two DIAL_RSP to ensure that the panic is resolved.

We shouldn't ever reach this case unless multiple DIAL_REQ are sent with the same randomID