### PR TITLE
Don't leak konn-client connections if DialResp is not recognized

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -115,6 +115,7 @@ func (t *grpcTunnel) serve(c clientConn) {
 
 			if !ok {
 				klog.V(1).InfoS("DialResp not recognized; dropped", "connectionID", resp.ConnectID, "dialID", resp.Random)
+				return
 			} else {
 				result := dialResult{
 					err:    resp.Error,


### PR DESCRIPTION
If the DialResp is not recognized, it seems we never will receive a
close request in this stream. So, we can close this connection by finishing the goroutine (a defer makes sure the connection is closed when we finish)

This patch greatly helps to reduce the leaks reported in #276. Although,
this doesn't completely fix the issue. The number of leaked fds seems to be ~1/10 with this patch, sometimes even less.

However, I have some open questions that you can maybe answer:
1. Is the close request/response for some reason always expected to come, even in this case, and therefore is there some other part of the code that we also need to fix?
2. Even if the answer to ^ is yes, I think closing the connection here (if we will only receive a close afterwards) seems valid, as we will prevent issues in case we have a regression in the future. Is closing it here legit? What do you think?

Updates: #276 