### PR TITLE
exit client with error when no agents are available

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 )
 
@@ -114,7 +114,11 @@ func (t *grpcTunnel) serve(c clientConn) {
 			t.pendingDialLock.RUnlock()
 
 			if !ok {
-				klog.V(1).InfoS("DialResp not recognized; dropped", "connectionID", resp.ConnectID, "dialID", resp.Random)
+				klog.V(1).InfoS("DialResp not recognized; dropped", "connectionID", resp.ConnectID, "dialID", resp.Random, "error", resp.Error)
+				ch <- dialResult{
+					err:    resp.Error,
+					connid: resp.ConnectID,
+				}
 				return
 			} else {
 				result := dialResult{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -425,8 +425,13 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 				klog.ErrorS(err, "Failed to get a backend", "serverID", s.serverID)
 
 				resp := &client.Packet{
-					Type:    client.PacketType_DIAL_RSP,
-					Payload: &client.Packet_DialResponse{DialResponse: &client.DialResponse{Error: err.Error()}},
+					Type: client.PacketType_DIAL_RSP,
+					Payload: &client.Packet_DialResponse{
+						DialResponse: &client.DialResponse{
+							Error:  err.Error(),
+							Random: pkt.GetDialRequest().Random,
+						},
+					},
 				}
 				if err := stream.Send(resp); err != nil {
 					klog.V(5).Infoln("Failed to send DIAL_RSP for no backend", "error", err, "serverID", s.serverID)


### PR DESCRIPTION
If there are no agents available `DialContext` fails after 30s with  `dial timeout, backstop` which is not sufficient to tell if the agents are not available or the dial is failing for some other reason. 

This PR makes it fail quickly with the error message received. Like this,

`error: failed to get dialer for client, got failed to dial request 127.0.0.:8000, got No backend available`.

This will also exit the goroutine as soon as we know it is no longer needed and remove the dial from pending dials. 