### PR TITLE
Update cloudbuild.yaml add auth step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,16 +3,19 @@ options:
   substitution_option: ALLOW_LOOSE
 steps:
   - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
-    entrypoint: make
+    entrypoint: bash
     env:
     - TAG=$_GIT_TAG
     - BASE_REF=$_PULL_BASE_REF
     - DOCKER_CLI_EXPERIMENTAL=enabled
-    args:
-    - release-staging
     # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
     # set the home to /root explicitly to if using docker buildx
     - HOME=/root
+    args:
+      - '-c'
+      - |
+        gcloud auth configure-docker \
+        && make release-staging
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
Following format provided by other k8s repos that also use docker buildx.

See
https://github.com/kubernetes/kubernetes/blob/master/build/pause/cloudbuild.yaml
https://github.com/kubernetes/ingress-nginx/blob/main/images/custom-error-pages/cloudbuild.yaml
https://github.com/kubernetes/ingress-nginx/blob/main/images/test-runner/cloudbuild.yaml

/assign @cheftako 