### PR TITLE
Fix HA test to be re-runnable

### DIFF
--- a/tests/ha_proxy_server_test.go
+++ b/tests/ha_proxy_server_test.go
@@ -45,6 +45,11 @@ func (lb *tcpLB) serve(stopCh chan struct{}) string {
 	}
 
 	go func() {
+		<-stopCh
+		ln.Close()
+	}()
+
+	go func() {
 		for {
 			select {
 			case <-stopCh:


### PR DESCRIPTION
The HA test wasn't properly shutting down the LB listener (since it's blocked on accept, so never gets to evaluate `stopCh`). Also, dynamically assign a port in case `:8000` is in use.