### PR TITLE
add/remove agent to default backend only if it accepts all traffic

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -378,13 +378,13 @@ func (a *Client) Serve() {
 
 		switch pkt.Type {
 		case client.PacketType_DIAL_REQ:
-			klog.V(4).Infoln("received DIAL_REQ")
+			dialReq := pkt.GetDialRequest()
+			klog.V(4).Infoln("received DIAL_REQ to: ", dialReq.Address)
 			resp := &client.Packet{
 				Type:    client.PacketType_DIAL_RSP,
 				Payload: &client.Packet_DialResponse{DialResponse: &client.DialResponse{}},
 			}
 
-			dialReq := pkt.GetDialRequest()
 			resp.GetDialResponse().Random = dialReq.Random
 
 			start := time.Now()

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -117,7 +117,8 @@ func (ids Identifiers) IsEmpty() bool {
 	return len(ids.IPv4) == 0 &&
 		len(ids.IPv6) == 0 &&
 		len(ids.Host) == 0 &&
-		len(ids.CIDR) == 0
+		len(ids.CIDR) == 0 &&
+		!ids.DefaultRoute
 }
 
 type IdentifierType string

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -113,6 +113,13 @@ type Identifiers struct {
 	DefaultRoute bool
 }
 
+func (ids Identifiers) IsEmpty() bool {
+	return len(ids.IPv4) == 0 &&
+		len(ids.IPv6) == 0 &&
+		len(ids.Host) == 0 &&
+		len(ids.CIDR) == 0
+}
+
 type IdentifierType string
 
 const (

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -401,7 +401,7 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 	for pkt := range recvCh {
 		switch pkt.Type {
 		case client.PacketType_DIAL_REQ:
-			klog.V(5).Infoln("Received DIAL_REQ")
+			klog.V(5).Infoln("Received DIAL_REQ to: ", pkt.GetDialRequest().Address)
 			// TODO: if we track what agent has historically served
 			// the address, then we can send the Dial_REQ to the
 			// same agent. That way we save the agent from creating

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -184,7 +184,6 @@ func (s *ProxyServer) getBackend(reqHost string) (Backend, error) {
 }
 
 func (s *ProxyServer) addBackend(agentID string, conn agent.AgentService_ConnectServer) (backend Backend) {
-
 	agentIdentifiers, err := getAgentIdentifiers(conn)
 	if err != nil {
 		klog.ErrorS(err, "fail to get the agent identifiers", "agentID", agentID)
@@ -221,14 +220,14 @@ func (s *ProxyServer) addBackend(agentID string, conn agent.AgentService_Connect
 }
 
 func (s *ProxyServer) removeBackend(agentID string, conn agent.AgentService_ConnectServer) {
+	agentIdentifiers, err := getAgentIdentifiers(conn)
+	if err != nil {
+		klog.ErrorS(err, "fail to get the agent identifiers", "agentID", agentID)
+	}
+
 	for _, bm := range s.BackendManagers {
 		switch bm.(type) {
 		case *DestHostBackendManager:
-			agentIdentifiers, err := getAgentIdentifiers(conn)
-			if err != nil {
-				klog.ErrorS(err, "fail to get the agent identifiers", "agentID", agentID)
-				break
-			}
 			for _, ipv4 := range agentIdentifiers.IPv4 {
 				klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", ipv4)
 				bm.RemoveBackend(ipv4, pkgagent.IPv4, conn)
@@ -242,11 +241,6 @@ func (s *ProxyServer) removeBackend(agentID string, conn agent.AgentService_Conn
 				bm.RemoveBackend(host, pkgagent.Host, conn)
 			}
 		case *DefaultRouteBackendManager:
-			agentIdentifiers, err := getAgentIdentifiers(conn)
-			if err != nil {
-				klog.ErrorS(err, "fail to get the agent identifiers", "agentID", agentID)
-				break
-			}
 			if agentIdentifiers.DefaultRoute {
 				klog.V(5).InfoS("Remove the agent from the DefaultRouteBackendManager", "agentID", agentID)
 				bm.RemoveBackend(agentID, pkgagent.DefaultRoute, conn)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -184,14 +184,15 @@ func (s *ProxyServer) getBackend(reqHost string) (Backend, error) {
 }
 
 func (s *ProxyServer) addBackend(agentID string, conn agent.AgentService_ConnectServer) (backend Backend) {
+
+	agentIdentifiers, err := getAgentIdentifiers(conn)
+	if err != nil {
+		klog.ErrorS(err, "fail to get the agent identifiers", "agentID", agentID)
+	}
+
 	for i := 0; i < len(s.BackendManagers); i++ {
 		switch s.BackendManagers[i].(type) {
 		case *DestHostBackendManager:
-			agentIdentifiers, err := getAgentIdentifiers(conn)
-			if err != nil {
-				klog.ErrorS(err, "fail to get the agent identifiers", "agentID", agentID)
-				break
-			}
 			for _, ipv4 := range agentIdentifiers.IPv4 {
 				klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", ipv4)
 				s.BackendManagers[i].AddBackend(ipv4, pkgagent.IPv4, conn)
@@ -205,18 +206,15 @@ func (s *ProxyServer) addBackend(agentID string, conn agent.AgentService_Connect
 				s.BackendManagers[i].AddBackend(host, pkgagent.Host, conn)
 			}
 		case *DefaultRouteBackendManager:
-			agentIdentifiers, err := getAgentIdentifiers(conn)
-			if err != nil {
-				klog.ErrorS(err, "fail to get the agent identifiers", "agentID", agentID)
-				break
-			}
 			if agentIdentifiers.DefaultRoute {
 				klog.V(5).InfoS("Add the agent to DefaultRouteBackendManager", "agentID", agentID)
 				backend = s.BackendManagers[i].AddBackend(agentID, pkgagent.DefaultRoute, conn)
 			}
 		default:
-			klog.V(5).InfoS("Add the agent to DefaultBackendManager", "agentID", agentID)
-			backend = s.BackendManagers[i].AddBackend(agentID, pkgagent.UID, conn)
+			if agentIdentifiers.IsEmpty() {
+				klog.V(5).InfoS("Add the agent to DefaultBackendManager", "agentID", agentID)
+				backend = s.BackendManagers[i].AddBackend(agentID, pkgagent.UID, conn)
+			}
 		}
 	}
 	return

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -48,14 +48,14 @@ func (f *testAgent) Context() context.Context {
 	return ctx
 }
 
-func TestDefaultBackendStorage_AddBackend(t *testing.T) {
+func TestDefaultBackendStorage_AddRemoveBackend(t *testing.T) {
 	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefault}, 1, nil)
 
-	p.addBackend("a1", &testAgent{
-		hosts: "host=a1.com",
-	})
+	a1 := &testAgent{hosts: "host=a1.com"}
+	p.addBackend("a1", a1)
 
-	p.addBackend("a2", new(testAgent))
+	a2 := new(testAgent)
+	p.addBackend("a2", a2)
 
 	bm := p.BackendManagers[0]
 	if bm.NumBackends() != 1 {
@@ -66,6 +66,20 @@ func TestDefaultBackendStorage_AddBackend(t *testing.T) {
 	if bm.NumBackends() != 1 {
 		t.Fatalf("expected: %d, got: %d", 1, bm.NumBackends())
 	}
+
+	p.removeBackend("a1", a1)
+	p.removeBackend("a2", a2)
+
+	bm = p.BackendManagers[0]
+	if bm.NumBackends() != 0 {
+		t.Fatalf("expected: %d, got: %d", 0, bm.NumBackends())
+	}
+
+	bm = p.BackendManagers[1]
+	if bm.NumBackends() != 0 {
+		t.Fatalf("expected: %d, got: %d", 0, bm.NumBackends())
+	}
+
 }
 
 func TestAgentTokenAuthenticationErrorsToken(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -49,13 +49,16 @@ func (f *testAgent) Context() context.Context {
 }
 
 func TestDefaultBackendStorage_AddRemoveBackend(t *testing.T) {
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefault}, 1, nil)
+	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefaultRoute, ProxyStrategyDefault}, 1, nil)
 
 	a1 := &testAgent{hosts: "host=a1.com"}
 	p.addBackend("a1", a1)
 
 	a2 := new(testAgent)
 	p.addBackend("a2", a2)
+
+	a3 := &testAgent{hosts: "default-route=true"}
+	p.addBackend("a3", a3)
 
 	bm := p.BackendManagers[0]
 	if bm.NumBackends() != 1 {
@@ -67,8 +70,14 @@ func TestDefaultBackendStorage_AddRemoveBackend(t *testing.T) {
 		t.Fatalf("expected: %d, got: %d", 1, bm.NumBackends())
 	}
 
+	bm = p.BackendManagers[2]
+	if bm.NumBackends() != 1 {
+		t.Fatalf("expected: %d, got: %d", 1, bm.NumBackends())
+	}
+
 	p.removeBackend("a1", a1)
 	p.removeBackend("a2", a2)
+	p.removeBackend("a3", a3)
 
 	bm = p.BackendManagers[0]
 	if bm.NumBackends() != 0 {
@@ -76,6 +85,11 @@ func TestDefaultBackendStorage_AddRemoveBackend(t *testing.T) {
 	}
 
 	bm = p.BackendManagers[1]
+	if bm.NumBackends() != 0 {
+		t.Fatalf("expected: %d, got: %d", 0, bm.NumBackends())
+	}
+
+	bm = p.BackendManagers[2]
 	if bm.NumBackends() != 0 {
 		t.Fatalf("expected: %d, got: %d", 0, bm.NumBackends())
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -32,9 +32,41 @@ import (
 	fakeauthenticationv1 "k8s.io/client-go/kubernetes/typed/authentication/v1/fake"
 	k8stesting "k8s.io/client-go/testing"
 
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	agentmock "sigs.k8s.io/apiserver-network-proxy/proto/agent/mocks"
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
+
+type testAgent struct {
+	agent.AgentService_ConnectServer
+	hosts string
+}
+
+func (f *testAgent) Context() context.Context {
+	ctx := context.Background()
+	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(header.AgentIdentifiers, f.hosts))
+	return ctx
+}
+
+func TestDefaultBackendStorage_AddBackend(t *testing.T) {
+	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefault}, 1, nil)
+
+	p.addBackend("a1", &testAgent{
+		hosts: "host=a1.com",
+	})
+
+	p.addBackend("a2", new(testAgent))
+
+	bm := p.BackendManagers[0]
+	if bm.NumBackends() != 1 {
+		t.Fatalf("expected: %d, got: %d", 1, bm.NumBackends())
+	}
+
+	bm = p.BackendManagers[1]
+	if bm.NumBackends() != 1 {
+		t.Fatalf("expected: %d, got: %d", 1, bm.NumBackends())
+	}
+}
 
 func TestAgentTokenAuthenticationErrorsToken(t *testing.T) {
 	stub := gomock.NewController(t)


### PR DESCRIPTION
The agents that specify `--agent-identifers` expect traffic going only to the specified destination. They shouldn't get any other traffic. 

`X`: Currently all the agents are added to the default backend. 

Scenario: 
1. Agent `a1` registers to handle traffic going to `a1.com`. 
2. Agent `a2` registers does not specify any agent identifiers so any traffic can be sent to it. 
3. A request is made to `b.com`. 
4. Since no agent is registered to specifically handle `b.com` we choose randomly from all the default agents. 
5. Because of `X` all the agents are there and `a1` gets chosen. 
6. The request fails. It should have gone to `a2`. 

This PR fixes the problem by adding an agent to the default backend only if it doesn't specify any agent identifiers.  

The fix is based on the assumption that an agent not specifying identifiers means any traffic can be sent to it. Let me know if I assumed wrong. 

Please, take a look. Thanks! :pray: 
