### PR TITLE
Make sure deps are clean prior to running update vendor.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,5 +41,6 @@ Creating a new release of network proxy involves releasing a new version of the 
 
     ```
     ./hack/pin-dependency.sh sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
+    make clean generated_files
     ./hack/update-vendor.sh
     ```


### PR DESCRIPTION
Update instructions to ensure K/K dependencies are clean before running update vendor.