### PR TITLE
konnectivity-client: ensure Close() is called for grpc.ClientConn in CreateSingleUseGrpcTunnel

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -76,6 +76,7 @@ func CreateSingleUseGrpcTunnel(ctx context.Context, address string, opts ...grpc
 
 	stream, err := grpcClient.Proxy(ctx)
 	if err != nil {
+		c.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
As part of the on-going investigation in https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/276.

If `grpcClient.Proxy(ctx)` from `CreateSingleUseGrpcTunnel` errors, then we never call Close() on the client connection. 

Signed-off-by: Andrew Sy Kim <andrewsy@google.com>