### PR TITLE
proxy-server: in gRPC mode, set same keepalive for UDS and mTLS.

### DIFF
--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -170,7 +170,10 @@ func (p *Proxy) runUDSFrontendServer(ctx context.Context, o *options.ProxyRunOpt
 	}
 	var stop StopFunc
 	if o.Mode == "grpc" {
-		grpcServer := grpc.NewServer()
+		frontendServerOptions := []grpc.ServerOption{
+			grpc.KeepaliveParams(keepalive.ServerParameters{Time: o.FrontendKeepaliveTime}),
+		}
+		grpcServer := grpc.NewServer(frontendServerOptions...)
 		client.RegisterProxyServiceServer(grpcServer, s)
 		lis, err := getUDSListener(ctx, o.UdsName)
 		if err != nil {


### PR DESCRIPTION
Fix an inconsistency that was identified in #276