### PR TITLE
Add http concurrent test

### DIFF
--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -293,8 +293,8 @@ func ignoreNotFound(err error) error {
 
 // GetRandomBackend returns a random backend connection from all connected agents.
 func (s *DefaultBackendStorage) GetRandomBackend() (Backend, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if len(s.backends) == 0 {
 		return nil, &ErrNotFound{}
 	}


### PR DESCRIPTION
- use Lock instead of RLock to fix read-write race condition on http concurrent test
```
==================
WARNING: DATA RACE
Read at 0x00c00022c000 by goroutine 50:
  math/rand.(*rngSource).Uint64()
      /snap/go/9028/src/math/rand/rng.go:239 +0x32
  math/rand.(*rngSource).Int63()
      /snap/go/9028/src/math/rand/rng.go:234 +0x1f1
  math/rand.(*Rand).Int63()
      /snap/go/9028/src/math/rand/rand.go:84 +0xa8
  math/rand.(*Rand).Int31()
      /snap/go/9028/src/math/rand/rand.go:98 +0xb3
  math/rand.(*Rand).Int31n()
      /snap/go/9028/src/math/rand/rand.go:130 +0xae
  math/rand.(*Rand).Intn()
      /snap/go/9028/src/math/rand/rand.go:171 +0x48
  sigs.k8s.io/apiserver-network-proxy/pkg/server.(*DefaultBackendStorage).GetRandomBackend()
      /root/apiserver-network-proxy/pkg/server/backend_manager.go:301 +0x149
  sigs.k8s.io/apiserver-network-proxy/pkg/server.(*DefaultBackendManager).Backend()
      /root/apiserver-network-proxy/pkg/server/backend_manager.go:133 +0x104
  sigs.k8s.io/apiserver-network-proxy/pkg/server.(*ProxyServer).getBackend()
      /root/apiserver-network-proxy/pkg/server/server.go:178 +0x101
  sigs.k8s.io/apiserver-network-proxy/pkg/server.(*Tunnel).ServeHTTP()
      /root/apiserver-network-proxy/pkg/server/tunnel.go:79 +0xed1
  sigs.k8s.io/apiserver-network-proxy/tests.runHTTPConnProxyServer.func4()
      /root/apiserver-network-proxy/tests/proxy_test.go:489 +0xee
  net/http.HandlerFunc.ServeHTTP()
      /snap/go/9028/src/net/http/server.go:2047 +0x4d
  net/http.serverHandler.ServeHTTP()
      /snap/go/9028/src/net/http/server.go:2879 +0x89a
  net/http.(*conn).serve()
      /snap/go/9028/src/net/http/server.go:1930 +0x12e4
  net/http.(*Server).Serve·dwrap·87()
      /snap/go/9028/src/net/http/server.go:3034 +0x58

Previous write at 0x00c00022c000 by goroutine 51:
  math/rand.(*rngSource).Uint64()
      /snap/go/9028/src/math/rand/rng.go:239 +0x44
  math/rand.(*rngSource).Int63()
      /snap/go/9028/src/math/rand/rng.go:234 +0x1f1
  math/rand.(*Rand).Int63()
      /snap/go/9028/src/math/rand/rand.go:84 +0xa8
  math/rand.(*Rand).Int31()
      /snap/go/9028/src/math/rand/rand.go:98 +0xb3
  math/rand.(*Rand).Int31n()
      /snap/go/9028/src/math/rand/rand.go:130 +0xae
  math/rand.(*Rand).Intn()
      /snap/go/9028/src/math/rand/rand.go:171 +0x48
  sigs.k8s.io/apiserver-network-proxy/pkg/server.(*DefaultBackendStorage).GetRandomBackend()
      /root/apiserver-network-proxy/pkg/server/backend_manager.go:301 +0x149
  sigs.k8s.io/apiserver-network-proxy/pkg/server.(*DefaultBackendManager).Backend()
      /root/apiserver-network-proxy/pkg/server/backend_manager.go:133 +0x104
  sigs.k8s.io/apiserver-network-proxy/pkg/server.(*ProxyServer).getBackend()
      /root/apiserver-network-proxy/pkg/server/server.go:178 +0x101
  sigs.k8s.io/apiserver-network-proxy/pkg/server.(*Tunnel).ServeHTTP()
      /root/apiserver-network-proxy/pkg/server/tunnel.go:79 +0xed1
  sigs.k8s.io/apiserver-network-proxy/tests.runHTTPConnProxyServer.func4()
      /root/apiserver-network-proxy/tests/proxy_test.go:489 +0xee
  net/http.HandlerFunc.ServeHTTP()
      /snap/go/9028/src/net/http/server.go:2047 +0x4d
  net/http.serverHandler.ServeHTTP()
      /snap/go/9028/src/net/http/server.go:2879 +0x89a
  net/http.(*conn).serve()
      /snap/go/9028/src/net/http/server.go:1930 +0x12e4
  net/http.(*Server).Serve·dwrap·87()
      /snap/go/9028/src/net/http/server.go:3034 +0x58

Goroutine 50 (running) created at:
  net/http.(*Server).Serve()
      /snap/go/9028/src/net/http/server.go:3034 +0x847
  sigs.k8s.io/apiserver-network-proxy/tests.runHTTPConnProxyServer.func6()
      /root/apiserver-network-proxy/tests/proxy_test.go:499 +0x50

Goroutine 51 (running) created at:
  net/http.(*Server).Serve()
      /snap/go/9028/src/net/http/server.go:3034 +0x847
  sigs.k8s.io/apiserver-network-proxy/tests.runHTTPConnProxyServer.func6()
      /root/apiserver-network-proxy/tests/proxy_test.go:499 +0x50
==================
```