### PR TITLE
images: fix invalid k8s-staging-test-infra/gcb-docker-gcloud tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,7 @@ timeout: 2400s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
     entrypoint: make
     env:
     - TAG=$_GIT_TAG


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/297

I copy-pasted the wrong tag :sweat_smile:  Sorry about the churn