### PR TITLE
Defer sending close response after having cleaned connection manager to

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -415,6 +415,9 @@ func (a *Client) Serve() {
 					}
 					resp.GetCloseResponse().ConnectID = connID
 
+					close(dataCh)
+					a.connManager.Delete(connID)
+
 					err := conn.Close()
 					if err != nil {
 						resp.GetCloseResponse().Error = err.Error()
@@ -423,9 +426,6 @@ func (a *Client) Serve() {
 					if err := a.Send(resp); err != nil {
 						klog.ErrorS(err, "close response failure")
 					}
-
-					close(dataCh)
-					a.connManager.Delete(connID)
 				},
 				warnChLim: a.warnOnChannelLimit,
 			}


### PR DESCRIPTION
Defer sending close response after having cleaned connection manager to avoid race conditions in `TestServeData_HTTP` unit test.

> --- FAIL: TestClose_Client (0.00s)
    client_test.go:338: client.connContext not released