### PR TITLE
add option to change cipher suites

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -42,7 +42,7 @@ type GrpcProxyAgentOptions struct {
 	SyncIntervalCap  time.Duration
 	// After a duration of this time if the agent doesn't see any activity it
 	// pings the server to see if the transport is still alive.
-	KeepaliveTime    time.Duration
+	KeepaliveTime time.Duration
 
 	// file contains service account authorization token for enabling proxy-server token based authorization
 	ServiceAccountTokenPath string
@@ -65,7 +65,7 @@ func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) 
 		SyncIntervalCap:         o.SyncIntervalCap,
 		DialOptions:             dialOptions,
 		ServiceAccountTokenPath: o.ServiceAccountTokenPath,
-		WarnOnChannelLimit:		 o.WarnOnChannelLimit,
+		WarnOnChannelLimit:      o.WarnOnChannelLimit,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.1.2
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.5
@@ -30,6 +29,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -137,7 +137,7 @@ func (cc *ClientSetConfig) NewAgentClientSet(stopCh <-chan struct{}) *ClientSet 
 		syncIntervalCap:         cc.SyncIntervalCap,
 		dialOptions:             cc.DialOptions,
 		serviceAccountTokenPath: cc.ServiceAccountTokenPath,
-		warnOnChannelLimit:		 cc.WarnOnChannelLimit,
+		warnOnChannelLimit:      cc.WarnOnChannelLimit,
 		stopCh:                  stopCh,
 	}
 }

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"crypto/tls"
 	"strings"
 )
 
@@ -47,4 +48,13 @@ func RemovePortFromHost(host string) string {
 		host = host[:strings.LastIndexByte(host, ':')]
 	}
 	return strings.Trim(host, "[]")
+}
+
+// GetAcceptedCiphers returns all the ciphers supported by the crypto/tls package
+func GetAcceptedCiphers() map[string]uint16 {
+	acceptedCiphers := make(map[string]uint16, len(tls.CipherSuites()))
+	for _, v := range tls.CipherSuites() {
+		acceptedCiphers[v.Name] = v.ID
+	}
+	return acceptedCiphers
 }


### PR DESCRIPTION
resolves: https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/283

This PR adds an option to change ANP server default cipher suite to specify a more strict list.