### PR TITLE
Add metrics for showing the number of backend agents connected to metric server

### DIFF
--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 	pkgagent "sigs.k8s.io/apiserver-network-proxy/pkg/agent"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
 	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 )
 
@@ -194,6 +195,7 @@ func (s *DefaultBackendStorage) AddBackend(identifier string, idType pkgagent.Id
 		s.backends[identifier] = append(s.backends[identifier], addedBackend)
 		return addedBackend
 	}
+	metrics.Metrics.BackendInc()
 	s.backends[identifier] = []*backend{addedBackend}
 	s.agentIDs = append(s.agentIDs, identifier)
 	return addedBackend
@@ -225,6 +227,7 @@ func (s *DefaultBackendStorage) RemoveBackend(identifier string, idType pkgagent
 	}
 	if len(s.backends[identifier]) == 0 {
 		delete(s.backends, identifier)
+		metrics.Metrics.BackendDec()
 		for i := range s.agentIDs {
 			if s.agentIDs[i] == identifier {
 				s.agentIDs[i] = s.agentIDs[len(s.agentIDs)-1]

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -195,8 +195,8 @@ func (s *DefaultBackendStorage) AddBackend(identifier string, idType pkgagent.Id
 		s.backends[identifier] = append(s.backends[identifier], addedBackend)
 		return addedBackend
 	}
-	metrics.Metrics.BackendInc()
 	s.backends[identifier] = []*backend{addedBackend}
+	metrics.Metrics.SetBackendCount(len(s.backends))
 	s.agentIDs = append(s.agentIDs, identifier)
 	return addedBackend
 }
@@ -227,7 +227,6 @@ func (s *DefaultBackendStorage) RemoveBackend(identifier string, idType pkgagent
 	}
 	if len(s.backends[identifier]) == 0 {
 		delete(s.backends, identifier)
-		metrics.Metrics.BackendDec()
 		for i := range s.agentIDs {
 			if s.agentIDs[i] == identifier {
 				s.agentIDs[i] = s.agentIDs[len(s.agentIDs)-1]
@@ -239,6 +238,7 @@ func (s *DefaultBackendStorage) RemoveBackend(identifier string, idType pkgagent
 	if !found {
 		klog.V(1).InfoS("Could not find connection matching identifier to remove", "connection", conn, "identifier", identifier)
 	}
+	metrics.Metrics.SetBackendCount(len(s.backends))
 }
 
 // NumBackends resturns the number of available backends

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -75,7 +75,8 @@ func newServerMetrics() *ServerMetrics {
 		prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
-			Name:      "Number of konnectivity agent connected to the proxy server",
+			Name:      "ready_backend_connections",
+			Help:      "Number of konnectivity agent connected to the proxy server",
 		},
 		[]string{},
 	)

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -112,5 +112,5 @@ func (a *ServerMetrics) ConnectionDec(serviceMethod string) {
 
 // SetBackendCount sets the number of backend connection.
 func (a *ServerMetrics) SetBackendCount(count int) {
-	a.backend.With().Set(count)
+	a.backend.With(prometheus.Labels{}).Set(float64(count))
 }

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -83,7 +83,11 @@ func newServerMetrics() *ServerMetrics {
 	prometheus.MustRegister(latencies)
 	prometheus.MustRegister(connections)
 	prometheus.MustRegister(backend)
-	return &ServerMetrics{latencies: latencies, connections: connections, backend: backend}
+	return &ServerMetrics{
+		latencies: latencies,
+		connections: connections,
+		backend: backend,
+	}
 }
 
 // Reset resets the metrics.
@@ -106,12 +110,7 @@ func (a *ServerMetrics) ConnectionDec(service_method string) {
 	a.connections.With(prometheus.Labels{"service_method": service_method}).Dec()
 }
 
-// BackendInc increments the number of backend connection.
-func (a *ServerMetrics) BackendInc() {
-	a.backend.With(prometheus.Labels{}).Inc()
-}
-
-// BackendDec decrements the number of backend connection.
-func (a *ServerMetrics) BackendDec() {
-	a.backend.With(prometheus.Labels{}).Dec()
+// SetBackendCount sets the number of backend connection.
+func (a *ServerMetrics) SetBackendCount(count int) {
+	a.backend.With().Set(count)
 }

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -45,6 +45,7 @@ var (
 type ServerMetrics struct {
 	latencies *prometheus.HistogramVec
 	connections *prometheus.GaugeVec
+	backend *prometheus.GaugeVec
 }
 
 // newServerMetrics create a new ServerMetrics, configured with default metric names.
@@ -70,10 +71,19 @@ func newServerMetrics() *ServerMetrics {
 			"service_method",
 		},
 	)
+	backend := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "Number of konnectivity agent connected to the proxy server",
+		},
+		[]string{},
+	)
 	
 	prometheus.MustRegister(latencies)
 	prometheus.MustRegister(connections)
-	return &ServerMetrics{latencies: latencies, connections: connections}
+	prometheus.MustRegister(backend)
+	return &ServerMetrics{latencies: latencies, connections: connections, backend: backend}
 }
 
 // Reset resets the metrics.
@@ -94,4 +104,14 @@ func (a *ServerMetrics) ConnectionInc(service_method string) {
 // ConnectionDec decrements a finished grpc client connection.
 func (a *ServerMetrics) ConnectionDec(service_method string) {
 	a.connections.With(prometheus.Labels{"service_method": service_method}).Dec()
+}
+
+// BackendInc increments the number of backend connection.
+func (a *ServerMetrics) BackendInc() {
+	a.backend.With(prometheus.Labels{}).Inc()
+}
+
+// BackendDec decrements the number of backend connection.
+func (a *ServerMetrics) BackendDec() {
+	a.backend.With(prometheus.Labels{}).Dec()
 }


### PR DESCRIPTION
Add a metric showing the number of backend agents conntected to the metric server. We will be able to verify whether the server is able to handling dial traffic.