### PR TITLE
use docker buildx to build multi-arch image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,10 @@ docker-push/http-test-server: docker-build/http-test-server
 ## Docker — All ARCH
 ## --------------------------------------
 
+# As `docker buildx` is time and resource consuming, if not necessary, building specific arch images,
+# like `make docker-build-arch-aamd64`, is recommended.
 .PHONY: docker-build-all
-docker-build-all: $(addprefix docker-build/proxy-agent-,$(ALL_ARCH)) $(addprefix docker-build/proxy-server-,$(ALL_ARCH)) $(addprefix docker-build/proxy-test-client-,$(ALL_ARCH)) $(addprefix docker-build/http-test-server-,$(ALL_ARCH))
+docker-build-all: $(addprefix docker-build-arch-,$(ALL_ARCH))
 
 .PHONY: docker-push-all
 docker-push-all: $(addprefix docker-push/proxy-agent-,$(ALL_ARCH)) $(addprefix docker-push/proxy-server-,$(ALL_ARCH)) $(addprefix docker-push/proxy-test-client-,$(ALL_ARCH)) $(addprefix docker-push/http-test-server-,$(ALL_ARCH))
@@ -240,6 +242,12 @@ docker-push-all: $(addprefix docker-push/proxy-agent-,$(ALL_ARCH)) $(addprefix d
 	$(MAKE) docker-push-manifest/proxy-server
 	$(MAKE) docker-push-manifest/proxy-test-client
 	$(MAKE) docker-push-manifest/http-test-server
+
+docker-build-arch-%:
+	$(MAKE) docker-build/proxy-agent-$*
+	$(MAKE) docker-build/proxy-server-$*
+	$(MAKE) docker-build/proxy-test-client-$*
+	$(MAKE) docker-build/http-test-server-$*
 
 docker-build/proxy-agent-%:
 	$(MAKE) ARCH=$* docker-build/proxy-agent

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,7 @@ certs: easy-rsa cfssl cfssljson
 ## Docker
 ## --------------------------------------
 
+.PHONY: buildx-setup
 buildx-setup:
 	${DOCKER_CMD} buildx inspect img-builder > /dev/null || docker buildx create --name img-builder --use
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 
 ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
+# The output type could either be docker (local), or registry.
+OUTPUT_TYPE ?= docker
 
 ifeq ($(GOPATH),)
 export GOPATH := $(shell go env GOPATH)
@@ -171,6 +173,9 @@ certs: easy-rsa cfssl cfssljson
 ## Docker
 ## --------------------------------------
 
+buildx-setup:
+	${DOCKER_CMD} buildx inspect img-builder > /dev/null || docker buildx create --name img-builder --use
+
 .PHONY: docker-build
 docker-build: docker-build/proxy-agent docker-build/proxy-server docker-build/proxy-test-client docker-build/http-test-server
 
@@ -178,10 +183,10 @@ docker-build: docker-build/proxy-agent docker-build/proxy-server docker-build/pr
 docker-push: docker-push/proxy-agent docker-push/proxy-server docker-push/proxy-test-client docker-push/http-test-server
 
 .PHONY: docker-build/proxy-agent
-docker-build/proxy-agent: cmd/agent/main.go proto/agent/agent.pb.go
+docker-build/proxy-agent: cmd/agent/main.go proto/agent/agent.pb.go buildx-setup
 	@[ "${TAG}" ] || ( echo "TAG is not set"; exit 1 )
 	echo "Building proxy-agent for ${ARCH}"
-	${DOCKER_CMD} build . --build-arg ARCH=$(ARCH) -f artifacts/images/agent-build.Dockerfile -t ${AGENT_FULL_IMAGE}-$(ARCH):${TAG}
+	${DOCKER_CMD} buildx build . --pull --output=type=$(OUTPUT_TYPE) --platform linux/$(ARCH) --build-arg ARCH=$(ARCH) -f artifacts/images/agent-build.Dockerfile -t ${AGENT_FULL_IMAGE}-$(ARCH):${TAG}
 
 .PHONY: docker-push/proxy-agent
 docker-push/proxy-agent: docker-build/proxy-agent
@@ -189,10 +194,10 @@ docker-push/proxy-agent: docker-build/proxy-agent
 	${DOCKER_CMD} push ${AGENT_FULL_IMAGE}-$(ARCH):${TAG}
 
 .PHONY: docker-build/proxy-server
-docker-build/proxy-server: cmd/server/main.go proto/agent/agent.pb.go
+docker-build/proxy-server: cmd/server/main.go proto/agent/agent.pb.go buildx-setup
 	@[ "${TAG}" ] || ( echo "TAG is not set"; exit 1 )
 	echo "Building proxy-server for ${ARCH}"
-	${DOCKER_CMD} build . --build-arg ARCH=$(ARCH) -f artifacts/images/server-build.Dockerfile -t ${SERVER_FULL_IMAGE}-$(ARCH):${TAG}
+	${DOCKER_CMD} buildx build . --pull --output=type=$(OUTPUT_TYPE) --platform linux/$(ARCH) --build-arg ARCH=$(ARCH) -f artifacts/images/server-build.Dockerfile -t ${SERVER_FULL_IMAGE}-$(ARCH):${TAG}
 
 .PHONY: docker-push/proxy-server
 docker-push/proxy-server: docker-build/proxy-server
@@ -200,10 +205,10 @@ docker-push/proxy-server: docker-build/proxy-server
 	${DOCKER_CMD} push ${SERVER_FULL_IMAGE}-$(ARCH):${TAG}
 
 .PHONY: docker-build/proxy-test-client
-docker-build/proxy-test-client: cmd/client/main.go proto/agent/agent.pb.go
+docker-build/proxy-test-client: cmd/client/main.go proto/agent/agent.pb.go buildx-setup
 	@[ "${TAG}" ] || ( echo "TAG is not set"; exit 1 )
 	echo "Building proxy-test-client for ${ARCH}"
-	${DOCKER_CMD} build . --build-arg ARCH=$(ARCH) -f artifacts/images/client-build.Dockerfile -t ${TEST_CLIENT_FULL_IMAGE}-$(ARCH):${TAG}
+	${DOCKER_CMD} buildx build . --pull --output=type=$(OUTPUT_TYPE) --platform linux/$(ARCH) --build-arg ARCH=$(ARCH) -f artifacts/images/client-build.Dockerfile -t ${TEST_CLIENT_FULL_IMAGE}-$(ARCH):${TAG}
 
 .PHONY: docker-push/proxy-test-client
 docker-push/proxy-test-client: docker-build/proxy-test-client
@@ -211,10 +216,10 @@ docker-push/proxy-test-client: docker-build/proxy-test-client
 	${DOCKER_CMD} push ${TEST_CLIENT_FULL_IMAGE}-$(ARCH):${TAG}
 
 .PHONY: docker-build/http-test-server
-docker-build/http-test-server: cmd/test-server/main.go
+docker-build/http-test-server: cmd/test-server/main.go buildx-setup
 	@[ "${TAG}" ] || ( echo "TAG is not set"; exit 1 )
 	echo "Building http-test-server for ${ARCH}"
-	${DOCKER_CMD} build . --build-arg ARCH=$(ARCH) -f artifacts/images/test-server-build.Dockerfile -t ${TEST_SERVER_FULL_IMAGE}-$(ARCH):${TAG}
+	${DOCKER_CMD} buildx build . --pull --output=type=$(OUTPUT_TYPE) --platform linux/$(ARCH) --build-arg ARCH=$(ARCH) -f artifacts/images/test-server-build.Dockerfile -t ${TEST_SERVER_FULL_IMAGE}-$(ARCH):${TAG}
 
 .PHONY: docker-push/http-test-server
 docker-push/http-test-server: docker-build/http-test-server


### PR DESCRIPTION
Before this change, the image built through our Makefile `docker-push/xxx` is with the same arch as the host as no arch simulation is introduced, even though ARCH is specified, as shown below I used `REGISTRY=qingchuanhao.azurecr.io ARCH=arm64 make docker-push/proxy-server` to push an arm64 image to ACR.

```
➜  apiserver-network-proxy git:(qinhao/docker-buildx) ✗ docker manifest inspect qingchuanhao.azurecr.io/proxy-server-arm64:4e8b12d2cd77db7ae5acecb5b706d5ecb3bf93e3 --verbose
{
        "Ref": "qingchuanhao.azurecr.io/proxy-server-arm64:4e8b12d2cd77db7ae5acecb5b706d5ecb3bf93e3",
        "Descriptor": {
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "digest": "sha256:1b7c6cda30a9107b6f3663f14aec7a8d8345db0edfb2d5a27df0be625120639a",
                "size": 529,
                "platform": {
                        "architecture": "amd64",
                        "os": "linux"
                }
        },
        "SchemaV2Manifest": {
                "schemaVersion": 2,
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "config": {
                        "mediaType": "application/vnd.docker.container.image.v1+json",
                        "size": 1626,
                        "digest": "sha256:6c8176319e0266e592a7c196fc59452c4f911264a28de871a6e7f6595b03bfaf"
                },
                "layers": [
                        {
                                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                                "size": 16844398,
                                "digest": "sha256:ac1c233a6102ecd2569ae1b62251b35c56aab32519e5cb6f85384230515c9374"
                        }
                ]
        }
}
```

After this change, the same command `REGISTRY=qingchuanhao.azurecr.io ARCH=arm64 make docker-push/proxy-server` return a arm64-based image
```
➜  apiserver-network-proxy git:(qinhao/docker-buildx) ✗ docker manifest inspect qingchuanhao.azurecr.io/proxy-server-arm64:4e8b12d2cd77db7ae5acecb5b706d5ecb3bf93e3 --verbose
{
        "Ref": "qingchuanhao.azurecr.io/proxy-server-arm64:4e8b12d2cd77db7ae5acecb5b706d5ecb3bf93e3",
        "Descriptor": {
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "digest": "sha256:50a9ac6271ab785d1bbe0dc4c90c691d8864882120042538816291986c386b9e",
                "size": 528,
                "platform": {
                        "architecture": "arm64",
                        "os": "linux"
                }
        },
        "SchemaV2Manifest": {
                "schemaVersion": 2,
                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                "config": {
                        "mediaType": "application/vnd.docker.container.image.v1+json",
                        "size": 795,
                        "digest": "sha256:553c6675d128f33660bd3a2d6e1c7af342e2253b7728954b2fed860f2cda618d"
                },
                "layers": [
                        {
                                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                                "size": 16844403,
                                "digest": "sha256:5d361ee5f90647819936c375addaab5996ccfb7d17181e5454c947d25a62cec8"
                        }
                ]
        }
}
```