### PR TITLE
rename pkg/agent/client to pkg/agent/agent

### DIFF
--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -73,7 +73,7 @@ func (a *Agent) runProxyConnection(o *options.GrpcProxyAgentOptions, stopCh <-ch
 		}),
 	}
 	cc := o.ClientSetConfig(dialOptions...)
-	cs := cc.NewAgentClientSet(stopCh)
+	cs := cc.NewAgentSet(stopCh)
 	cs.Serve()
 
 	return nil

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -19,7 +19,7 @@ func TestServeData_HTTP(t *testing.T) {
 	var err error
 	var stream agent.AgentService_ConnectClient
 	stopCh := make(chan struct{})
-	testClient := &Client{
+	testClient := &Agent{
 		connManager: newConnectionManager(),
 		stopCh:      stopCh,
 	}
@@ -115,7 +115,7 @@ func TestServeData_HTTP(t *testing.T) {
 func TestClose_Client(t *testing.T) {
 	var stream agent.AgentService_ConnectClient
 	stopCh := make(chan struct{})
-	testClient := &Client{
+	testClient := &Agent{
 		connManager: newConnectionManager(),
 		stopCh:      stopCh,
 	}

--- a/pkg/agent/agentset.go
+++ b/pkg/agent/agentset.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// nolint: golint
 // AgentSet consists of agents connected to each instance of an HA proxy server.
 type AgentSet struct {
 	mu     sync.Mutex        //protects the agents.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -615,7 +615,7 @@ func (s *ProxyServer) authenticateAgentViaToken(ctx context.Context) error {
 		return fmt.Errorf("Failed to validate authentication token, err:%v", err)
 	}
 
-	klog.V(2).Infoln("Client successfully authenticated via token")
+	klog.V(2).Infoln("Agent successfully authenticated via token")
 	return nil
 }
 
@@ -633,7 +633,7 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 
 	if s.AgentAuthenticationOptions.Enabled {
 		if err := s.authenticateAgentViaToken(stream.Context()); err != nil {
-			klog.ErrorS(err, "Client authentication failed", "agentID", agentID)
+			klog.ErrorS(err, "Agent authentication failed", "agentID", agentID)
 			return err
 		}
 	}

--- a/tests/ha_proxy_server_test.go
+++ b/tests/ha_proxy_server_test.go
@@ -129,7 +129,7 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 	var hc, cc int
 	for i := 0; i < 3; i++ {
 		time.Sleep(1 * time.Second)
-		hc, cc = clientset.HealthyClientsCount(), clientset.ClientsCount()
+		hc, cc = clientset.HealthyAgentsCount(), clientset.AgentsCount()
 		t.Logf("got %d clients, %d of them are healthy", hc, cc)
 		if hc == 3 && cc == 3 {
 			ready = true
@@ -167,7 +167,7 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 	ready = false
 	for i := 0; i < 3; i++ {
 		time.Sleep(1 * time.Second)
-		hc, cc = clientset.HealthyClientsCount(), clientset.ClientsCount()
+		hc, cc = clientset.HealthyAgentsCount(), clientset.AgentsCount()
 		t.Logf("got %d clients, %d of them are healthy", hc, cc)
 		if hc == 3 && (cc == 3 || cc == 4) {
 			ready = true

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -512,11 +512,11 @@ func runHTTPConnProxyServer() (proxy, func(), error) {
 	return proxy, cleanup, nil
 }
 
-func runAgent(addr string, stopCh <-chan struct{}) *agent.ClientSet {
+func runAgent(addr string, stopCh <-chan struct{}) *agent.AgentSet {
 	return runAgentWithID(uuid.New().String(), addr, stopCh)
 }
 
-func runAgentWithID(agentID, addr string, stopCh <-chan struct{}) *agent.ClientSet {
+func runAgentWithID(agentID, addr string, stopCh <-chan struct{}) *agent.AgentSet {
 	cc := agent.ClientSetConfig{
 		Address:       addr,
 		AgentID:       agentID,
@@ -524,7 +524,7 @@ func runAgentWithID(agentID, addr string, stopCh <-chan struct{}) *agent.ClientS
 		ProbeInterval: 100 * time.Millisecond,
 		DialOptions:   []grpc.DialOption{grpc.WithInsecure()},
 	}
-	client := cc.NewAgentClientSet(stopCh)
+	client := cc.NewAgentSet(stopCh)
 	client.Serve()
 	return client
 }


### PR DESCRIPTION
It is easy to confuse  `pkg/agent/client ` with `konnectivity-client/pkg/client`, especially if you are coming back to the code after a long time or in the middle of debugging session. 

This renaming should help to remove the confusion.



