### PR TITLE
Agent: Add flag for health server listen address

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -27,6 +27,7 @@ type GrpcProxyAgentOptions struct {
 	AlpnProtos      []string
 
 	// Ports for the health and admin server
+	HealthServerHost string
 	HealthServerPort int
 	AdminServerPort  int
 	// Enables pprof at host:adminPort/debug/pprof.
@@ -80,6 +81,7 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.ProxyServerHost, "proxy-server-host", o.ProxyServerHost, "The hostname to use to connect to the proxy-server.")
 	flags.IntVar(&o.ProxyServerPort, "proxy-server-port", o.ProxyServerPort, "The port the proxy server is listening on.")
 	flags.StringSliceVar(&o.AlpnProtos, "alpn-proto", o.AlpnProtos, "Additional ALPN protocols to be presented when connecting to the server. Useful to distinguish between network proxy and apiserver connections that share the same destination address.")
+	flags.StringVar(&o.HealthServerHost, "health-server-host", o.HealthServerHost, "The host address to listen on, without port.")
 	flags.IntVar(&o.HealthServerPort, "health-server-port", o.HealthServerPort, "The port the health server is listening on.")
 	flags.IntVar(&o.AdminServerPort, "admin-server-port", o.AdminServerPort, "The port the admin server is listening on.")
 	flags.BoolVar(&o.EnableProfiling, "enable-profiling", o.EnableProfiling, "enable pprof at host:admin-port/debug/pprof")
@@ -103,6 +105,7 @@ func (o *GrpcProxyAgentOptions) Print() {
 	klog.V(1).Infof("ProxyServerHost set to %q.\n", o.ProxyServerHost)
 	klog.V(1).Infof("ProxyServerPort set to %d.\n", o.ProxyServerPort)
 	klog.V(1).Infof("ALPNProtos set to %+s.\n", o.AlpnProtos)
+	klog.V(1).Infof("HealthServerHost set to %s\n", o.HealthServerHost)
 	klog.V(1).Infof("HealthServerPort set to %d.\n", o.HealthServerPort)
 	klog.V(1).Infof("AdminServerPort set to %d.\n", o.AdminServerPort)
 	klog.V(1).Infof("EnableProfiling set to %v.\n", o.EnableProfiling)
@@ -192,6 +195,7 @@ func NewGrpcProxyAgentOptions() *GrpcProxyAgentOptions {
 		CaCert:                    "",
 		ProxyServerHost:           "127.0.0.1",
 		ProxyServerPort:           8091,
+		HealthServerHost:          "",
 		HealthServerPort:          8093,
 		AdminServerPort:           8094,
 		EnableProfiling:           false,

--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"runtime"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -93,7 +94,7 @@ func (a *Agent) runHealthServer(o *options.GrpcProxyAgentOptions) error {
 	muxHandler.HandleFunc("/ready", readinessHandler)
 	muxHandler.HandleFunc("/readyz", readinessHandler)
 	healthServer := &http.Server{
-		Addr:           fmt.Sprintf(":%d", o.HealthServerPort),
+		Addr:           net.JoinHostPort(o.HealthServerHost, strconv.Itoa(o.HealthServerPort)),
 		Handler:        muxHandler,
 		MaxHeaderBytes: 1 << 20,
 	}


### PR DESCRIPTION
This allows for example to make the health server listen on the
localhost interface only. The default of binding to all interfaces is
unchanged.