### PR TITLE
send headers to an agent after it is added to backends

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -622,13 +622,13 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 		}
 	}
 
+	backend := s.addBackend(agentID, stream)
+	defer s.removeBackend(agentID, stream)
+
 	h := metadata.Pairs(header.ServerID, s.serverID, header.ServerCount, strconv.Itoa(s.serverCount))
 	if err := stream.SendHeader(h); err != nil {
 		return err
 	}
-
-	backend := s.addBackend(agentID, stream)
-	defer s.removeBackend(agentID, stream)
 
 	recvCh := make(chan *client.Packet, 10)
 


### PR DESCRIPTION
Fixes this https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/257/files/e90ddb06fa6d62231dbb4de4beda91ea06c3fcff#r693089519

> Reversing the order of SendHeader() and addBackend() is also a significant change. Might be worth at least a comment. Calling SendHeader() will unblock the agent. (https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/master/pkg/agent/client.go#L225) I think that's ok, because the agent only adds the connection to the list of connected Konn Servers. It won't start using that connection until a frontend is using that connection. An occurrence which cannot currently happen before the agent has been added to the list of backends below. Worth noting that this assumption becomes less true with #176.

