### PR TITLE
fix: client should return instantly when no backend

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -425,8 +425,12 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 				klog.ErrorS(err, "Failed to get a backend", "serverID", s.serverID)
 
 				resp := &client.Packet{
-					Type:    client.PacketType_DIAL_RSP,
-					Payload: &client.Packet_DialResponse{DialResponse: &client.DialResponse{Error: err.Error()}},
+					Type: client.PacketType_DIAL_RSP,
+					Payload: &client.Packet_DialResponse{
+						DialResponse: &client.DialResponse{
+							Random: pkt.GetDialRequest().Random,
+							Error:  err.Error(),
+						}},
 				}
 				if err := stream.Send(resp); err != nil {
 					klog.V(5).Infoln("Failed to send DIAL_RSP for no backend", "error", err, "serverID", s.serverID)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -459,8 +459,10 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			if err := backend.Send(pkt); err != nil {
 				// TODO: retry with other backends connecting to this agent.
 				klog.ErrorS(err, "CLOSE_REQ to Backend failed", "serverID", s.serverID, "connectionID", connID)
+			} else {
+				klog.V(5).Infoln("CLOSE_REQ sent to backend", "serverID", s.serverID, "connectionID", connID)
+				return
 			}
-			klog.V(5).Infoln("CLOSE_REQ sent to backend", "serverID", s.serverID, "connectionID", connID)
 
 		case client.PacketType_DIAL_CLS:
 			random := pkt.GetCloseDial().Random

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -253,7 +253,7 @@ func prepareAgentConnMD(ctrl *gomock.Controller, proxyServer *ProxyServer) *agen
 	return agentConn
 }
 
-func baseTestWithoutBackend(t *testing.T, validate func(*agentmock.MockAgentService_ConnectServer)) {
+func baseServerProxyTestWithoutBackend(t *testing.T, validate func(*agentmock.MockAgentService_ConnectServer)) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -267,7 +267,8 @@ func baseTestWithoutBackend(t *testing.T, validate func(*agentmock.MockAgentServ
 	// add a sleep to make sure `serveRecvFrontend` ends after `Proxy` finished.
 	time.Sleep(1 * time.Second)
 }
-func baseTestWithBackend(t *testing.T, validate func(*agentmock.MockAgentService_ConnectServer, *agentmock.MockAgentService_ConnectServer)) {
+
+func baseServerProxyTestWithBackend(t *testing.T, validate func(*agentmock.MockAgentService_ConnectServer, *agentmock.MockAgentService_ConnectServer)) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -314,12 +315,12 @@ func TestServerProxyNoBackend(t *testing.T) {
 			frontendConn.EXPECT().Recv().Return(dialReq, nil).Times(1),
 			frontendConn.EXPECT().Recv().Return(nil, io.EOF).Times(1),
 			// NOTE(mainred): `Send` should come before `Recv` io.EOF, but we cannot add wait between
-			// two Recvs, Recv comes before `Send`
+			//                two Recvs, thus `Recv`` comes before `Send`
 			frontendConn.EXPECT().Send(dialResp).Return(nil).Times(1),
 		)
 
 	}
-	baseTestWithoutBackend(t, validate)
+	baseServerProxyTestWithoutBackend(t, validate)
 }
 
 func TestServerProxyNormalClose(t *testing.T) {
@@ -356,5 +357,5 @@ func TestServerProxyNormalClose(t *testing.T) {
 			agentConn.EXPECT().Send(closeReq).Return(nil).Times(1),
 		)
 	}
-	baseTestWithBackend(t, validate)
+	baseServerProxyTestWithBackend(t, validate)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -223,10 +223,7 @@ func TestAddRemoveFrontends(t *testing.T) {
 	}
 }
 
-func TestServerProxyNormalClose(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
+func prepareFrontendConn(ctrl *gomock.Controller) *agentmock.MockAgentService_ConnectServer {
 	// prepare the connection to fontend  of proxy-server
 	frontendConn := agentmock.NewMockAgentService_ConnectServer(ctrl)
 	frontendConnMD := metadata.MD{
@@ -236,10 +233,10 @@ func TestServerProxyNormalClose(t *testing.T) {
 	}
 	frontendConnCtx := metadata.NewIncomingContext(context.Background(), frontendConnMD)
 	frontendConn.EXPECT().Context().Return(frontendConnCtx).AnyTimes()
+	return frontendConn
+}
 
-	// prepare proxy server
-	proxyServer := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, true)
-
+func prepareAgentConnMD(ctrl *gomock.Controller, proxyServer *ProxyServer) *agentmock.MockAgentService_ConnectServer {
 	// prepare the the connection to agent of proxy-server
 	agentConn := agentmock.NewMockAgentService_ConnectServer(ctrl)
 	agentConnMD := metadata.MD{
@@ -253,41 +250,111 @@ func TestServerProxyNormalClose(t *testing.T) {
 	agentConn.EXPECT().Context().Return(agentConnCtx).AnyTimes()
 
 	_ = proxyServer.addBackend(uuid.New().String(), agentConn)
+	return agentConn
+}
 
-	// receive DIAL_REQ from frontend and proxy to backend
-	randomId := rand.Int63()
-	dialReq := &client.Packet{
-		Type: client.PacketType_DIAL_REQ,
-		Payload: &client.Packet_DialRequest{
-			DialRequest: &client.DialRequest{
-				Protocol: "tcp",
-				Address:  "127.0.0.1:8080",
-				Random:   randomId,
-			},
-		},
-	}
+func baseTestWithoutBackend(t *testing.T, validate func(*agentmock.MockAgentService_ConnectServer)) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-	// recevie CLOSE_REQ from frontend and proxy to backend
-	closeReq := &client.Packet{
-		Type: client.PacketType_CLOSE_REQ,
-		Payload: &client.Packet_CloseRequest{
-			CloseRequest: &client.CloseRequest{
-				ConnectID: 1,
-			}},
-	}
+	frontendConn := prepareFrontendConn(ctrl)
+	proxyServer := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, true)
 
-	gomock.InOrder(
-		frontendConn.EXPECT().Recv().Return(dialReq, nil).Times(1),
-		frontendConn.EXPECT().Recv().Return(closeReq, nil).Times(1),
-		frontendConn.EXPECT().Recv().Return(nil, io.EOF).Times(1),
-	)
-	gomock.InOrder(
-		agentConn.EXPECT().Send(dialReq).Return(nil).Times(1),
-		agentConn.EXPECT().Send(closeReq).Return(nil).Times(1),
-	)
+	validate(frontendConn)
 
 	proxyServer.Proxy(frontendConn)
 
 	// add a sleep to make sure `serveRecvFrontend` ends after `Proxy` finished.
 	time.Sleep(1 * time.Second)
+}
+func baseTestWithBackend(t *testing.T, validate func(*agentmock.MockAgentService_ConnectServer, *agentmock.MockAgentService_ConnectServer)) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	frontendConn := prepareFrontendConn(ctrl)
+
+	// prepare proxy server
+	proxyServer := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, true)
+
+	agentConn := prepareAgentConnMD(ctrl, proxyServer)
+
+	validate(frontendConn, agentConn)
+
+	proxyServer.Proxy(frontendConn)
+
+	// add a sleep to make sure `serveRecvFrontend` ends after `Proxy` finished.
+	time.Sleep(1 * time.Second)
+}
+
+func TestServerProxyNoBackend(t *testing.T) {
+	validate := func(frontendConn *agentmock.MockAgentService_ConnectServer) {
+		// receive DIAL_REQ from frontend and proxy to backend
+		randomId := rand.Int63()
+		dialReq := &client.Packet{
+			Type: client.PacketType_DIAL_REQ,
+			Payload: &client.Packet_DialRequest{
+				DialRequest: &client.DialRequest{
+					Protocol: "tcp",
+					Address:  "127.0.0.1:8080",
+					Random:   randomId,
+				},
+			},
+		}
+
+		dialResp := &client.Packet{
+			Type: client.PacketType_DIAL_RSP,
+			Payload: &client.Packet_DialResponse{
+				DialResponse: &client.DialResponse{
+					Random: randomId,
+					Error:  (&ErrNotFound{}).Error(),
+				}},
+		}
+
+		gomock.InOrder(
+			frontendConn.EXPECT().Recv().Return(dialReq, nil).Times(1),
+			frontendConn.EXPECT().Recv().Return(nil, io.EOF).Times(1),
+			// NOTE(mainred): `Send` should come before `Recv` io.EOF, but we cannot add wait between
+			// two Recvs, Recv comes before `Send`
+			frontendConn.EXPECT().Send(dialResp).Return(nil).Times(1),
+		)
+
+	}
+	baseTestWithoutBackend(t, validate)
+}
+
+func TestServerProxyNormalClose(t *testing.T) {
+	validate := func(frontendConn, agentConn *agentmock.MockAgentService_ConnectServer) {
+		// receive DIAL_REQ from frontend and proxy to backend
+		randomId := rand.Int63()
+		dialReq := &client.Packet{
+			Type: client.PacketType_DIAL_REQ,
+			Payload: &client.Packet_DialRequest{
+				DialRequest: &client.DialRequest{
+					Protocol: "tcp",
+					Address:  "127.0.0.1:8080",
+					Random:   randomId,
+				},
+			},
+		}
+
+		// recevie CLOSE_REQ from frontend and proxy to backend
+		closeReq := &client.Packet{
+			Type: client.PacketType_CLOSE_REQ,
+			Payload: &client.Packet_CloseRequest{
+				CloseRequest: &client.CloseRequest{
+					ConnectID: 1,
+				}},
+		}
+
+		gomock.InOrder(
+			frontendConn.EXPECT().Recv().Return(dialReq, nil).Times(1),
+			frontendConn.EXPECT().Recv().Return(closeReq, nil).Times(1),
+			frontendConn.EXPECT().Recv().Return(nil, io.EOF).Times(1),
+		)
+		gomock.InOrder(
+			agentConn.EXPECT().Send(dialReq).Return(nil).Times(1),
+			agentConn.EXPECT().Send(closeReq).Return(nil).Times(1),
+		)
+	}
+	baseTestWithBackend(t, validate)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -290,14 +290,14 @@ func baseServerProxyTestWithBackend(t *testing.T, validate func(*agentmock.MockA
 func TestServerProxyNoBackend(t *testing.T) {
 	validate := func(frontendConn *agentmock.MockAgentService_ConnectServer) {
 		// receive DIAL_REQ from frontend and proxy to backend
-		randomId := rand.Int63()
+		randomID := rand.Int63() /* #nosec G404 */
 		dialReq := &client.Packet{
 			Type: client.PacketType_DIAL_REQ,
 			Payload: &client.Packet_DialRequest{
 				DialRequest: &client.DialRequest{
 					Protocol: "tcp",
 					Address:  "127.0.0.1:8080",
-					Random:   randomId,
+					Random:   randomID,
 				},
 			},
 		}
@@ -306,7 +306,7 @@ func TestServerProxyNoBackend(t *testing.T) {
 			Type: client.PacketType_DIAL_RSP,
 			Payload: &client.Packet_DialResponse{
 				DialResponse: &client.DialResponse{
-					Random: randomId,
+					Random: randomID,
 					Error:  (&ErrNotFound{}).Error(),
 				}},
 		}
@@ -326,14 +326,14 @@ func TestServerProxyNoBackend(t *testing.T) {
 func TestServerProxyNormalClose(t *testing.T) {
 	validate := func(frontendConn, agentConn *agentmock.MockAgentService_ConnectServer) {
 		// receive DIAL_REQ from frontend and proxy to backend
-		randomId := rand.Int63()
+		randomID := rand.Int63() /* #nosec G404 */
 		dialReq := &client.Packet{
 			Type: client.PacketType_DIAL_REQ,
 			Payload: &client.Packet_DialRequest{
 				DialRequest: &client.DialRequest{
 					Protocol: "tcp",
 					Address:  "127.0.0.1:8080",
-					Random:   randomId,
+					Random:   randomID,
 				},
 			},
 		}


### PR DESCRIPTION
Two changes are included in this PR:
- If no backend is registered to the server, and the grpc client request will hang for 30s instead of returning instantly with `no backend` error. This is caused by the issue that random id is not included in dia resp from server to client, thus the client does not recognize the dial resp and return, dropping the error.
- for a normal client-server close case, close req is sent to backend twice, one as proxy from client, and the other one is as a generalized one. The latter one is not necessary, and bring misleading error message for both proxy-server and proxy-agent