### PR TITLE
Decouple read remote from write to server.

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -172,6 +172,9 @@ type Client struct {
 
 	cs *ClientSet // the clientset that includes this AgentClient.
 
+	serverChannel    chan *client.Packet
+	cleanChannel     sync.Once
+	serverError      error // Currently checking and setting of error all occur in writeToProxyServer
 	stream           agent.AgentService_ConnectClient
 	agentID          string
 	agentIdentifiers string
@@ -250,9 +253,33 @@ func (a *Client) Connect() (int, error) {
 	}
 	a.conn = conn
 	a.stream = stream
+	a.serverChannel = make(chan *client.Packet, xfrChannelSize)
+	a.serverError = nil
 	a.serverID = serverID
+	go a.writeToProxyServer()
 	klog.V(2).InfoS("Connect to", "server", serverID)
 	return serverCount, nil
+}
+
+func (a *Client) writeToProxyServer() {
+	defer func() {
+		if panicInfo := recover(); panicInfo != nil {
+			klog.V(2).InfoS("Exiting writeToProxyServer with recovery", "panicInfo", panicInfo, "serverID", a.serverID)
+		} else {
+			klog.V(2).InfoS("Exiting writeToProxyServer", "serverID", a.serverID)
+		}
+	}()
+
+	for pkt := range a.serverChannel {
+		klog.V(5).InfoS("writeToProxyServer recevied packet to send to KonnServer", "serverID", a.serverID)
+		err := a.stream.Send(pkt)
+		if err != nil && err != io.EOF {
+			metrics.Metrics.ObserveFailure(metrics.DirectionToServer)
+			a.cs.RemoveClient(a.serverID)
+			klog.V(2).InfoS("writeToProxyServer removing server from clientset", "serverID", a.serverID)
+			a.serverError = err
+		}
+	}
 }
 
 // Close closes the underlying connection.
@@ -271,12 +298,23 @@ func (a *Client) Send(pkt *client.Packet) error {
 	a.sendLock.Lock()
 	defer a.sendLock.Unlock()
 
-	err := a.stream.Send(pkt)
-	if err != nil && err != io.EOF {
-		metrics.Metrics.ObserveFailure(metrics.DirectionToServer)
-		a.cs.RemoveClient(a.serverID)
+	if a.serverError != nil {
+		// We know the return connection is closed, so return the error.
+		// Failing to return an error here does not mean the send will succeed.
+		// It just means we do not know yet if it will fail.
+		// Slight back-flips here to ensure the write is closing the channel.
+		a.cleanChannel.Do(func() {
+			klog.V(2).InfoS("Data channel to server has errored out", "serverID", a.serverID)
+			close(a.serverChannel)
+		})
+		return a.serverError
 	}
-	return err
+
+	if a.warnOnChannelLimit && len(a.serverChannel) >= xfrChannelSize {
+		klog.V(2).InfoS("Data channel to server on agent is full", "serverID", a.serverID)
+	}
+	a.serverChannel <- pkt
+	return nil
 }
 
 func (a *Client) Recv() (*client.Packet, error) {
@@ -495,9 +533,6 @@ func (a *Client) remoteToProxy(connID int64, ctx *connContext) {
 	defer ctx.cleanup()
 
 	var buf [1 << 12]byte
-	resp := &client.Packet{
-		Type: client.PacketType_DATA,
-	}
 
 	for {
 		n, err := ctx.conn.Read(buf[:])
@@ -515,10 +550,16 @@ func (a *Client) remoteToProxy(connID int64, ctx *connContext) {
 			}
 			return
 		} else {
-			resp.Payload = &client.Packet_Data{Data: &client.Data{
-				Data:      buf[:n],
-				ConnectID: connID,
-			}}
+			data := make([]byte, 0, n)
+			data = append(data, buf[:n]...)
+			klog.V(5).InfoS("remoteToProxy set up data to send back", "dataSize", n)
+			resp := &client.Packet{
+				Type: client.PacketType_DATA,
+				Payload: &client.Packet_Data{Data: &client.Data{
+					Data:      data,
+					ConnectID: connID,
+				}},
+			}
 			if err := a.Send(resp); err != nil {
 				klog.ErrorS(err, "stream send failure", "connectionID", connID)
 			}
@@ -541,7 +582,7 @@ func (a *Client) proxyToRemote(connID int64, ctx *connContext) {
 		for {
 			n, err := ctx.conn.Write(d[pos:])
 			if err == nil {
-				klog.V(4).InfoS("write to remote", "connectionID", connID, "lastData", n, "dataSize", len(d))
+				klog.V(4).InfoS("write to remote", "connectionID", connID, "lastData", n)
 				break
 			} else if n > 0 {
 				// https://golang.org/pkg/io/#Writer specifies return non nil error if n < len(d)

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -20,13 +20,16 @@ func TestServeData_HTTP(t *testing.T) {
 	var stream agent.AgentService_ConnectClient
 	stopCh := make(chan struct{})
 	testClient := &Client{
-		connManager: newConnectionManager(),
-		stopCh:      stopCh,
+		serverChannel: make(chan *client.Packet, xfrChannelSize),
+		serverError:   nil,
+		connManager:   newConnectionManager(),
+		stopCh:        stopCh,
 	}
 	testClient.stream, stream = pipe()
 
 	// Start agent
 	go testClient.Serve()
+	go testClient.writeToProxyServer()
 	defer close(stopCh)
 
 	// Start test http server as remote service
@@ -44,17 +47,17 @@ func TestServeData_HTTP(t *testing.T) {
 	}
 
 	// Expect receiving DIAL_RSP packet from (Agent) Client
-	pkg, err := stream.Recv()
+	pkt, err := stream.Recv()
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if pkg == nil {
+	if pkt == nil {
 		t.Fatal("unexpected nil packet")
 	}
-	if pkg.Type != client.PacketType_DIAL_RSP {
-		t.Errorf("expect PacketType_DIAL_RSP; got %v", pkg.Type)
+	if pkt.Type != client.PacketType_DIAL_RSP {
+		t.Errorf("expect PacketType_DIAL_RSP; got %v", pkt.Type)
 	}
-	dialRsp := pkg.Payload.(*client.Packet_DialResponse)
+	dialRsp := pkt.Payload.(*client.Packet_DialResponse)
 	connID := dialRsp.DialResponse.ConnectID
 	if dialRsp.DialResponse.Random != 111 {
 		t.Errorf("expect random=111; got %v", dialRsp.DialResponse.Random)
@@ -68,14 +71,14 @@ func TestServeData_HTTP(t *testing.T) {
 	}
 
 	// Expect receiving http response via (Agent) Client
-	pkg, _ = stream.Recv()
-	if pkg == nil {
+	pkt, _ = stream.Recv()
+	if pkt == nil {
 		t.Fatal("unexpected nil packet")
 	}
-	if pkg.Type != client.PacketType_DATA {
-		t.Errorf("expect PacketType_DATA; got %v", pkg.Type)
+	if pkt.Type != client.PacketType_DATA {
+		t.Errorf("expect PacketType_DATA; got %v", pkt.Type)
 	}
-	data := pkg.Payload.(*client.Packet_Data).Data.Data
+	data := pkt.Payload.(*client.Packet_Data).Data.Data
 
 	// Verify response data
 	//
@@ -94,14 +97,14 @@ func TestServeData_HTTP(t *testing.T) {
 	ts.Close()
 
 	// Verify receiving CLOSE_RSP
-	pkg, _ = stream.Recv()
-	if pkg == nil {
+	pkt, _ = stream.Recv()
+	if pkt == nil {
 		t.Fatal("unexpected nil packet")
 	}
-	if pkg.Type != client.PacketType_CLOSE_RSP {
-		t.Errorf("expect PacketType_CLOSE_RSP; got %v", pkg.Type)
+	if pkt.Type != client.PacketType_CLOSE_RSP {
+		t.Errorf("expect PacketType_CLOSE_RSP; got %v", pkt.Type)
 	}
-	closeErr := pkg.Payload.(*client.Packet_CloseResponse).CloseResponse.Error
+	closeErr := pkt.Payload.(*client.Packet_CloseResponse).CloseResponse.Error
 	if closeErr != "" {
 		t.Errorf("expect nil closeErr; got %v", closeErr)
 	}
@@ -116,6 +119,8 @@ func TestClose_Client(t *testing.T) {
 	var stream agent.AgentService_ConnectClient
 	stopCh := make(chan struct{})
 	testClient := &Client{
+		serverChannel: make(chan *client.Packet, xfrChannelSize),
+		serverError:   nil,
 		connManager: newConnectionManager(),
 		stopCh:      stopCh,
 	}
@@ -123,6 +128,7 @@ func TestClose_Client(t *testing.T) {
 
 	// Start agent
 	go testClient.Serve()
+	go testClient.writeToProxyServer()
 	defer close(stopCh)
 
 	// Start test http server as remote service


### PR DESCRIPTION
Currently we read from the remote and on the same routine, we write to
the konn server. This means that reading from subsequent reads from
remote are effectively blocked on the write to the konn server. This PR
decouples the read and write. It combines all the writes on to a
channel. Then the writes are on their own routine which reads from that
channel.