### PR TITLE
Fixed race condition writing to closed channel

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -50,6 +50,17 @@ func (c *connContext) cleanup() {
 	c.cleanOnce.Do(c.cleanFunc)
 }
 
+func (c *connContext) send(msg []byte) {
+	// TODO (cheftako@): Get perf test working and compare this solution with a lock based solution.
+	defer func() {
+		// Handles the race condition where we write to a closed channel
+		if err := recover(); err != nil {
+			klog.InfoS("Recovered from attempt to write to closed channel")
+		}
+	}()
+	c.dataCh <- msg
+}
+
 type connectionManager struct {
 	mu          sync.RWMutex
 	connections map[int64]*connContext
@@ -421,7 +432,7 @@ func (a *Client) Serve() {
 
 			ctx, ok := a.connManager.Get(data.ConnectID)
 			if ok {
-				ctx.dataCh <- data.Data
+				ctx.send(data.Data)
 			}
 
 		case client.PacketType_CLOSE_REQ:


### PR DESCRIPTION
Case is when agent gets a packet and attempts to proxy it forward.
However the channel to the connection we are going to forward to
has been closed.
As a result we get an error on writing to the channel.
One possibility is to use a lock to protect the channel for each packet.
Attempting a solution which does not need the lock.
Using a select does not work (https://play.golang.org/p/Az_YCJ24Cu1)
However also shown there is a send made safe using Recover().