### PR TITLE
Reduce proxy-server log noise.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -266,7 +266,7 @@ func (s *ProxyServer) removeBackend(agentID string, conn agent.AgentService_Conn
 }
 
 func (s *ProxyServer) addFrontend(agentID string, connID int64, p *ProxyClientConnection) {
-	klog.V(2).InfoS("Register frontend for agent", "frontend", p, "agentID", agentID, "connectionID", connID)
+	klog.V(2).InfoS("Register frontend for agent", "agentID", agentID, "connectionID", connID)
 	s.fmu.Lock()
 	defer s.fmu.Unlock()
 	if _, ok := s.frontends[agentID]; !ok {
@@ -287,7 +287,7 @@ func (s *ProxyServer) removeFrontend(agentID string, connID int64) {
 		klog.V(2).InfoS("Cannot find connection for agent in the frontends", "connectionID", connID, "agentID", agentID)
 		return
 	}
-	klog.V(2).InfoS("Remove frontend for agent", "frontend", conns[connID], "agentID", agentID, "connectionID", connID)
+	klog.V(2).InfoS("Remove frontend for agent", "agentID", agentID, "connectionID", connID)
 	delete(s.frontends[agentID], connID)
 	if len(s.frontends[agentID]) == 0 {
 		delete(s.frontends, agentID)


### PR DESCRIPTION
Note that agentID and connectionID are already present in structured
logs; including the frontend doesn't add much value.

Example logs:
```
I1111 18:45:04.309310       1 server.go:262] "Register frontend for agent" frontend=&{Mode:grpc Grpc:0xc002874760 HTTP:<nil> connected:0xc002640f60 connectID:96 agentID:df752e37-615c-4ce9-a973-99136e1a8de5 start:{wall:13860803171892147580 ext:58170314102322 loc:0x2198760} backend:0xc0001b3fe0} agentID="df752e37-615c-4ce9-a973-99136e1a8de5" connectionID=96
I1111 18:51:25.308754       1 server.go:283] "Remove frontend for agent" frontend=&{Mode:grpc Grpc:0xc002874760 HTTP:<nil> connected:0xc002640f60 connectID:96 agentID:df752e37-615c-4ce9-a973-99136e1a8de5 start:{wall:13860803171892147580 ext:58170314102322 loc:0x2198760} backend:0xc0001b3fe0} agentID="df752e37-615c-4ce9-a973-99136e1a8de5" connectionID=96
```
