### PR TITLE
Update to go 1.17.12 to fix various security issues

### DIFF
--- a/artifacts/images/agent-build.Dockerfile
+++ b/artifacts/images/agent-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-agent binary
-FROM golang:1.17.8 as builder
+FROM golang:1.17.12 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/client-build.Dockerfile
+++ b/artifacts/images/client-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the client binary
-FROM golang:1.17.8 as builder
+FROM golang:1.17.12 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/server-build.Dockerfile
+++ b/artifacts/images/server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-server binary
-FROM golang:1.17.8 as builder
+FROM golang:1.17.12 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/test-server-build.Dockerfile
+++ b/artifacts/images/test-server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the http test server binary
-FROM golang:1.17.8 as builder
+FROM golang:1.17.12 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy


### PR DESCRIPTION
go 1.17.9
---------
- CVE-2022-28327
- CVE-2022-24675

go 1.17.10
----------
- CVE-2022-29526

go 1.17.11
----------
- CVE-2022-30580
- CVE-2022-30634
- CVE-2022-30629
- CVE-2022-29804

go 1.17.12
----------
- CVE-2022-30630
- CVE-2022-30631
- CVE-2022-30633
- CVE-2022-30632
- CVE-2022-28131
- CVE-2022-30635
- CVE-2022-1962
- CVE-2022-32148
- CVE-2022-1705