### PR TITLE
Remove gcloud tagging step for unpushed images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,8 +262,6 @@ release-staging: ## Builds and push container images to the staging bucket.
 release-alias-tag: # Adds the tag to the last build tag. BASE_REF comes from the cloudbuild.yaml
 	gcloud container images add-tag $(AGENT_FULL_IMAGE):$(TAG) $(AGENT_FULL_IMAGE):$(BASE_REF)
 	gcloud container images add-tag $(SERVER_FULL_IMAGE):$(TAG) $(SERVER_FULL_IMAGE):$(BASE_REF)
-	gcloud container images add-tag $(TEST_CLIENT_FULL_IMAGE):$(TAG) $(TEST_CLIENT_FULL_IMAGE):$(BASE_REF)
-	gcloud container images add-tag $(TEST_SERVER_FULL_IMAGE):$(TAG) $(TEST_SERVER_FULL_IMAGE):$(BASE_REF)
 
 ## --------------------------------------
 ## Cleanup / Verification


### PR DESCRIPTION
Fix docker push prow job failure: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/apiserver-network-proxy-push-images/1473458166879490048

We recently removed the proxy-test-client and http-server from being pushed to the container registry.

/assign @cheftako 