### PR TITLE
konnectivity-client: close channels for connections that never received CLOSE_RSP

### DIFF
--- a/konnectivity-client/pkg/client/conn.go
+++ b/konnectivity-client/pkg/client/conn.go
@@ -30,6 +30,8 @@ import (
 // successful delivery of CLOSE_REQ.
 const CloseTimeout = 10 * time.Second
 
+var errConnCloseTimeout = errors.New("close timeout")
+
 // conn is an implementation of net.Conn, where the data is transported
 // over an established tunnel defined by a gRPC service ProxyService.
 type conn struct {
@@ -151,5 +153,5 @@ func (c *conn) Close() error {
 	case <-time.After(CloseTimeout):
 	}
 
-	return errors.New("close timeout")
+	return errConnCloseTimeout
 }

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -235,6 +235,59 @@ func TestProxyHandle_SlowContext_GRPC(t *testing.T) {
 	}
 }
 
+func TestProxyHandle_ContextCancelled_GRPC(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	slowServer := newEchoServer("hello")
+	slowServer.wchan = make(chan struct{})
+	server := httptest.NewServer(slowServer)
+	defer server.Close()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	proxy, cleanup, err := runGRPCProxyServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	runAgent(proxy.agent, stopCh)
+
+	// Wait for agent to register on proxy server
+	time.Sleep(time.Second)
+
+	// run test client
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		cancel()
+		close(slowServer.wchan)
+	}()
+
+	c := &http.Client{
+		Transport: &http.Transport{
+			DialContext: tunnel.DialContext,
+		},
+	}
+
+	// TODO: handle case where there is no context on the request.
+	req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = c.Do(req)
+	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Error("Expected error when context is cancelled, did not receive error")
+	}
+}
+
 func TestProxy_LargeResponse(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -183,8 +183,7 @@ func TestProxyHandle_DoneContext_GRPC(t *testing.T) {
 }
 
 func TestProxyHandle_SlowContext_GRPC(t *testing.T) {
-	// TODO: enable goleak validation after https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/340
-	// defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	slowServer := newEchoServer("hello")
 	slowServer.wchan = make(chan struct{})


### PR DESCRIPTION
This PR is a follow-up to https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/325 and fixes a goroutine leak that was reproducible in `TestProxyHandle_SlowContext_GRPC` when a client closes a transport before the CLOSE_RSP is received:
```
--- FAIL: TestProxyHandle_SlowContext_GRPC (4.47s)                                                                                                                                                 
    leaks.go:78: found unexpected goroutines:                                                                                                                                                      
        [Goroutine 2057 in state chan receive, with sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client.(*conn).Read on top of the stack:                                           
        goroutine 2057 [chan receive]:                                                                                                                                                             
        sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client.(*conn).Read(0xc001673860, {0xc0022fe000, 0x1000, 0x5f3513?})                                                           
                /usr/local/google/home/andrewsy/go/src/sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/conn.go:74 +0xc5                                                         
        net/http.(*persistConn).Read(0xc0022fa120, {0xc0022fe000, 0x1000, 0x1000})                                                                                                                 
                /usr/lib/google-golang/src/net/http/transport.go:1931 +0x110                                                                                                                       
        bufio.(*Reader).fill(0xc0005afec0)                                                                                                                                                         
                /usr/lib/google-golang/src/bufio/bufio.go:106 +0x294                                                                                                                               
        bufio.(*Reader).Peek(0xc0005afec0, 0x1)                                                                                                                                                    
                /usr/lib/google-golang/src/bufio/bufio.go:144 +0xcc                                                                                                                                
        net/http.(*persistConn).readLoop(0xc0022fa120)                                                                                                                                             
                /usr/lib/google-golang/src/net/http/transport.go:2092 +0x2bc                                                                                                                       
        created by net/http.(*Transport).dialConn                                                                                                                                                  
                /usr/lib/google-golang/src/net/http/transport.go:1752 +0x25c5   
```

Fixes https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/340