### PR TITLE
add DefaultRoute strategy to validation

### DIFF
--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -38,7 +38,7 @@ type ProxyRunOptions struct {
 	HealthPort uint
 	// After a duration of this time if the server doesn't see any activity it
 	// pings the client to see if the transport is still alive.
-	KeepaliveTime       time.Duration
+	KeepaliveTime         time.Duration
 	FrontendKeepaliveTime time.Duration
 	// Enables pprof at host:AdminPort/debug/pprof.
 	EnableProfiling bool
@@ -252,8 +252,9 @@ func (o *ProxyRunOptions) Validate() error {
 			switch ps {
 			case string(server.ProxyStrategyDestHost):
 			case string(server.ProxyStrategyDefault):
+			case string(server.ProxyStrategyDefaultRoute):
 			default:
-				return fmt.Errorf("unknown proxy strategy: %s, available strategy are: default, destHost", ps)
+				return fmt.Errorf("unknown proxy strategy: %s, available strategy are: default, destHost, defaultRoute", ps)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes missed validation update in https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/228

Currently, trying to use `defaultRoute` with v0.0.20 results in
```
E0621 14:23:13.975690       1 main.go:49] error: failed to validate server options with unknown proxy strategy: defaultRoute, available strategy are: default, destHost
```

@relyt0925