### PR TITLE
(WIP - Do not review) Terminate Idle connections by setting a timeout to free up resources

### DIFF
--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -41,6 +41,9 @@ type ProxyRunOptions struct {
 	// pings the client to see if the transport is still alive.
 	KeepaliveTime         time.Duration
 	FrontendKeepaliveTime time.Duration
+	// Time that a gRPC stream between frontend and the proxy-server can be inactive (no pkt received) before
+	// it is closed.
+	GrpcMaxIdleTime time.Duration
 	// Enables pprof at host:AdminPort/debug/pprof.
 	EnableProfiling bool
 	// If EnableProfiling is true, this enables the lock contention
@@ -117,6 +120,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.ProxyStrategies, "proxy-strategies", o.ProxyStrategies, "The list of proxy strategies used by the server to pick a backend/tunnel, available strategies are: default, destHost.")
 	flags.BoolVar(&o.WarnOnChannelLimit, "warn-on-channel-limit", o.WarnOnChannelLimit, "Turns on a warning if the system is going to push to a full channel. The check involves an unsafe read.")
 	flags.StringVar(&o.CipherSuites, "cipher-suites", o.CipherSuites, "The comma separated list of allowed cipher suites. Has no effect on TLS1.3. Empty means allow default list.")
+	flags.DurationVar(&o.GrpcMaxIdleTime, "grpc-max-idle-time", o.GrpcMaxIdleTime, "Time that a gRPC connection can be inactive (no pkt received) before it is closed.")
 	return flags
 }
 
@@ -136,6 +140,7 @@ func (o *ProxyRunOptions) Print() {
 	klog.V(1).Infof("Health port set to %d.\n", o.HealthPort)
 	klog.V(1).Infof("Keepalive time set to %v.\n", o.KeepaliveTime)
 	klog.V(1).Infof("Frontend keepalive time set to %v.\n", o.FrontendKeepaliveTime)
+	klog.V(1).Infof("gRPC maxIdleTime time set to %v.\n", o.GrpcMaxIdleTime)
 	klog.V(1).Infof("EnableProfiling set to %v.\n", o.EnableProfiling)
 	klog.V(1).Infof("EnableContentionProfiling set to %v.\n", o.EnableContentionProfiling)
 	klog.V(1).Infof("ServerID set to %s.\n", o.ServerID)

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -107,7 +107,7 @@ func (p *Proxy) run(o *options.ProxyRunOptions) error {
 	if err != nil {
 		return err
 	}
-	server := server.NewProxyServer(o.ServerID, ps, int(o.ServerCount), authOpt, o.WarnOnChannelLimit)
+	server := server.NewProxyServer(o.ServerID, ps, int(o.ServerCount), authOpt, o.WarnOnChannelLimit, o.GrpcMaxIdleTime)
 
 	frontendStop, err := p.runFrontendServer(ctx, o, server)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -145,6 +145,9 @@ type ProxyServer struct {
 	AgentAuthenticationOptions *AgentTokenAuthenticationOptions
 
 	proxyStrategies []ProxyStrategy
+
+	// Klls inactive (no app payload) Proxy connections after this duration.
+	grpcMaxIdleTime time.Duration
 }
 
 // AgentTokenAuthenticationOptions contains list of parameters required for agent token based authentication
@@ -326,7 +329,7 @@ func (s *ProxyServer) getFrontendsForBackendConn(agentID string, backend Backend
 }
 
 // NewProxyServer creates a new ProxyServer instance
-func NewProxyServer(serverID string, proxyStrategies []ProxyStrategy, serverCount int, agentAuthenticationOptions *AgentTokenAuthenticationOptions, warnOnChannelLimit bool) *ProxyServer {
+func NewProxyServer(serverID string, proxyStrategies []ProxyStrategy, serverCount int, agentAuthenticationOptions *AgentTokenAuthenticationOptions, warnOnChannelLimit bool, grpcMaxIdleTime time.Duration) *ProxyServer {
 	var bms []BackendManager
 	for _, ps := range proxyStrategies {
 		switch ps {
@@ -352,6 +355,7 @@ func NewProxyServer(serverID string, proxyStrategies []ProxyStrategy, serverCoun
 		Readiness:          bms[0],
 		proxyStrategies:    proxyStrategies,
 		warnOnChannelLimit: warnOnChannelLimit,
+		grpcMaxIdleTime:    grpcMaxIdleTime,
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"google.golang.org/grpc/metadata"
@@ -159,6 +160,7 @@ func TestAgentTokenAuthenticationErrorsToken(t *testing.T) {
 				conn.EXPECT().Recv().Return(nil, io.EOF)
 			}
 
+			grpcMaxIdleTime := 1 * time.Minute
 			p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{
 				Enabled:             true,
 				KubernetesClient:    kcs,
@@ -166,6 +168,7 @@ func TestAgentTokenAuthenticationErrorsToken(t *testing.T) {
 				AgentServiceAccount: tc.wantServiceAccount,
 			},
 				false,
+				grpcMaxIdleTime,
 			)
 
 			err := p.Connect(conn)
@@ -189,7 +192,8 @@ func TestAddRemoveFrontends(t *testing.T) {
 	agent2ConnID2 := new(ProxyClientConnection)
 	agent3ConnID1 := new(ProxyClientConnection)
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, false)
+	grpcMaxIdleTime := 1 * time.Minute
+	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, false, grpcMaxIdleTime)
 	p.addFrontend("agent1", int64(1), agent1ConnID1)
 	p.removeFrontend("agent1", int64(1))
 	expectedFrontends := make(map[string]map[int64]*ProxyClientConnection)
@@ -197,7 +201,7 @@ func TestAddRemoveFrontends(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	p = NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, false)
+	p = NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, false, grpcMaxIdleTime)
 	p.addFrontend("agent1", int64(1), agent1ConnID1)
 	p.addFrontend("agent1", int64(2), agent1ConnID2)
 	p.addFrontend("agent2", int64(1), agent2ConnID1)

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -424,7 +424,8 @@ func runGRPCProxyServerWithServerCount(serverCount int) (proxy, *server.ProxySer
 	var err error
 	var lis, lis2 net.Listener
 
-	server := server.NewProxyServer(uuid.New().String(), []server.ProxyStrategy{server.ProxyStrategyDefault}, serverCount, &server.AgentTokenAuthenticationOptions{}, false)
+	grpcMaxIdleTime := 1 * time.Minute
+	server := server.NewProxyServer(uuid.New().String(), []server.ProxyStrategy{server.ProxyStrategyDefault}, serverCount, &server.AgentTokenAuthenticationOptions{}, false, grpcMaxIdleTime)
 	grpcServer := grpc.NewServer()
 	agentServer := grpc.NewServer()
 	cleanup := func() {
@@ -463,7 +464,9 @@ func runGRPCProxyServerWithServerCount(serverCount int) (proxy, *server.ProxySer
 func runHTTPConnProxyServer() (proxy, func(), error) {
 	ctx := context.Background()
 	var proxy proxy
-	s := server.NewProxyServer(uuid.New().String(), []server.ProxyStrategy{server.ProxyStrategyDefault}, 0, &server.AgentTokenAuthenticationOptions{}, false)
+
+	grpcMaxIdleTime := 1 * time.Minute
+	s := server.NewProxyServer(uuid.New().String(), []server.ProxyStrategy{server.ProxyStrategyDefault}, 0, &server.AgentTokenAuthenticationOptions{}, false, grpcMaxIdleTime)
 	agentServer := grpc.NewServer()
 
 	agentproto.RegisterAgentServiceServer(agentServer, s)


### PR DESCRIPTION
This PR fixes #276 by addressing the issue #311.

We introduce a new flag `--grpc-max-idle-time` after which any idle connections from frontend(kube-apiserver) to proxy-server will be terminated.

To test this PR: reproduce the steps:
1. checkout this PR/branch locally and build the proxy-server binary
2. Follow steps described in the issue #311.

Start the proxy-server with:
```
./bin/proxy-server --server-port=0 --uds-name=/tmp/uds-proxy --cluster-ca-cert=certs/agent/issued/ca.crt --cluster-cert=certs/agent/issued/proxy-frontend.crt --cluster-key=certs/agent/private/proxy-frontend.key --warn-on-channel-limit --v 5 --keepalive-time 1m --frontend-keepalive-time 1m  --enable-profiling --grpc-max-idle-time 3m 2>&1 | tee server.log
```

Before running the stress test, get the following metrics
```
$ curl -s localhost:8095/metrics | grep -E "grpc"
# HELP konnectivity_network_proxy_server_grpc_connections Number of current grpc connections, partitioned by service method.
# TYPE konnectivity_network_proxy_server_grpc_connections gauge
konnectivity_network_proxy_server_grpc_connections{service_method="Connect"} 1
konnectivity_network_proxy_server_grpc_connections{service_method="Proxy"} 0


$ curl -s localhost:8095/metrics | grep -E "open_fds"
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 13
```

Take a note of the metrics, during the stress test:

Once the stress test is complete and enough time has passed to trigger a `--grpc-max-idle-time` timeout, you'll notice that the metrics values would be pre-stress test levels.

/cc @rata @iaguis