### PR TITLE
randomize selected backend for desthost backend manager

### DIFF
--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -37,8 +37,8 @@ func TestAddRemoveBackends(t *testing.T) {
 
 	p := NewDefaultBackendManager()
 
-	p.AddBackend("agent1", pkgagent.UID, conn1)
-	p.RemoveBackend("agent1", pkgagent.UID, conn1)
+	p.AddBackend("agent1", "agent1", pkgagent.UID, conn1)
+	p.RemoveBackend("agent1", "agent1", pkgagent.UID, conn1)
 	expectedBackends := make(map[string][]*backend)
 	expectedAgentIDs := []string{}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
@@ -49,18 +49,18 @@ func TestAddRemoveBackends(t *testing.T) {
 	}
 
 	p = NewDefaultBackendManager()
-	p.AddBackend("agent1", pkgagent.UID, conn1)
-	p.AddBackend("agent1", pkgagent.UID, conn12)
+	p.AddBackend("agent1", "agent1", pkgagent.UID, conn1)
+	p.AddBackend("agent1", "agent1", pkgagent.UID, conn12)
 	// Adding the same connection again should be a no-op.
-	p.AddBackend("agent1", pkgagent.UID, conn12)
-	p.AddBackend("agent2", pkgagent.UID, conn2)
-	p.AddBackend("agent2", pkgagent.UID, conn22)
-	p.AddBackend("agent3", pkgagent.UID, conn3)
-	p.RemoveBackend("agent2", pkgagent.UID, conn22)
-	p.RemoveBackend("agent2", pkgagent.UID, conn2)
-	p.RemoveBackend("agent1", pkgagent.UID, conn1)
+	p.AddBackend("agent1", "agent1", pkgagent.UID, conn12)
+	p.AddBackend("agent2", "agent2", pkgagent.UID, conn2)
+	p.AddBackend("agent2", "agent2", pkgagent.UID, conn22)
+	p.AddBackend("agent3", "agent3", pkgagent.UID, conn3)
+	p.RemoveBackend("agent2", "agent2", pkgagent.UID, conn22)
+	p.RemoveBackend("agent2", "agent2", pkgagent.UID, conn2)
+	p.RemoveBackend("agent1", "agent1", pkgagent.UID, conn1)
 	// This is invalid. agent1 doesn't have conn3. This should be a no-op.
-	p.RemoveBackend("agent1", pkgagent.UID, conn3)
+	p.RemoveBackend("agent1", "agent1", pkgagent.UID, conn3)
 	expectedBackends = map[string][]*backend{
 		"agent1": {newBackend(conn12)},
 		"agent3": {newBackend(conn3)},
@@ -83,8 +83,8 @@ func TestAddRemoveBackendsWithDefaultRoute(t *testing.T) {
 
 	p := NewDefaultRouteBackendManager()
 
-	p.AddBackend("agent1", pkgagent.DefaultRoute, conn1)
-	p.RemoveBackend("agent1", pkgagent.DefaultRoute, conn1)
+	p.AddBackend("agent1", "agent1", pkgagent.DefaultRoute, conn1)
+	p.RemoveBackend("agent1", "agent1", pkgagent.DefaultRoute, conn1)
 	expectedBackends := make(map[string][]*backend)
 	expectedAgentIDs := []string{}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
@@ -98,18 +98,18 @@ func TestAddRemoveBackendsWithDefaultRoute(t *testing.T) {
 	}
 
 	p = NewDefaultRouteBackendManager()
-	p.AddBackend("agent1", pkgagent.DefaultRoute, conn1)
-	p.AddBackend("agent1", pkgagent.DefaultRoute, conn12)
+	p.AddBackend("agent1", "agent1", pkgagent.DefaultRoute, conn1)
+	p.AddBackend("agent1", "agent1", pkgagent.DefaultRoute, conn12)
 	// Adding the same connection again should be a no-op.
-	p.AddBackend("agent1", pkgagent.DefaultRoute, conn12)
-	p.AddBackend("agent2", pkgagent.DefaultRoute, conn2)
-	p.AddBackend("agent2", pkgagent.DefaultRoute, conn22)
-	p.AddBackend("agent3", pkgagent.DefaultRoute, conn3)
-	p.RemoveBackend("agent2", pkgagent.DefaultRoute, conn22)
-	p.RemoveBackend("agent2", pkgagent.DefaultRoute, conn2)
-	p.RemoveBackend("agent1", pkgagent.DefaultRoute, conn1)
+	p.AddBackend("agent1", "agent1", pkgagent.DefaultRoute, conn12)
+	p.AddBackend("agent2", "agent2", pkgagent.DefaultRoute, conn2)
+	p.AddBackend("agent2", "agent2", pkgagent.DefaultRoute, conn22)
+	p.AddBackend("agent3", "agent3", pkgagent.DefaultRoute, conn3)
+	p.RemoveBackend("agent2", "agent2", pkgagent.DefaultRoute, conn22)
+	p.RemoveBackend("agent2", "agent2", pkgagent.DefaultRoute, conn2)
+	p.RemoveBackend("agent1", "agent1", pkgagent.DefaultRoute, conn1)
 	// This is invalid. agent1 doesn't have conn3. This should be a no-op.
-	p.RemoveBackend("agent1", pkgagent.DefaultRoute, conn3)
+	p.RemoveBackend("agent1", "agent1", pkgagent.DefaultRoute, conn3)
 
 	expectedBackends = map[string][]*backend{
 		"agent1": {newBackend(conn12)},
@@ -121,6 +121,60 @@ func TestAddRemoveBackendsWithDefaultRoute(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 	if e, a := expectedDefaultRouteAgentIDs, p.defaultRouteAgentIDs; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestAddRemoveBackendsWithDestHost(t *testing.T) {
+	conn1 := new(fakeAgentServiceConnectServer)
+	conn12 := new(fakeAgentServiceConnectServer)
+	conn2 := new(fakeAgentServiceConnectServer)
+	conn22 := new(fakeAgentServiceConnectServer)
+	conn3 := new(fakeAgentServiceConnectServer)
+
+	p := NewDestHostBackendManager()
+
+	p.AddBackend("agent1", "10.10.10.10", pkgagent.IPv4, conn1)
+	p.RemoveBackend("agent1", "10.10.10.10", pkgagent.IPv4, conn1)
+	expectedBackends := make(map[string][]*backend)
+	expectedAgentIDs := []string{}
+	expectedHostToUniqueAgentIDs := make(map[string][]string)
+	expectedHostToUniqueAgentIDs["10.10.10.10"] = []string{}
+	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedHostToUniqueAgentIDs["10.10.10.10"], p.hostToUniqueAgentIDTracker["10.10.10.10"]; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+
+	p = NewDestHostBackendManager()
+	p.AddBackend("agent1", "10.10.10.10", pkgagent.IPv4, conn1)
+	p.AddBackend("agent1", "10.10.10.10", pkgagent.IPv4, conn12)
+	// Adding the same connection again should be a no-op.
+	p.AddBackend("agent1", "10.10.10.10", pkgagent.IPv4, conn12)
+	p.AddBackend("agent2", "10.10.10.10", pkgagent.IPv4, conn2)
+	p.AddBackend("agent2", "10.10.10.10", pkgagent.IPv4, conn22)
+	p.AddBackend("agent3", "10.10.10.10", pkgagent.IPv4, conn3)
+	p.RemoveBackend("agent2", "10.10.10.10", pkgagent.IPv4, conn22)
+	p.RemoveBackend("agent2", "10.10.10.10", pkgagent.IPv4, conn2)
+	p.RemoveBackend("agent1", "10.10.10.10", pkgagent.IPv4, conn1)
+	// This is invalid. agent1 doesn't have conn3. This should be a no-op.
+	p.RemoveBackend("agent1", "10.10.10.10", pkgagent.IPv4, conn3)
+
+	expectedBackends = map[string][]*backend{
+		"agent1": {newBackend(conn12)},
+		"agent3": {newBackend(conn3)},
+	}
+	expectedHostToUniqueAgentIDs = make(map[string][]string)
+	expectedHostToUniqueAgentIDs["10.10.10.10"] = []string{"agent1", "agent3"}
+
+	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedHostToUniqueAgentIDs["10.10.10.10"], p.hostToUniqueAgentIDTracker["10.10.10.10"]; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -44,10 +44,10 @@ func (dibm *DestHostBackendManager) Backend(ctx context.Context) (Backend, error
 	}
 	destHost := ctx.Value(destHost).(string)
 	if destHost != "" {
-		bes, exist := dibm.backends[destHost]
-		if exist && len(bes) > 0 {
+		uniqueAgentIDs, exist := dibm.hostToUniqueAgentIDTracker[destHost]
+		if exist && len(uniqueAgentIDs) > 0 {
 			klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
-			return dibm.backends[destHost][0], nil
+			return dibm.backends[uniqueAgentIDs[dibm.random.Intn(len(uniqueAgentIDs))]][0], nil
 		}
 	}
 	return nil, &ErrNotFound{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -199,15 +199,15 @@ func (s *ProxyServer) addBackend(agentID string, conn agent.AgentService_Connect
 			}
 			for _, ipv4 := range agentIdentifiers.IPv4 {
 				klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", ipv4)
-				s.BackendManagers[i].AddBackend(ipv4, pkgagent.IPv4, conn)
+				s.BackendManagers[i].AddBackend(agentID, ipv4, pkgagent.IPv4, conn)
 			}
 			for _, ipv6 := range agentIdentifiers.IPv6 {
 				klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", ipv6)
-				s.BackendManagers[i].AddBackend(ipv6, pkgagent.IPv6, conn)
+				s.BackendManagers[i].AddBackend(agentID, ipv6, pkgagent.IPv6, conn)
 			}
 			for _, host := range agentIdentifiers.Host {
 				klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", host)
-				s.BackendManagers[i].AddBackend(host, pkgagent.Host, conn)
+				s.BackendManagers[i].AddBackend(agentID, host, pkgagent.Host, conn)
 			}
 		case *DefaultRouteBackendManager:
 			agentIdentifiers, err := getAgentIdentifiers(conn)
@@ -217,11 +217,11 @@ func (s *ProxyServer) addBackend(agentID string, conn agent.AgentService_Connect
 			}
 			if agentIdentifiers.DefaultRoute {
 				klog.V(5).InfoS("Add the agent to DefaultRouteBackendManager", "agentID", agentID)
-				backend = s.BackendManagers[i].AddBackend(agentID, pkgagent.DefaultRoute, conn)
+				backend = s.BackendManagers[i].AddBackend(agentID, agentID, pkgagent.DefaultRoute, conn)
 			}
 		default:
 			klog.V(5).InfoS("Add the agent to DefaultBackendManager", "agentID", agentID)
-			backend = s.BackendManagers[i].AddBackend(agentID, pkgagent.UID, conn)
+			backend = s.BackendManagers[i].AddBackend(agentID, agentID, pkgagent.UID, conn)
 		}
 	}
 	return
@@ -238,15 +238,15 @@ func (s *ProxyServer) removeBackend(agentID string, conn agent.AgentService_Conn
 			}
 			for _, ipv4 := range agentIdentifiers.IPv4 {
 				klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", ipv4)
-				bm.RemoveBackend(ipv4, pkgagent.IPv4, conn)
+				bm.RemoveBackend(agentID, ipv4, pkgagent.IPv4, conn)
 			}
 			for _, ipv6 := range agentIdentifiers.IPv6 {
 				klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", ipv6)
-				bm.RemoveBackend(ipv6, pkgagent.IPv6, conn)
+				bm.RemoveBackend(agentID, ipv6, pkgagent.IPv6, conn)
 			}
 			for _, host := range agentIdentifiers.Host {
 				klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", host)
-				bm.RemoveBackend(host, pkgagent.Host, conn)
+				bm.RemoveBackend(agentID, host, pkgagent.Host, conn)
 			}
 		case *DefaultRouteBackendManager:
 			agentIdentifiers, err := getAgentIdentifiers(conn)
@@ -256,11 +256,11 @@ func (s *ProxyServer) removeBackend(agentID string, conn agent.AgentService_Conn
 			}
 			if agentIdentifiers.DefaultRoute {
 				klog.V(5).InfoS("Remove the agent from the DefaultRouteBackendManager", "agentID", agentID)
-				bm.RemoveBackend(agentID, pkgagent.DefaultRoute, conn)
+				bm.RemoveBackend(agentID, agentID, pkgagent.DefaultRoute, conn)
 			}
 		default:
 			klog.V(5).InfoS("Remove the agent from the DefaultBackendManager", "agentID", agentID)
-			bm.RemoveBackend(agentID, pkgagent.UID, conn)
+			bm.RemoveBackend(agentID, agentID, pkgagent.UID, conn)
 		}
 	}
 }

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -62,14 +62,14 @@ type singleTimeManager struct {
 	used     map[string]struct{}
 }
 
-func (s *singleTimeManager) AddBackend(agentID string, _ pkgagent.IdentifierType, conn agent.AgentService_ConnectServer) server.Backend {
+func (s *singleTimeManager) AddBackend(agentID string, _ string, _ pkgagent.IdentifierType, conn agent.AgentService_ConnectServer) server.Backend {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.backends[agentID] = conn
 	return conn
 }
 
-func (s *singleTimeManager) RemoveBackend(agentID string, _ pkgagent.IdentifierType, conn agent.AgentService_ConnectServer) {
+func (s *singleTimeManager) RemoveBackend(agentID string, _ string, _ pkgagent.IdentifierType, conn agent.AgentService_ConnectServer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	v, ok := s.backends[agentID]


### PR DESCRIPTION
helps solve:
https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/261

Currently the destHost strategy does not select a random backend (unlike the other strategies). If there are a pool of redundant agents that can all contact the same ip this does not lead to the most highly available/load balanced solution.

This changes the backend to be more inline with the other backend and select a random candidate.