### PR TITLE
Added histogram metric for send to frontend.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ bin/proxy-test-client: konnectivity-client/proto/client/client.pb.go bin cmd/cli
 bin/http-test-server: bin cmd/test-server/main.go
 	GO111MODULE=on go build -o bin/http-test-server cmd/test-server/main.go
 
-bin/proxy-server: proto/agent/agent.pb.go konnectivity-client/proto/client/client.pb.go bin cmd/server/main.go
+bin/proxy-server: proto/agent/agent.pb.go konnectivity-client/proto/client/client.pb.go bin cmd/server/main.go pkg/server/server.go pkg/server/metrics/metrics.go
 	GO111MODULE=on go build -o bin/proxy-server cmd/server/main.go
 
 ## --------------------------------------

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -51,4 +51,3 @@ func main() {
 		os.Exit(1)
 	}
 }
-

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -58,6 +58,8 @@ const (
 )
 
 func (c *ProxyClientConnection) send(pkt *client.Packet) error {
+	start := time.Now()
+	defer metrics.Metrics.ObserveFrontendWriteLatency(time.Since(start))
 	if c.Mode == "grpc" {
 		stream := c.Grpc
 		return stream.Send(pkt)


### PR DESCRIPTION
Extended range of standard metric down to nanoseconds.
Added histogram for write to frontend (KAS).
Improved Makefile to reflect server metrics dependency.

```
$ curl http://localhost:8095/metrics
...
# HELP konnectivity_network_proxy_server_frontend_write_duration_seconds Latency of write to the frontend in seconds
# TYPE konnectivity_network_proxy_server_frontend_write_duration_seconds histogram
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="1e-07"} 0
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="1e-06"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="1e-05"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.0001"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.005"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.025"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.1"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="0.5"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="2.5"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="12.5"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_bucket{le="+Inf"} 3
konnectivity_network_proxy_server_frontend_write_duration_seconds_sum 3.9399999999999995e-07
konnectivity_network_proxy_server_frontend_write_duration_seconds_count 3
```