### PR TITLE
Bubble up errors on grpc connections.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -388,6 +388,7 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 			}
 			if err != nil {
 				klog.ErrorS(err, "Stream read from frontend failure")
+				stopCh <- err
 				close(stopCh)
 				return
 			}
@@ -666,6 +667,7 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 			}
 			if err != nil {
 				klog.ErrorS(err, "stream read failure")
+				stopCh <- err
 				close(stopCh)
 				return
 			}


### PR DESCRIPTION
The Connect() and Proxy() method always return nil today, as they return
what is received in the stopCh (see [here][link1] and [here][link2]).
When the channel is closed, the nil error is received and then returned.

This patch just changes to send the error (instead of closing the
channel) when an error was received. This way, we report the proper
error to the grpc layer.

This is mostly a no-op IIUC, but the recommended way in the grpc
quick start.

[link1]: https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/a007c42f6c9d06ff869da5b93c428546658c414e/pkg/server/server.go#L402
[link2]: https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/a007c42f6c9d06ff869da5b93c428546658c414e/pkg/server/server.go#L680

Signed-off-by: Rodrigo Campos <rodrigo@kinvolk.io>