### PR TITLE
Fixes connection leakage due to close timeout

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -242,6 +242,7 @@ func (t *grpcTunnel) DialContext(ctx context.Context, protocol, address string) 
 		c.connID = res.connid
 		c.readCh = make(chan []byte, 10)
 		c.closeCh = make(chan string, 1)
+		c.finishedCh = make(chan bool, 1)
 		t.connsLock.Lock()
 		t.conns[res.connid] = c
 		t.connsLock.Unlock()


### PR DESCRIPTION
we noticed some connection leakage happening when the connections are not gracefully closed. the `conn#Read(..)` function will not return infinitely even if the `conn#Close(..)` called due to client-side timeout. this will cause memory leakage when ANP is working under an unstable-ish network environment. this PR notifies the `Read(..)` to exit w/ an error when the conn is aborted from client-side.