### PR TITLE
WarnOnChannelLimit improvements

### DIFF
--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -107,7 +107,7 @@ func (p *Proxy) run(o *options.ProxyRunOptions) error {
 	if err != nil {
 		return err
 	}
-	server := server.NewProxyServer(o.ServerID, ps, int(o.ServerCount), authOpt, o.WarnOnChannelLimit)
+	server := server.NewProxyServer(o.ServerID, ps, int(o.ServerCount), authOpt)
 
 	frontendStop, err := p.runFrontendServer(ctx, o, server)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -371,7 +371,7 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 	go s.serveRecvFrontend(stream, recvCh)
 
 	defer func() {
-		klog.V(2).InfoS("Receive channel on Proxy is stopping", "userAgent", userAgent, "serverID", s.serverID)
+		klog.V(2).InfoS("Receive channel from frontend is stopping", "userAgent", userAgent, "serverID", s.serverID)
 		close(recvCh)
 	}()
 
@@ -380,7 +380,7 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 		for {
 			in, err := stream.Recv()
 			if err == io.EOF {
-				klog.V(2).InfoS("Stream closed on Proxy", "userAgent", userAgent, "serverID", s.serverID)
+				klog.V(2).InfoS("Receive stream from frontend closed", "userAgent", userAgent, "serverID", s.serverID)
 				close(stopCh)
 				return
 			}
@@ -398,7 +398,7 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 			select {
 			case recvCh <- in: // Send didn't block, carry on.
 			default: // Send blocked; record it and try again.
-				klog.V(2).InfoS("Receive channel on Proxy is full", "userAgent", userAgent, "serverID", s.serverID)
+				klog.V(2).InfoS("Receive channel from frontend is full", "userAgent", userAgent, "serverID", s.serverID)
 				fullRecvChannelMetric := metrics.Metrics.FullRecvChannel(metrics.Proxy)
 				fullRecvChannelMetric.Inc()
 				recvCh <- in
@@ -667,7 +667,7 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 	go s.serveRecvBackend(backend, stream, agentID, recvCh)
 
 	defer func() {
-		klog.V(2).InfoS("Receive channel on Connect is stopping", "agentID", agentID, "serverID", s.serverID)
+		klog.V(2).InfoS("Receive channel from agent is stopping", "agentID", agentID, "serverID", s.serverID)
 		close(recvCh)
 	}()
 
@@ -676,12 +676,12 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 		for {
 			in, err := stream.Recv()
 			if err == io.EOF {
-				klog.V(2).InfoS("Stream closed on Connect", "agentID", agentID, "serverID", s.serverID)
+				klog.V(2).InfoS("Receive stream from agent is closed", "agentID", agentID, "serverID", s.serverID)
 				close(stopCh)
 				return
 			}
 			if err != nil {
-				klog.ErrorS(err, "stream read failure")
+				klog.ErrorS(err, "Receive stream from agent read failure")
 				stopCh <- err
 				close(stopCh)
 				return
@@ -690,7 +690,7 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 			select {
 			case recvCh <- in: // Send didn't block, carry on.
 			default: // Send blocked; record it and try again.
-				klog.V(2).InfoS("Receive channel on Connect is full", "agentID", agentID, "serverID", s.serverID)
+				klog.V(2).InfoS("Receive channel from agent is full", "agentID", agentID, "serverID", s.serverID)
 				fullRecvChannelMetric := metrics.Metrics.FullRecvChannel(metrics.Connect)
 				fullRecvChannelMetric.Inc()
 				recvCh <- in

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -399,7 +399,10 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 			case recvCh <- in: // Send didn't block, carry on.
 			default: // Send blocked; record it and try again.
 				klog.V(2).InfoS("Receive channel on Proxy is full", "userAgent", userAgent, "serverID", s.serverID)
+				fullRecvChannelMetric := metrics.Metrics.FullRecvChannel(metrics.Proxy)
+				fullRecvChannelMetric.Inc()
 				recvCh <- in
+				fullRecvChannelMetric.Dec()
 			}
 		}
 	}()
@@ -688,7 +691,10 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 			case recvCh <- in: // Send didn't block, carry on.
 			default: // Send blocked; record it and try again.
 				klog.V(2).InfoS("Receive channel on Connect is full", "agentID", agentID, "serverID", s.serverID)
+				fullRecvChannelMetric := metrics.Metrics.FullRecvChannel(metrics.Connect)
+				fullRecvChannelMetric.Inc()
 				recvCh <- in
+				fullRecvChannelMetric.Dec()
 			}
 		}
 	}()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -167,9 +167,7 @@ func TestAgentTokenAuthenticationErrorsToken(t *testing.T) {
 				KubernetesClient:    kcs,
 				AgentNamespace:      tc.wantNamespace,
 				AgentServiceAccount: tc.wantServiceAccount,
-			},
-				false,
-			)
+			})
 
 			err := p.Connect(conn)
 			if tc.wantError {
@@ -192,7 +190,7 @@ func TestAddRemoveFrontends(t *testing.T) {
 	agent2ConnID2 := new(ProxyClientConnection)
 	agent3ConnID1 := new(ProxyClientConnection)
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, false)
+	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil)
 	p.addFrontend("agent1", int64(1), agent1ConnID1)
 	p.removeFrontend("agent1", int64(1))
 	expectedFrontends := make(map[string]map[int64]*ProxyClientConnection)
@@ -200,7 +198,7 @@ func TestAddRemoveFrontends(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	p = NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, false)
+	p = NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil)
 	p.addFrontend("agent1", int64(1), agent1ConnID1)
 	p.addFrontend("agent1", int64(2), agent1ConnID2)
 	p.addFrontend("agent2", int64(1), agent2ConnID1)
@@ -257,7 +255,7 @@ func baseServerProxyTestWithoutBackend(t *testing.T, validate func(*agentmock.Mo
 	defer ctrl.Finish()
 
 	frontendConn := prepareFrontendConn(ctrl)
-	proxyServer := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, true)
+	proxyServer := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{})
 
 	validate(frontendConn)
 
@@ -274,7 +272,7 @@ func baseServerProxyTestWithBackend(t *testing.T, validate func(*agentmock.MockA
 	frontendConn := prepareFrontendConn(ctrl)
 
 	// prepare proxy server
-	proxyServer := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, true)
+	proxyServer := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{})
 
 	agentConn := prepareAgentConnMD(ctrl, proxyServer)
 

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -505,7 +505,7 @@ func runGRPCProxyServerWithServerCount(serverCount int) (proxy, *server.ProxySer
 	var err error
 	var lis, lis2 net.Listener
 
-	server := server.NewProxyServer(uuid.New().String(), []server.ProxyStrategy{server.ProxyStrategyDefault}, serverCount, &server.AgentTokenAuthenticationOptions{}, false)
+	server := server.NewProxyServer(uuid.New().String(), []server.ProxyStrategy{server.ProxyStrategyDefault}, serverCount, &server.AgentTokenAuthenticationOptions{})
 	grpcServer := grpc.NewServer()
 	agentServer := grpc.NewServer()
 	cleanup := func() {
@@ -544,7 +544,7 @@ func runGRPCProxyServerWithServerCount(serverCount int) (proxy, *server.ProxySer
 func runHTTPConnProxyServer() (proxy, func(), error) {
 	ctx := context.Background()
 	var proxy proxy
-	s := server.NewProxyServer(uuid.New().String(), []server.ProxyStrategy{server.ProxyStrategyDefault}, 0, &server.AgentTokenAuthenticationOptions{}, false)
+	s := server.NewProxyServer(uuid.New().String(), []server.ProxyStrategy{server.ProxyStrategyDefault}, 0, &server.AgentTokenAuthenticationOptions{})
 	agentServer := grpc.NewServer()
 
 	agentproto.RegisterAgentServiceServer(agentServer, s)


### PR DESCRIPTION
1. Use a thread-safe approach for detecting full channels, always enable the warning log, and deprecate the associated flag.
2. Add a `full_receive_channels` gauge metric. The metric is incremented when a send is blocked on a full channel, and decremented when the send goes through successfully.

Any guidance on how to test this would be appreciated.