### PR TITLE
Added histogram metric for send to frontend.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,25 +138,25 @@ cfssljson:
 certs: export PATH := $(shell pwd):$(PATH)
 certs: easy-rsa-master cfssl cfssljson
 	# set up easy-rsa
-	cp -rf easy-rsa-master/easyrsa3 easy-rsa-master/master
+	cp -rf easy-rsa-master/easyrsa3 easy-rsa-master/frontend
 	cp -rf easy-rsa-master/easyrsa3 easy-rsa-master/agent
 	# create the client <-> server-proxy connection certs
-	cd easy-rsa-master/master; \
+	cd easy-rsa-master/frontend; \
 	./easyrsa init-pki; \
 	./easyrsa --batch "--req-cn=127.0.0.1@$(date +%s)" build-ca nopass; \
-	./easyrsa --subject-alt-name="DNS:kubernetes,DNS:localhost,IP:127.0.0.1" build-server-full "proxy-master" nopass; \
+	./easyrsa --subject-alt-name="DNS:kubernetes,DNS:localhost,IP:127.0.0.1" build-server-full "proxy-frontend" nopass; \
 	./easyrsa build-client-full proxy-client nopass; \
 	echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","client auth"]}}}' > "ca-config.json"; \
 	echo '{"CN":"proxy","names":[{"O":"system:nodes"}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=pki/ca.crt -ca-key=pki/private/ca.key -config=ca-config.json - | cfssljson -bare proxy
-	mkdir -p certs/master
-	cp -r easy-rsa-master/master/pki/private certs/master
-	cp -r easy-rsa-master/master/pki/issued certs/master
-	cp easy-rsa-master/master/pki/ca.crt certs/master/issued
+	mkdir -p certs/frontend
+	cp -r easy-rsa-master/frontend/pki/private certs/frontend
+	cp -r easy-rsa-master/frontend/pki/issued certs/frontend
+	cp easy-rsa-master/frontend/pki/ca.crt certs/frontend/issued
 	# create the agent <-> server-proxy connection certs
 	cd easy-rsa-master/agent; \
 	./easyrsa init-pki; \
 	./easyrsa --batch "--req-cn=$(PROXY_SERVER_IP)@$(date +%s)" build-ca nopass; \
-	./easyrsa --subject-alt-name="DNS:kubernetes,DNS:localhost,IP:$(PROXY_SERVER_IP)" build-server-full "proxy-master" nopass; \
+	./easyrsa --subject-alt-name="DNS:kubernetes,DNS:localhost,IP:$(PROXY_SERVER_IP)" build-server-full "proxy-frontend" nopass; \
 	./easyrsa build-client-full proxy-agent nopass; \
 	echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","agent auth"]}}}' > "ca-config.json"; \
 	echo '{"CN":"proxy","names":[{"O":"system:nodes"}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=pki/ca.crt -ca-key=pki/private/ca.key -config=ca-config.json - | cfssljson -bare proxy

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ requests on the other.
 ### GRPC Client using mTLS Proxy with dial back Agent
 
 ```
-client =HTTP over GRPC=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> http-test-server(:8000)
-  |                                                    ^
-  |                          Tunnel                    |
-  +----------------------------------------------------+
+Frontend client =HTTP over GRPC=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> http-test-server(:8000)
+  |                                                               ^
+  |                               Tunnel                          |
+  +---------------------------------------------------------------+
 ```
 
 - Start Simple test HTTP Server (Sample destination)
@@ -75,7 +75,7 @@ client =HTTP over GRPC=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> http-test-s
 
 - Start proxy service
 ```console
-./bin/proxy-server --server-ca-cert=certs/master/issued/ca.crt --server-cert=certs/master/issued/proxy-master.crt --server-key=certs/master/private/proxy-master.key --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-master.crt --cluster-key=certs/agent/private/proxy-master.key
+./bin/proxy-server --server-ca-cert=certs/frontend/issued/ca.crt --server-cert=certs/frontend/issued/proxy-frontend.crt --server-key=certs/frontend/private/proxy-frontend.key --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-frontend.crt --cluster-key=certs/agent/private/proxy-frontend.key
 ```
 
 - Start agent service
@@ -85,16 +85,16 @@ client =HTTP over GRPC=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> http-test-s
 
 - Run client (mTLS enabled sample client)
 ```console
-./bin/proxy-test-client --ca-cert=certs/master/issued/ca.crt --client-cert=certs/master/issued/proxy-client.crt --client-key=certs/master/private/proxy-client.key
+./bin/proxy-test-client --ca-cert=certs/frontend/issued/ca.crt --client-cert=certs/frontend/issued/proxy-client.crt --client-key=certs/frontend/private/proxy-client.key
 ```
 
 ### GRPC+UDS Client using Proxy with dial back Agent
 
 ```
-client =HTTP over GRPC+UDS=> (/tmp/uds-proxy) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPServer(:8000)
-  |                                                    ^
-  |                          Tunnel                    |
-  +----------------------------------------------------+
+Frontend client =HTTP over GRPC+UDS=> (/tmp/uds-proxy) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPServer(:8000)
+  |                                                                            ^
+  |                                     Tunnel                                 |
+  +----------------------------------------------------------------------------+
 ```
 
 - Start Simple test HTTP Server (Sample destination)
@@ -104,7 +104,7 @@ client =HTTP over GRPC+UDS=> (/tmp/uds-proxy) proxy (:8091) <=GRPC= agent =HTTP=
 
 - Start proxy service
 ```console
-./bin/proxy-server --server-port=0 --uds-name=/tmp/uds-proxy --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-master.crt --cluster-key=certs/agent/private/proxy-master.key
+./bin/proxy-server --server-port=0 --uds-name=/tmp/uds-proxy --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-frontend.crt --cluster-key=certs/agent/private/proxy-frontend.key
 ```
 
 - Start agent service
@@ -121,10 +121,10 @@ client =HTTP over GRPC+UDS=> (/tmp/uds-proxy) proxy (:8091) <=GRPC= agent =HTTP=
 ### HTTP-Connect Client using mTLS Proxy with dial back Agent (Either curl OR test client)
 
 ```
-client =HTTP-CONNECT=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPServer(:8000)
-  |                                                    ^
-  |                          Tunnel                    |
-  +----------------------------------------------------+
+Frontend client =HTTP-CONNECT=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPServer(:8000)
+  |                                                             ^
+  |                              Tunnel                         |
+  +-------------------------------------------------------------+
 ```
 
 - Start SimpleHTTPServer (Sample destination)
@@ -134,7 +134,7 @@ client =HTTP-CONNECT=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPSer
 
 - Start proxy service
 ```console
-./bin/proxy-server --mode=http-connect --server-ca-cert=certs/master/issued/ca.crt --server-cert=certs/master/issued/proxy-master.crt --server-key=certs/master/private/proxy-master.key --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-master.crt --cluster-key=certs/agent/private/proxy-master.key
+./bin/proxy-server --mode=http-connect --server-ca-cert=certs/frontend/issued/ca.crt --server-cert=certs/frontend/issued/proxy-frontend.crt --server-key=certs/frontend/private/proxy-frontend.key --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-frontend.crt --cluster-key=certs/agent/private/proxy-frontend.key
 ```
 
 - Start agent service
@@ -144,12 +144,12 @@ client =HTTP-CONNECT=> (:8090) proxy (:8091) <=GRPC= agent =HTTP=> SimpleHTTPSer
 
 - Run client (mTLS & http-connect enabled sample client)
 ```console
-./bin/proxy-test-client --mode=http-connect  --proxy-host=127.0.0.1 --ca-cert=certs/master/issued/ca.crt --client-cert=certs/master/issued/proxy-client.crt --client-key=certs/master/private/proxy-client.key
+./bin/proxy-test-client --mode=http-connect  --proxy-host=127.0.0.1 --ca-cert=certs/frontend/issued/ca.crt --client-cert=certs/frontend/issued/proxy-client.crt --client-key=certs/frontend/private/proxy-client.key
 ```
 
 - Run curl client (curl using a mTLS http-connect proxy)
 ```console
-curl -v -p --proxy-key certs/master/private/proxy-client.key --proxy-cert certs/master/issued/proxy-client.crt --proxy-cacert certs/master/issued/ca.crt --proxy-cert-type PEM -x https://127.0.0.1:8090  http://localhost:8000```
+curl -v -p --proxy-key certs/frontend/private/proxy-client.key --proxy-cert certs/frontend/issued/proxy-client.crt --proxy-cacert certs/frontend/issued/ca.crt --proxy-cert-type PEM -x https://127.0.0.1:8090  http://localhost:8000```
 ```
 
 ### Running on kubernetes

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -50,4 +50,3 @@ func main() {
 		os.Exit(1)
 	}
 }
-

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -87,16 +87,16 @@ func (p *Proxy) run(o *options.ProxyRunOptions) error {
 		KubernetesClient:       k8sClient,
 		AuthenticationAudience: o.AuthenticationAudience,
 	}
-	klog.V(1).Infoln("Starting master server for client connections.")
+	klog.V(1).Infoln("Starting frontend server for client connections.")
 	ps, err := server.GenProxyStrategiesFromStr(o.ProxyStrategies)
 	if err != nil {
 		return err
 	}
 	server := server.NewProxyServer(o.ServerID, ps, int(o.ServerCount), authOpt)
 
-	masterStop, err := p.runMasterServer(ctx, o, server)
+	frontendStop, err := p.runFrontendServer(ctx, o, server)
 	if err != nil {
-		return fmt.Errorf("failed to run the master server: %v", err)
+		return fmt.Errorf("failed to run the frontend server: %v", err)
 	}
 
 	klog.V(1).Infoln("Starting agent server for tunnel connections.")
@@ -119,8 +119,8 @@ func (p *Proxy) run(o *options.ProxyRunOptions) error {
 	<-stopCh
 	klog.V(1).Infoln("Shutting down server.")
 
-	if masterStop != nil {
-		masterStop()
+	if frontendStop != nil {
+		frontendStop()
 	}
 
 	return nil
@@ -155,14 +155,14 @@ func getUDSListener(ctx context.Context, udsName string) (net.Listener, error) {
 	return lis, nil
 }
 
-func (p *Proxy) runMasterServer(ctx context.Context, o *options.ProxyRunOptions, server *server.ProxyServer) (StopFunc, error) {
+func (p *Proxy) runFrontendServer(ctx context.Context, o *options.ProxyRunOptions, server *server.ProxyServer) (StopFunc, error) {
 	if o.UdsName != "" {
-		return p.runUDSMasterServer(ctx, o, server)
+		return p.runUDSFrontendServer(ctx, o, server)
 	}
-	return p.runMTLSMasterServer(ctx, o, server)
+	return p.runMTLSFrontendServer(ctx, o, server)
 }
 
-func (p *Proxy) runUDSMasterServer(ctx context.Context, o *options.ProxyRunOptions, s *server.ProxyServer) (StopFunc, error) {
+func (p *Proxy) runUDSFrontendServer(ctx context.Context, o *options.ProxyRunOptions, s *server.ProxyServer) (StopFunc, error) {
 	if o.DeleteUDSFile {
 		if err := os.Remove(o.UdsName); err != nil && !os.IsNotExist(err) {
 			klog.ErrorS(err, "failed to delete file", "file", o.UdsName)
@@ -237,7 +237,7 @@ func (p *Proxy) getTLSConfig(caFile, certFile, keyFile string) (*tls.Config, err
 	return tlsConfig, nil
 }
 
-func (p *Proxy) runMTLSMasterServer(ctx context.Context, o *options.ProxyRunOptions, s *server.ProxyServer) (StopFunc, error) {
+func (p *Proxy) runMTLSFrontendServer(ctx context.Context, o *options.ProxyRunOptions, s *server.ProxyServer) (StopFunc, error) {
 	var stop StopFunc
 
 	var tlsConfig *tls.Config
@@ -277,7 +277,7 @@ func (p *Proxy) runMTLSMasterServer(ctx context.Context, o *options.ProxyRunOpti
 		go func() {
 			err := server.ListenAndServeTLS("", "") // empty files defaults to tlsConfig
 			if err != nil {
-				klog.ErrorS(err, "failed to listen on master port")
+				klog.ErrorS(err, "failed to listen on frontend port")
 			}
 		}()
 	}
@@ -371,4 +371,3 @@ func (p *Proxy) runHealthServer(o *options.ProxyRunOptions, server *server.Proxy
 
 	return nil
 }
-

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,4 +51,3 @@ func main() {
 		os.Exit(1)
 	}
 }
-

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -111,17 +111,17 @@ func (p *TestServer) run(o *TestServerRunOptions) error {
 	defer cancel()
 
 	klog.Info("Starting test http server for client requests.")
-	masterStop, err := p.runMasterServer(ctx, o)
+	testStop, err := p.runTestServer(ctx, o)
 	if err != nil {
-		return fmt.Errorf("failed to run the master server: %v", err)
+		return fmt.Errorf("failed to run the test server: %v", err)
 	}
 
 	stopCh := SetupSignalHandler()
 	<-stopCh
 	klog.Info("Shutting down server.")
 
-	if masterStop != nil {
-		masterStop()
+	if testStop != nil {
+		testStop()
 	}
 
 	return nil
@@ -187,7 +187,7 @@ func sleepReturnSuccess(w http.ResponseWriter, req *http.Request) {
 	returnSuccess(w, req)
 }
 
-func (p *TestServer) runMasterServer(ctx context.Context, o *TestServerRunOptions) (StopFunc, error) {
+func (p *TestServer) runTestServer(ctx context.Context, o *TestServerRunOptions) (StopFunc, error) {
 	muxHandler := http.NewServeMux()
 	muxHandler.HandleFunc("/success", returnSuccess)
 	muxHandler.HandleFunc("/sleep", sleepReturnSuccess)

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -32,7 +32,7 @@ CLUSTER_KEY=/etc/srv/kubernetes/pki/apiserver.key
 ```
 
 # Register SERVER_TOKEN in [static-token-file](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file)
-Append the output of the following line to the [static-token-file](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file) and restart **kube-apiserver** on the master
+Append the output of the following line to the [static-token-file](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#static-token-file) and restart **kube-apiserver** on the control plane.
 ```bash
 echo "${SERVER_TOKEN},system:konnectivity-server,uid:system:konnectivity-server"
 ```
@@ -46,7 +46,7 @@ K8S_API_PID=$(sudo crictl ps | grep kube-apiserver | awk '{ print $1; }')
 sudo crictl stop ${K8S_API_PID}
 ```
 
-# Save following config at /etc/srv/kubernetes/konnectivity-server/kubeconfig on master VM
+# Save following config at /etc/srv/kubernetes/konnectivity-server/kubeconfig on control plane VM
 ```bash
 SERVER_TOKEN=${SERVER_TOKEN} envsubst < examples/kubernetes/kubeconfig
 ```

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -25,6 +25,7 @@ const (
 	// NodeToMasterTraffic enables the traffic initiated in the agents side
 	// to flow to the server side e.g. Kubelet to KAS and pods to KAS traffic
 	// (KEP-2025).
+	// TODO (#issues/232) Determine how to safely fix the feature gate name.
 	NodeToMasterTraffic featuregate.Feature = "NodeToMasterTraffic"
 )
 

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -45,7 +45,7 @@ var (
 type ServerMetrics struct {
 	latencies   *prometheus.HistogramVec
 	connections *prometheus.GaugeVec
-	backend *prometheus.GaugeVec
+	backend     *prometheus.GaugeVec
 }
 
 // newServerMetrics create a new ServerMetrics, configured with default metric names.
@@ -80,14 +80,14 @@ func newServerMetrics() *ServerMetrics {
 		},
 		[]string{},
 	)
-	
+
 	prometheus.MustRegister(latencies)
 	prometheus.MustRegister(connections)
 	prometheus.MustRegister(backend)
 	return &ServerMetrics{
-		latencies: latencies,
+		latencies:   latencies,
 		connections: connections,
-		backend: backend,
+		backend:     backend,
 	}
 }
 


### PR DESCRIPTION
Extended range of standard metric down to nanoseconds.
Added histogram for write to frontend (KAS).
Improved Makefile to reflect server metrics dependency.
```
$ curl http://localhost:8095/metrics
...
# HELP konnectivity_network_proxy_server_frontend_write_duration_seconds Latency of write to the frontend in seconds
# TYPE konnectivity_network_proxy_server_frontend_write_duration_seconds histogram
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="1e-07"} 0
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="1e-06"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="1e-05"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.0001"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.005"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.025"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.1"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.5"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="2.5"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="12.5"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="+Inf"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_sum 3.9399999999999995e-07
konnectivity_network_proxy_server_frontend_write_duration_seconds_count 3
```