### PR TITLE
add agent to backends after it is authenticated

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -152,10 +152,10 @@ func TestAgentTokenAuthenticationErrorsToken(t *testing.T) {
 			ctx = metadata.NewIncomingContext(ctx, md)
 			conn := agentmock.NewMockAgentService_ConnectServer(stub)
 			conn.EXPECT().Context().AnyTimes().Return(ctx)
-			conn.EXPECT().SendHeader(gomock.Any()).Return(nil)
 
 			// close agent's connection if no error is expected
 			if !tc.wantError {
+				conn.EXPECT().SendHeader(gomock.Any()).Return(nil)
 				conn.EXPECT().Recv().Return(nil, io.EOF)
 			}
 


### PR DESCRIPTION
In `ProxyServer.Connect` an agent is added to the backends and _then_ it is authenticated (if agent authentication is enabled). 
This means the agent is available for proxying requests while question of weather it is authentic or not is being decided. This clearly is a security risk. 

Please, take a look. Thanks! 