### PR TITLE
Agent: Respect HTTPS_PROXY env vars for proxied connections

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -426,7 +426,7 @@ func (a *Client) Serve() {
 			go func() {
 				defer close(dialDone)
 				start := time.Now()
-				conn, err := net.DialTimeout(dialReq.Protocol, dialReq.Address, dialTimeout)
+				conn, err := dial(dialReq.Protocol, dialReq.Address, dialTimeout)
 				if err != nil {
 					dialResp.GetDialResponse().Error = err.Error()
 					if err := a.Send(dialResp); err != nil {

--- a/pkg/agent/proxy_dialer.go
+++ b/pkg/agent/proxy_dialer.go
@@ -1,0 +1,105 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+func dial(network, address string, timeout time.Duration) (net.Conn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return proxy.Dial(ctx, network, address)
+}
+
+func init() {
+	// The proxy package only interprets the ALL_PROXY variable.
+	os.Setenv("ALL_PROXY", os.Getenv("HTTPS_PROXY"))
+	// The proxy itself might be using either http or https, so we have to
+	// register both dialers.
+	proxy.RegisterDialerType("http", newHTTPDialer)
+	proxy.RegisterDialerType("https", newHTTPDialer)
+}
+
+func newHTTPDialer(proxyURL *url.URL, forwardDialer proxy.Dialer) (proxy.Dialer, error) {
+	return &httpProxyDialer{proxyURL: proxyURL, forwardDial: forwardDialer.Dial}, nil
+}
+
+// Everything below is a copied from https://github.com/fasthttp/websocket/blob/2f8e79d2aac1e8e5a06518870e872b15608cea90/proxy.go
+// as the golang.org/x/net/proxy package only supports socks5 proxies, but does allow registering additional protocols.
+type httpProxyDialer struct {
+	proxyURL    *url.URL
+	forwardDial func(network, addr string) (net.Conn, error)
+}
+
+func (hpd *httpProxyDialer) Dial(network string, addr string) (net.Conn, error) {
+	hostPort, _ := hostPortNoPort(hpd.proxyURL)
+	conn, err := hpd.forwardDial(network, hostPort)
+	if err != nil {
+		return nil, err
+	}
+
+	connectHeader := make(http.Header)
+	if user := hpd.proxyURL.User; user != nil {
+		proxyUser := user.Username()
+		if proxyPassword, passwordSet := user.Password(); passwordSet {
+			credential := base64.StdEncoding.EncodeToString([]byte(proxyUser + ":" + proxyPassword))
+			connectHeader.Set("Proxy-Authorization", "Basic "+credential)
+		}
+	}
+
+	connectReq := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Opaque: addr},
+		Host:   addr,
+		Header: connectHeader,
+	}
+
+	if err := connectReq.Write(conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	// Read response. It's OK to use and discard buffered reader here becaue
+	// the remote server does not speak until spoken to.
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, connectReq)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	if resp.StatusCode != 200 {
+		conn.Close()
+		f := strings.SplitN(resp.Status, " ", 2)
+		return nil, errors.New(f[1])
+	}
+	return conn, nil
+}
+
+func hostPortNoPort(u *url.URL) (hostPort, hostNoPort string) {
+	hostPort = u.Host
+	hostNoPort = u.Host
+	if i := strings.LastIndex(u.Host, ":"); i > strings.LastIndex(u.Host, "]") {
+		hostNoPort = hostNoPort[:i]
+	} else {
+		switch u.Scheme {
+		case "wss":
+			hostPort += ":443"
+		case "https":
+			hostPort += ":443"
+		default:
+			hostPort += ":80"
+		}
+	}
+	return hostPort, hostNoPort
+}


### PR DESCRIPTION
Currently, the HTTP{,S}_PROXY env vars are only respected when
connecting to the server but not when creating outgoing connections.
This fixes that.

The usecase for needing this is that controlplane components need to
access services that are only available from within the cluster network
when using a http connect proxy.