### PR TITLE
Fixed readiness url path to be /readyz

### DIFF
--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -82,7 +82,9 @@ func (a *Agent) runHealthServer(o *options.GrpcProxyAgentOptions) error {
 	muxHandler := http.NewServeMux()
 	muxHandler.Handle("/metrics", promhttp.Handler())
 	muxHandler.HandleFunc("/healthz", livenessHandler)
+	// "/ready" is deprecated but being maintained for backward compatibility
 	muxHandler.HandleFunc("/ready", readinessHandler)
+	muxHandler.HandleFunc("/readyz", readinessHandler)
 	healthServer := &http.Server{
 		Addr:           fmt.Sprintf(":%d", o.HealthServerPort),
 		Handler:        muxHandler,

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -352,7 +352,9 @@ func (p *Proxy) runHealthServer(o *options.ProxyRunOptions, server *server.Proxy
 
 	muxHandler := http.NewServeMux()
 	muxHandler.HandleFunc("/healthz", livenessHandler)
+	// "/ready" is deprecated but being maintained for backward compatibility
 	muxHandler.HandleFunc("/ready", readinessHandler)
+	muxHandler.HandleFunc("/readyz", readinessHandler)
 	healthServer := &http.Server{
 		Addr:           fmt.Sprintf(":%d", o.HealthPort),
 		Handler:        muxHandler,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,3 +51,4 @@ func main() {
 		os.Exit(1)
 	}
 }
+


### PR DESCRIPTION
K8s specifies /readyz as the proper url path for the readiness check.
Added that path to the supported url pathes for the readiness check.
Keeping /ready for now for bacwkard compatability.
We are treating it as deprecated.