### PR TITLE
Update golang version as part of security fix.

### DIFF
--- a/artifacts/images/agent-build.Dockerfile
+++ b/artifacts/images/agent-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-agent binary
-FROM golang:1.17.5 as builder
+FROM golang:1.17.7 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/client-build.Dockerfile
+++ b/artifacts/images/client-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the client binary
-FROM golang:1.17.5 as builder
+FROM golang:1.17.7 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/server-build.Dockerfile
+++ b/artifacts/images/server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-server binary
-FROM golang:1.17.5 as builder
+FROM golang:1.17.7 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/test-server-build.Dockerfile
+++ b/artifacts/images/test-server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the http test server binary
-FROM golang:1.17.5 as builder
+FROM golang:1.17.7 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy


### PR DESCRIPTION
The following CVEs require updating to go 1.17.7
- CVE-2022-23772
- CVE-2022-23773
- CVE-2022-23806
- CVE-2022-23772
- CVE-2022-23773
- CVE-2022-23806