### PR TITLE
Increase cloudbuild timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-timeout: 2400s
+timeout: 9000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
Increase cloudbuild timeout to 2.5 hours based on measurements provided [here](https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/274#issuecomment-970228867)

/assign @cheftako 