### PR TITLE
Avoid race between serve loop and DialContext receiving dial result

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -43,10 +43,17 @@ type dialResult struct {
 	connid int64
 }
 
+type pendingDial struct {
+	// resultCh is the channel to send the dial result to
+	resultCh chan<- dialResult
+	// cancelCh is the channel closed when resultCh no longer has a receiver
+	cancelCh <-chan struct{}
+}
+
 // grpcTunnel implements Tunnel
 type grpcTunnel struct {
 	stream          client.ProxyService_ProxyClient
-	pendingDial     map[int64]chan<- dialResult
+	pendingDial     map[int64]pendingDial
 	conns           map[int64]*conn
 	pendingDialLock sync.RWMutex
 	connsLock       sync.RWMutex
@@ -82,7 +89,7 @@ func CreateSingleUseGrpcTunnel(ctx context.Context, address string, opts ...grpc
 
 	tunnel := &grpcTunnel{
 		stream:             stream,
-		pendingDial:        make(map[int64]chan<- dialResult),
+		pendingDial:        make(map[int64]pendingDial),
 		conns:              make(map[int64]*conn),
 		readTimeoutSeconds: 10,
 	}
@@ -111,7 +118,7 @@ func (t *grpcTunnel) serve(c clientConn) {
 		case client.PacketType_DIAL_RSP:
 			resp := pkt.GetDialResponse()
 			t.pendingDialLock.RLock()
-			ch, ok := t.pendingDial[resp.Random]
+			pendingDial, ok := t.pendingDial[resp.Random]
 			t.pendingDialLock.RUnlock()
 
 			if !ok {
@@ -123,14 +130,16 @@ func (t *grpcTunnel) serve(c clientConn) {
 					connid: resp.ConnectID,
 				}
 				select {
-				case ch <- result:
-				default:
+				// try to send to the result channel
+				case pendingDial.resultCh <- result:
+				// unblock if the cancel channel is closed
+				case <-pendingDial.cancelCh:
 					// If there are no readers of the pending dial channel above, it means one of two things:
 					//   1. There was a second DIAL_RSP for the connection request (this is very unlikely but possible)
 					//   2. grpcTunnel.DialContext() returned early due to a dial timeout or the client canceling the context
 					//
 					// In either scenario, we should return here as this tunnel is no longer needed.
-					klog.V(1).InfoS("DialResp has no receiver; dropped", "connectionID", resp.ConnectID, "dialID", resp.Random)
+					klog.V(1).InfoS("Pending dial has been cancelled; dropped", "connectionID", resp.ConnectID, "dialID", resp.Random)
 					return
 				}
 			}
@@ -187,10 +196,16 @@ func (t *grpcTunnel) DialContext(ctx context.Context, protocol, address string) 
 	}
 
 	random := rand.Int63() /* #nosec G404 */
+
+	// This channel is closed once we're returning and no longer waiting on resultCh
+	cancelCh := make(chan struct{})
+	defer close(cancelCh)
+
 	// This channel MUST NOT be buffered. The sender needs to know when we are not receiving things, so they can abort.
 	resCh := make(chan dialResult)
+
 	t.pendingDialLock.Lock()
-	t.pendingDial[random] = resCh
+	t.pendingDial[random] = pendingDial{resultCh: resCh, cancelCh: cancelCh}
 	t.pendingDialLock.Unlock()
 	defer func() {
 		t.pendingDialLock.Lock()


### PR DESCRIPTION
Fixes a possible race between `case res := <-resCh` in `DialContext` and `case ch <- result:` in the `serve` loop.

If that race occurred, no leak would occur, but `DialContext` would wait for the timeout or context cancellation, then return a failure.

This PR changes the send/default select in `serve` to select between sending to the result channel and receiving from a cancel channel. This lets DialContext explicitly indicate when it is done waiting on the result channel.

Added a unit test test demonstrating the race where the `serve` loop processes the dial response before the `DialContext` function makes it to waiting on the result channel. The test fails on master and works on this PR.