### PR TITLE
agent: reduce noisy error logs when trying to write to a closed network connection

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -507,9 +507,10 @@ func (a *Client) remoteToProxy(connID int64, ctx *connContext) {
 			klog.V(2).InfoS("connection EOF", "connectionID", connID)
 			return
 		} else if err != nil {
+			// "use of closed network connection" errors are expected upon receiving CLOSE_REQ
+			// If connID doesn't exist in connManager, we assume the connection was meant to be closed.
 			if _, ok := a.connManager.Get(connID); !ok {
-				// Normal when receive a CLOSE_REQ
-				klog.V(5).InfoS("read from a normally closed connection", "connectionID", connID, "err", err)
+				klog.V(5).InfoS("reading to a closed connection", "connectionID", connID, "err", err)
 			} else {
 				klog.ErrorS(err, "connection read failure", "connectionID", connID)
 			}


### PR DESCRIPTION
This is a follow-up PR to https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/317, where we reduced error logs whenever reading from a closed network connection. This PR introduces a similar fix but also from the writer.