### PR TITLE
fix: don't send closeReq twice if it is already sent

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -414,7 +414,7 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 	klog.V(4).Infoln("start serving frontend stream")
 
 	var connID int64
-	var closeReqSent bool = false
+	var closeReqSent bool
 	// The first packet should be a DIAL_REQ, then we will get a
 	// backend from the configured BackendMangers.
 	var backend Backend

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -470,11 +470,9 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 				// TODO: retry with other backends connecting to this agent.
 				klog.ErrorS(err, "CLOSE_REQ to Backend failed", "serverID", s.serverID, "connectionID", connID)
 			} else {
-				klog.V(5).InfoS("CLOSE_REQ sent to backend", "serverID", s.serverID, "connectionID", connID)
+				klog.V(5).Infoln("CLOSE_REQ sent to backend", "serverID", s.serverID, "connectionID", connID)
+				closeReqSent = true
 			}
-			closeReqSent = true
-			klog.V(5).Infoln("CLOSE_REQ sent to backend", "serverID", s.serverID, "connectionID", connID)
-
 		case client.PacketType_DIAL_CLS:
 			random := pkt.GetCloseDial().Random
 			klog.V(5).InfoS("Received DIAL_CLOSE", "serverID", s.serverID, "dialID", random)


### PR DESCRIPTION
This PR tries to fix https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/319

- don't send closeReq twice if it is already sent: currently we have single use grpc tunnel, that's why connID does/shall not change during the lifecycle of the connection, that's why I think the firstConnID variable is not really necessary - as it is just controls some Info log currently
- although, I agree that we could add connID comparison/validation, if needed
- silent the rpc error Canceled (it comes in normal client-server close case)

@mainred I have just found that you have a similar PR:
https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/307
