### PR TITLE
Add context to CreateSingleUseGrpcTunnel.

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -35,7 +35,7 @@ import (
 type Tunnel interface {
 	// Dial connects to the address on the named network, similar to
 	// what net.Dial does. The only supported protocol is tcp.
-	Dial(protocol, address string) (net.Conn, error)
+	DialContext(ctx context.Context, protocol, address string) (net.Conn, error)
 }
 
 type dialResult struct {
@@ -66,15 +66,15 @@ var _ clientConn = &grpc.ClientConn{}
 // gRPC based proxy service.
 // Currently, a single tunnel supports a single connection, and the tunnel is closed when the connection is terminated
 // The Dial() method of the returned tunnel should only be called once
-func CreateSingleUseGrpcTunnel(address string, opts ...grpc.DialOption) (Tunnel, error) {
-	c, err := grpc.Dial(address, opts...)
+func CreateSingleUseGrpcTunnel(ctx context.Context, address string, opts ...grpc.DialOption) (Tunnel, error) {
+	c, err := grpc.DialContext(ctx, address, opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	grpcClient := client.NewProxyServiceClient(c)
 
-	stream, err := grpcClient.Proxy(context.Background())
+	stream, err := grpcClient.Proxy(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (t *grpcTunnel) serve(c clientConn) {
 
 // Dial connects to the address on the named network, similar to
 // what net.Dial does. The only supported protocol is tcp.
-func (t *grpcTunnel) Dial(protocol, address string) (net.Conn, error) {
+func (t *grpcTunnel) DialContext(ctx context.Context, protocol, address string) (net.Conn, error) {
 	if protocol != "tcp" {
 		return nil, errors.New("protocol not supported")
 	}
@@ -224,7 +224,9 @@ func (t *grpcTunnel) Dial(protocol, address string) (net.Conn, error) {
 		t.conns[res.connid] = c
 		t.connsLock.Unlock()
 	case <-time.After(30 * time.Second):
-		return nil, errors.New("dial timeout")
+		return nil, errors.New("dial timeout, backstop")
+	case <-ctx.Done():
+		return nil, errors.New("dial timeout, context")
 	}
 
 	return c, nil

--- a/konnectivity-client/pkg/client/client_test.go
+++ b/konnectivity-client/pkg/client/client_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -28,6 +29,7 @@ import (
 )
 
 func TestDial(t *testing.T) {
+	ctx := context.Background()
 	s, ps := pipe()
 	ts := testServer(ps, 100)
 
@@ -43,7 +45,7 @@ func TestDial(t *testing.T) {
 	go tunnel.serve(&fakeConn{})
 	go ts.serve()
 
-	_, err := tunnel.Dial("tcp", "127.0.0.1:80")
+	_, err := tunnel.DialContext(ctx, "tcp", "127.0.0.1:80")
 	if err != nil {
 		t.Fatalf("expect nil; got %v", err)
 	}
@@ -58,6 +60,7 @@ func TestDial(t *testing.T) {
 }
 
 func TestData(t *testing.T) {
+	ctx := context.Background()
 	s, ps := pipe()
 	ts := testServer(ps, 100)
 
@@ -73,7 +76,7 @@ func TestData(t *testing.T) {
 	go tunnel.serve(&fakeConn{})
 	go ts.serve()
 
-	conn, err := tunnel.Dial("tcp", "127.0.0.1:80")
+	conn, err := tunnel.DialContext(ctx, "tcp", "127.0.0.1:80")
 	if err != nil {
 		t.Fatalf("expect nil; got %v", err)
 	}
@@ -115,6 +118,7 @@ func TestData(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
+	ctx := context.Background()
 	s, ps := pipe()
 	ts := testServer(ps, 100)
 
@@ -130,7 +134,7 @@ func TestClose(t *testing.T) {
 	go tunnel.serve(&fakeConn{})
 	go ts.serve()
 
-	conn, err := tunnel.Dial("tcp", "127.0.0.1:80")
+	conn, err := tunnel.DialContext(ctx, "tcp", "127.0.0.1:80")
 	if err != nil {
 		t.Fatalf("expect nil; got %v", err)
 	}

--- a/proto/agent/mocks/agent_mock.go
+++ b/proto/agent/mocks/agent_mock.go
@@ -21,37 +21,36 @@ package mock_agent
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	metadata "google.golang.org/grpc/metadata"
+	reflect "reflect"
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 )
 
-// MockAgentService_ConnectServer is a mock of AgentService_ConnectServer interface.
+// MockAgentService_ConnectServer is a mock of AgentService_ConnectServer interface
 type MockAgentService_ConnectServer struct {
 	ctrl     *gomock.Controller
 	recorder *MockAgentService_ConnectServerMockRecorder
 }
 
-// MockAgentService_ConnectServerMockRecorder is the mock recorder for MockAgentService_ConnectServer.
+// MockAgentService_ConnectServerMockRecorder is the mock recorder for MockAgentService_ConnectServer
 type MockAgentService_ConnectServerMockRecorder struct {
 	mock *MockAgentService_ConnectServer
 }
 
-// NewMockAgentService_ConnectServer creates a new mock instance.
+// NewMockAgentService_ConnectServer creates a new mock instance
 func NewMockAgentService_ConnectServer(ctrl *gomock.Controller) *MockAgentService_ConnectServer {
 	mock := &MockAgentService_ConnectServer{ctrl: ctrl}
 	mock.recorder = &MockAgentService_ConnectServerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockAgentService_ConnectServer) EXPECT() *MockAgentService_ConnectServerMockRecorder {
 	return m.recorder
 }
 
-// Context mocks base method.
+// Context mocks base method
 func (m *MockAgentService_ConnectServer) Context() context.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
@@ -59,13 +58,13 @@ func (m *MockAgentService_ConnectServer) Context() context.Context {
 	return ret0
 }
 
-// Context indicates an expected call of Context.
+// Context indicates an expected call of Context
 func (mr *MockAgentService_ConnectServerMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAgentService_ConnectServer)(nil).Context))
 }
 
-// Recv mocks base method.
+// Recv mocks base method
 func (m *MockAgentService_ConnectServer) Recv() (*client.Packet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Recv")
@@ -74,13 +73,13 @@ func (m *MockAgentService_ConnectServer) Recv() (*client.Packet, error) {
 	return ret0, ret1
 }
 
-// Recv indicates an expected call of Recv.
+// Recv indicates an expected call of Recv
 func (mr *MockAgentService_ConnectServerMockRecorder) Recv() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recv", reflect.TypeOf((*MockAgentService_ConnectServer)(nil).Recv))
 }
 
-// RecvMsg mocks base method.
+// RecvMsg mocks base method
 func (m *MockAgentService_ConnectServer) RecvMsg(arg0 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecvMsg", arg0)
@@ -88,13 +87,13 @@ func (m *MockAgentService_ConnectServer) RecvMsg(arg0 interface{}) error {
 	return ret0
 }
 
-// RecvMsg indicates an expected call of RecvMsg.
+// RecvMsg indicates an expected call of RecvMsg
 func (mr *MockAgentService_ConnectServerMockRecorder) RecvMsg(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecvMsg", reflect.TypeOf((*MockAgentService_ConnectServer)(nil).RecvMsg), arg0)
 }
 
-// Send mocks base method.
+// Send mocks base method
 func (m *MockAgentService_ConnectServer) Send(arg0 *client.Packet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Send", arg0)
@@ -102,13 +101,13 @@ func (m *MockAgentService_ConnectServer) Send(arg0 *client.Packet) error {
 	return ret0
 }
 
-// Send indicates an expected call of Send.
+// Send indicates an expected call of Send
 func (mr *MockAgentService_ConnectServerMockRecorder) Send(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockAgentService_ConnectServer)(nil).Send), arg0)
 }
 
-// SendHeader mocks base method.
+// SendHeader mocks base method
 func (m *MockAgentService_ConnectServer) SendHeader(arg0 metadata.MD) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendHeader", arg0)
@@ -116,13 +115,13 @@ func (m *MockAgentService_ConnectServer) SendHeader(arg0 metadata.MD) error {
 	return ret0
 }
 
-// SendHeader indicates an expected call of SendHeader.
+// SendHeader indicates an expected call of SendHeader
 func (mr *MockAgentService_ConnectServerMockRecorder) SendHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendHeader", reflect.TypeOf((*MockAgentService_ConnectServer)(nil).SendHeader), arg0)
 }
 
-// SendMsg mocks base method.
+// SendMsg mocks base method
 func (m *MockAgentService_ConnectServer) SendMsg(arg0 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendMsg", arg0)
@@ -130,13 +129,13 @@ func (m *MockAgentService_ConnectServer) SendMsg(arg0 interface{}) error {
 	return ret0
 }
 
-// SendMsg indicates an expected call of SendMsg.
+// SendMsg indicates an expected call of SendMsg
 func (mr *MockAgentService_ConnectServerMockRecorder) SendMsg(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockAgentService_ConnectServer)(nil).SendMsg), arg0)
 }
 
-// SetHeader mocks base method.
+// SetHeader mocks base method
 func (m *MockAgentService_ConnectServer) SetHeader(arg0 metadata.MD) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHeader", arg0)
@@ -144,19 +143,19 @@ func (m *MockAgentService_ConnectServer) SetHeader(arg0 metadata.MD) error {
 	return ret0
 }
 
-// SetHeader indicates an expected call of SetHeader.
+// SetHeader indicates an expected call of SetHeader
 func (mr *MockAgentService_ConnectServerMockRecorder) SetHeader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHeader", reflect.TypeOf((*MockAgentService_ConnectServer)(nil).SetHeader), arg0)
 }
 
-// SetTrailer mocks base method.
+// SetTrailer mocks base method
 func (m *MockAgentService_ConnectServer) SetTrailer(arg0 metadata.MD) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetTrailer", arg0)
 }
 
-// SetTrailer indicates an expected call of SetTrailer.
+// SetTrailer indicates an expected call of SetTrailer
 func (mr *MockAgentService_ConnectServerMockRecorder) SetTrailer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrailer", reflect.TypeOf((*MockAgentService_ConnectServer)(nil).SetTrailer), arg0)

--- a/tests/agent_disconnect_test.go
+++ b/tests/agent_disconnect_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -21,7 +22,7 @@ func TestProxy_Agent_Disconnect_HTTP_Persistent_Connection(t *testing.T) {
 	testcases := []struct {
 		name                string
 		proxyServerFunction func() (proxy, func(), error)
-		clientFunction      func(string, string) (*http.Client, error)
+		clientFunction      func(context.Context, string, string) (*http.Client, error)
 	}{
 		{
 			name:                "grpc",
@@ -37,6 +38,7 @@ func TestProxy_Agent_Disconnect_HTTP_Persistent_Connection(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
 			server := httptest.NewServer(newEchoServer("hello"))
 			defer server.Close()
 
@@ -59,7 +61,7 @@ func TestProxy_Agent_Disconnect_HTTP_Persistent_Connection(t *testing.T) {
 
 			// run test client
 
-			c, err := tc.clientFunction(proxy.front, server.URL)
+			c, err := tc.clientFunction(ctx, proxy.front, server.URL)
 			if err != nil {
 				t.Errorf("error obtaining client: %v", err)
 			}
@@ -92,7 +94,7 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 	testcases := []struct {
 		name                string
 		proxyServerFunction func() (proxy, func(), error)
-		clientFunction      func(string, string) (*http.Client, error)
+		clientFunction      func(context.Context, string, string) (*http.Client, error)
 	}{
 		{
 			name:                "grpc",
@@ -108,6 +110,7 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
 
 			server := httptest.NewServer(newEchoServer("hello"))
 			defer server.Close()
@@ -130,7 +133,7 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 
 			// run test client
 
-			c, err := tc.clientFunction(proxy.front, server.URL)
+			c, err := tc.clientFunction(ctx, proxy.front, server.URL)
 			if err != nil {
 				t.Errorf("error obtaining client: %v", err)
 			}
@@ -159,7 +162,7 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 			})
 
 			// Proxy requests should work again after agent reconnects
-			c2, err := tc.clientFunction(proxy.front, server.URL)
+			c2, err := tc.clientFunction(ctx, proxy.front, server.URL)
 			if err != nil {
 				t.Errorf("error obtaining client: %v", err)
 			}
@@ -190,8 +193,8 @@ func clientRequest(c *http.Client, addr string) ([]byte, error) {
 	return data, nil
 }
 
-func createGrpcTunnelClient(proxyAddr, addr string) (*http.Client, error) {
-	tunnel, err := client.CreateSingleUseGrpcTunnel(proxyAddr, grpc.WithInsecure())
+func createGrpcTunnelClient(ctx context.Context, proxyAddr, addr string) (*http.Client, error) {
+	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxyAddr, grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}
@@ -199,14 +202,14 @@ func createGrpcTunnelClient(proxyAddr, addr string) (*http.Client, error) {
 	c := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
-			Dial: tunnel.Dial,
+			DialContext: tunnel.DialContext,
 		},
 	}
 
 	return c, nil
 }
 
-func createHTTPConnectClient(proxyAddr, addr string) (*http.Client, error) {
+func createHTTPConnectClient(ctx context.Context, proxyAddr, addr string) (*http.Client, error) {
 	conn, err := net.Dial("tcp", proxyAddr)
 	if err != nil {
 		return nil, err

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -41,14 +41,15 @@ func (s *simpleServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 // TODO: test http-connect as well.
 func getTestClient(front string, t *testing.T) *http.Client {
-	tunnel, err := client.CreateSingleUseGrpcTunnel(front, grpc.WithInsecure())
+	ctx := context.Background()
+	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, front, grpc.WithInsecure())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	return &http.Client{
 		Transport: &http.Transport{
-			Dial: tunnel.Dial,
+			DialContext: tunnel.DialContext,
 		},
 		Timeout: 2 * time.Second,
 	}

--- a/tests/ha_proxy_server_test.go
+++ b/tests/ha_proxy_server_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"log"
@@ -183,14 +184,15 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 }
 
 func testProxyServer(t *testing.T, front string, target string) {
-	tunnel, err := client.CreateSingleUseGrpcTunnel(front, grpc.WithInsecure())
+	ctx := context.Background()
+	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, front, grpc.WithInsecure())
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	c := &http.Client{
 		Transport: &http.Transport{
-			Dial: tunnel.Dial,
+			DialContext: tunnel.DialContext,
 		},
 		Timeout: 1 * time.Second,
 	}

--- a/tests/tcp_server_test.go
+++ b/tests/tcp_server_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ func echo(conn net.Conn) {
 }
 
 func TestEchoServer(t *testing.T) {
+	ctx := context.Background()
 	ln, err := net.Listen("tcp", "")
 	if err != nil {
 		t.Error(err)
@@ -60,12 +62,12 @@ func TestEchoServer(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// run test client
-	tunnel, err := client.CreateSingleUseGrpcTunnel(proxy.front, grpc.WithInsecure())
+	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	conn, err := tunnel.Dial("tcp", ln.Addr().String())
+	conn, err := tunnel.DialContext(ctx, "tcp", ln.Addr().String())
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This should make it possible for apiserver (egress selector) to
propagate cancel to proxy-server.