### PR TITLE
capture the loop variable in the proxy-test-client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ bin/proxy-server: proto/agent/agent.pb.go konnectivity-client/proto/client/clien
 .PHONY: lint
 lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(INSTALL_LOCATION) v$(GOLANGCI_LINT_VERSION)
-	$(INSTALL_LOCATION)/golangci-lint run --no-config --disable-all --enable=gofmt,golint,gosec --fix --verbose --timeout 3m
+	$(INSTALL_LOCATION)/golangci-lint run --no-config --disable-all --enable=gofmt,golint,gosec,govet --fix --verbose --timeout 3m
 
 ## --------------------------------------
 ## Go

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -245,6 +245,7 @@ func (c *Client) run(o *GrpcProxyClientOptions) error {
 	var wg sync.WaitGroup
 
 	for i := 1; i <= o.testRequests; i++ {
+		i := i
 		wg.Add(1)
 		go func() error {
 			defer wg.Done()
@@ -268,7 +269,7 @@ func (c *Client) run(o *GrpcProxyClientOptions) error {
 			}
 
 			if i != o.testRequests {
-				klog.V(1).InfoS("Waiting for next connection test.", "seconds", o.testDelaySec)
+				klog.V(1).InfoS("Waiting for next connection test.", "seconds", o.testDelaySec, "iteration", i, "test requests", o.testRequests)
 				wait := time.Duration(o.testDelaySec) * time.Second
 				time.Sleep(wait)
 			}


### PR DESCRIPTION
When using the proxy-test-client, the test-delay option wasn't
working as expected, because it compares against the loop
variable. However this loop variable is used inside a closure,
hence it is always taking the last value, unless we capture it.

Running without capturing the loop variable:

```
DEBUG iteration 4
I0620 12:46:11.022338   45406 main.go:274] "Waiting for next connection test." seconds=0 iteration=4 test requests=3
I0620 12:46:11.022354   45406 conn.go:115] closing connection
I0620 12:46:11.023627   45406 main.go:311] HTML Response:
<!DOCTYPE html>
<html>
    <head>
        <title>Success</title>
    </head>
    <body>
        <p>The success test page!</p>
    </body>
</html>
DEBUG iteration 4
I0620 12:46:11.023642   45406 main.go:274] "Waiting for next connection test." seconds=0 iteration=4 test requests=3
```