### PR TITLE
Simple konn-client cleanups

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -300,14 +300,15 @@ func (t *grpcTunnel) serve(tunnelCtx context.Context) {
 			resp := pkt.GetCloseResponse()
 			conn, ok := t.conns.get(resp.ConnectID)
 
-			if ok {
-				close(conn.readCh)
-				conn.closeCh <- resp.Error
-				close(conn.closeCh)
-				t.conns.remove(resp.ConnectID)
-				return
+			if !ok {
+				klog.V(1).InfoS("Connection not recognized", "connectionID", resp.ConnectID)
+				continue
 			}
-			klog.V(1).InfoS("connection not recognized", "connectionID", resp.ConnectID)
+			close(conn.readCh)
+			conn.closeCh <- resp.Error
+			close(conn.closeCh)
+			t.conns.remove(resp.ConnectID)
+			return
 		}
 	}
 }


### PR DESCRIPTION
This PR doesn't make _any_ behavior change, just cleans up the code to reduce unneeded indentations and just tries to filter out errors first for better readability.

If when you review this you think "hm, do we want to close the connection in this case instead of just continue on the loop?", I wonder the same and opened https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/338 to investigate that. This PR, though, is just making the current code more readable. The bugfix (if any ends up being needed) can be discussed in that issue.