### PR TITLE
konnectivity-client: fix race condition with pending dials leading to goroutine leaks

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -130,6 +130,7 @@ func (t *grpcTunnel) serve(c clientConn) {
 					//   2. grpcTunnel.DialContext() returned early due to a dial timeout or the client canceling the context
 					//
 					// In either scenario, we should return here as this tunnel is no longer needed.
+					klog.V(1).InfoS("DialResp has no receiver; dropped", "connectionID", resp.ConnectID, "dialID", resp.Random)
 					return
 				}
 			}

--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -231,8 +231,10 @@ func (t *grpcTunnel) DialContext(ctx context.Context, protocol, address string) 
 		t.conns[res.connid] = c
 		t.connsLock.Unlock()
 	case <-time.After(30 * time.Second):
+		klog.V(5).InfoS("Timed out waiting for DialResp", "dialID", random)
 		return nil, errors.New("dial timeout, backstop")
 	case <-ctx.Done():
+		klog.V(5).InfoS("Context canceled waiting for DialResp", "ctxErr", ctx.Err(), "dialID", random)
 		return nil, errors.New("dial timeout, context")
 	}
 

--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -186,6 +186,7 @@ func (t *grpcTunnel) DialContext(ctx context.Context, protocol, address string) 
 	}
 
 	random := rand.Int63() /* #nosec G404 */
+	// This channel MUST NOT be buffered. The sender needs to know when we are not receiving things, so they can abort.
 	resCh := make(chan dialResult)
 	t.pendingDialLock.Lock()
 	t.pendingDial[random] = resCh


### PR DESCRIPTION
This fixes a race condition with how konnectivity-client handles pending dials, which led to goroutine leaks in both kube-apiserver and proxy-server. The race condition was possible due to the use of buffered channels for receiving results for pending dials. See https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/276#issuecomment-1055025833 for more details.

Signed-off-by: Andrew Sy Kim <andrewsy@google.com>