### PR TITLE
Test cleanup

### DIFF
--- a/tests/agent_disconnect_test.go
+++ b/tests/agent_disconnect_test.go
@@ -50,7 +50,7 @@ func TestProxy_Agent_Disconnect_HTTP_Persistent_Connection(t *testing.T) {
 			defer cleanup()
 
 			runAgent(proxy.agent, stopCh)
-			waitForBackends(t, 1, proxy.server)
+			waitForConnectedAgentCount(t, 1, proxy.server)
 
 			// run test client
 
@@ -67,7 +67,7 @@ func TestProxy_Agent_Disconnect_HTTP_Persistent_Connection(t *testing.T) {
 			close(stopCh)
 
 			// Wait for the agent to disconnect
-			waitForBackends(t, 0, proxy.server)
+			waitForConnectedAgentCount(t, 0, proxy.server)
 
 			// Reuse same client to make the request
 			_, err = clientRequest(c, server.URL)
@@ -114,7 +114,7 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 			defer cleanup()
 
 			cs1 := runAgent(proxy.agent, stopCh)
-			waitForHealthyClients(t, 1, cs1)
+			waitForConnectedServerCount(t, 1, cs1)
 
 			// run test client
 
@@ -130,13 +130,13 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 			close(stopCh)
 
 			// Wait for the agent to disconnect
-			waitForBackends(t, 0, proxy.server)
+			waitForConnectedAgentCount(t, 0, proxy.server)
 
 			// Reconnect agent
 			stopCh2 := make(chan struct{})
 			defer close(stopCh2)
 			cs2 := runAgent(proxy.agent, stopCh2)
-			waitForHealthyClients(t, 1, cs2)
+			waitForConnectedServerCount(t, 1, cs2)
 
 			// Proxy requests should work again after agent reconnects
 			c2, err := tc.clientFunction(ctx, proxy.front, server.URL)

--- a/tests/agent_disconnect_test.go
+++ b/tests/agent_disconnect_test.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
 )
 
@@ -51,13 +50,7 @@ func TestProxy_Agent_Disconnect_HTTP_Persistent_Connection(t *testing.T) {
 			defer cleanup()
 
 			runAgent(proxy.agent, stopCh)
-
-			// Wait for agent to register on proxy server
-			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
-
-				ready, _ := proxy.server.Readiness.Ready()
-				return ready, nil
-			})
+			waitForBackends(t, 1, proxy.server)
 
 			// run test client
 
@@ -74,10 +67,7 @@ func TestProxy_Agent_Disconnect_HTTP_Persistent_Connection(t *testing.T) {
 			close(stopCh)
 
 			// Wait for the agent to disconnect
-			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
-				ready, _ := proxy.server.Readiness.Ready()
-				return !ready, nil
-			})
+			waitForBackends(t, 0, proxy.server)
 
 			// Reuse same client to make the request
 			_, err = clientRequest(c, server.URL)
@@ -123,13 +113,8 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 			}
 			defer cleanup()
 
-			runAgent(proxy.agent, stopCh)
-
-			// Wait for agent to register on proxy server
-			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
-				ready, _ := proxy.server.Readiness.Ready()
-				return ready, nil
-			})
+			cs1 := runAgent(proxy.agent, stopCh)
+			waitForHealthyClients(t, 1, cs1)
 
 			// run test client
 
@@ -145,21 +130,13 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 			close(stopCh)
 
 			// Wait for the agent to disconnect
-			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
-				ready, _ := proxy.server.Readiness.Ready()
-				return !ready, nil
-			})
+			waitForBackends(t, 0, proxy.server)
 
 			// Reconnect agent
 			stopCh2 := make(chan struct{})
-			runAgent(proxy.agent, stopCh2)
 			defer close(stopCh2)
-
-			// Wait for agent to register on proxy server
-			wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
-				ready, _ := proxy.server.Readiness.Ready()
-				return ready, nil
-			})
+			cs2 := runAgent(proxy.agent, stopCh2)
+			waitForHealthyClients(t, 1, cs2)
 
 			// Proxy requests should work again after agent reconnects
 			c2, err := tc.clientFunction(ctx, proxy.front, server.URL)

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -131,8 +131,8 @@ func TestConcurrentClientRequest(t *testing.T) {
 	// Run two agents
 	cs1 := runAgent(proxy.agent, stopCh)
 	cs2 := runAgent(proxy.agent, stopCh)
-	waitForHealthyClients(t, 1, cs1)
-	waitForHealthyClients(t, 1, cs2)
+	waitForConnectedServerCount(t, 1, cs1)
+	waitForConnectedServerCount(t, 1, cs2)
 
 	client1 := getTestClient(proxy.front, t)
 	client2 := getTestClient(proxy.front, t)

--- a/tests/concurrent_test.go
+++ b/tests/concurrent_test.go
@@ -29,7 +29,7 @@ func TestProxy_ConcurrencyGRPC(t *testing.T) {
 	defer cleanup()
 
 	clientset := runAgent(proxy.agent, stopCh)
-	waitForHealthyClients(t, 1, clientset)
+	waitForConnectedServerCount(t, 1, clientset)
 
 	// run test client
 	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())
@@ -88,7 +88,7 @@ func TestProxy_ConcurrencyHTTP(t *testing.T) {
 	defer cleanup()
 
 	clientset := runAgent(proxy.agent, stopCh)
-	waitForHealthyClients(t, 1, clientset)
+	waitForConnectedServerCount(t, 1, clientset)
 
 	// run test clients
 	var wg sync.WaitGroup
@@ -153,7 +153,7 @@ func TestAgent_MultipleConn(t *testing.T) {
 			defer cleanup()
 
 			cs1 := runAgentWithID("multipleAgentConn", proxy.agent, stopCh)
-			waitForHealthyClients(t, 1, cs1)
+			waitForConnectedServerCount(t, 1, cs1)
 			defer close(stopCh)
 
 			// run test client
@@ -177,10 +177,10 @@ func TestAgent_MultipleConn(t *testing.T) {
 			// This simulates the scenario where a proxy agent established connections with HA proxy server
 			// and creates multiple connections with the same proxy server
 			cs2 := runAgentWithID("multipleAgentConn", proxy.agent, stopCh2)
-			waitForHealthyClients(t, 1, cs2)
+			waitForConnectedServerCount(t, 1, cs2)
 			close(stopCh2)
 			// Wait for the server to run cleanup routine
-			waitForBackends(t, 1, proxy.server)
+			waitForConnectedAgentCount(t, 1, proxy.server)
 			close(waitServer.respondCh)
 
 			<-fcnStopCh

--- a/tests/ha_proxy_server_test.go
+++ b/tests/ha_proxy_server_test.go
@@ -135,6 +135,9 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 
 	clientset := runAgent(lbAddr, stopCh)
 	waitForConnectedServerCount(t, 3, clientset)
+	if cc := clientset.ClientsCount(); cc != 3 {
+		t.Fatalf("Expected 3 clients, got %d", cc)
+	}
 
 	// run test client
 	testProxyServer(t, proxy[0].front, server.URL)
@@ -163,6 +166,9 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 
 	// wait for the new server to be connected.
 	waitForConnectedServerCount(t, 3, clientset)
+	if cc := clientset.ClientsCount(); cc != 3 && cc != 4 {
+		t.Fatalf("Expected 3 or 4 clients, got %d", cc)
+	}
 
 	// run test client
 	testProxyServer(t, proxy[1].front, server.URL)

--- a/tests/ha_proxy_server_test.go
+++ b/tests/ha_proxy_server_test.go
@@ -134,7 +134,7 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 	lbAddr := lb.serve(stopCh)
 
 	clientset := runAgent(lbAddr, stopCh)
-	waitForHealthyClients(t, 3, clientset)
+	waitForConnectedServerCount(t, 3, clientset)
 
 	// run test client
 	testProxyServer(t, proxy[0].front, server.URL)
@@ -148,7 +148,7 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 	cleanups[0]()
 
 	// give the agent some time to detect the disconnection
-	waitForHealthyClients(t, 2, clientset)
+	waitForConnectedServerCount(t, 2, clientset)
 
 	proxy4, _, cleanup4, err := runGRPCProxyServerWithServerCount(haServerCount)
 	if err != nil {
@@ -162,7 +162,7 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 	}()
 
 	// wait for the new server to be connected.
-	waitForHealthyClients(t, 3, clientset)
+	waitForConnectedServerCount(t, 3, clientset)
 
 	// run test client
 	testProxyServer(t, proxy[1].front, server.URL)

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -155,8 +155,10 @@ func TestProxyHandleDialError_GRPC(t *testing.T) {
 	invalidServer.Close()
 
 	_, err = c.Get(url)
-	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+	if err == nil {
 		t.Error("Expected error when destination is unreachable, did not receive error")
+	} else if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("Unexpected error: %v", err)
 	}
 }
 
@@ -182,8 +184,10 @@ func TestProxyHandle_DoneContext_GRPC(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), -time.Second)
 	defer cancel()
 	_, err = client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())
-	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+	if err == nil {
 		t.Error("Expected error when context is cancelled, did not receive error")
+	} else if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("Unexpected error: %v", err)
 	}
 }
 
@@ -232,8 +236,10 @@ func TestProxyHandle_SlowContext_GRPC(t *testing.T) {
 	}
 
 	_, err = c.Do(req)
-	if err == nil || !strings.Contains(err.Error(), "context deadline exceeded") {
+	if err == nil {
 		t.Error("Expected error when context is cancelled, did not receive error")
+	} else if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("Unexpected error: %v", err)
 	}
 }
 
@@ -282,8 +288,10 @@ func TestProxyHandle_ContextCancelled_GRPC(t *testing.T) {
 	}
 
 	_, err = c.Do(req)
-	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+	if err == nil {
 		t.Error("Expected error when context is cancelled, did not receive error")
+	} else if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("Unexpected error: %v", err)
 	}
 }
 
@@ -463,8 +471,10 @@ func TestFailedDial_HTTPCONN(t *testing.T) {
 	}
 
 	_, err = c.Get(server.URL)
-	if err == nil || !strings.Contains(err.Error(), "connection reset by peer") {
+	if err == nil {
 		t.Error(err)
+	} else if !strings.Contains(err.Error(), "connection reset by peer") {
+		t.Errorf("Unexpected error: %v", err)
 	}
 
 	err = wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -459,13 +459,12 @@ func TestFailedDial_HTTPCONN(t *testing.T) {
 		t.Error(err)
 	}
 
-	for i := 0; i < 20; i++ {
-		if proxy.getActiveHTTPConnectConns() == 0 {
-			return
-		}
-		time.Sleep(time.Millisecond * 10)
+	err = wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		return proxy.getActiveHTTPConnectConns() == 0, nil
+	})
+	if err != nil {
+		t.Errorf("while waiting for connection to be closed: %v", err)
 	}
-	t.Errorf("expected connection to eventually be closed")
 }
 
 func localAddr(addr net.Addr) string {

--- a/tests/readiness_test.go
+++ b/tests/readiness_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"testing"
-	"time"
 )
 
 func TestReadiness(t *testing.T) {
@@ -20,10 +19,8 @@ func TestReadiness(t *testing.T) {
 		t.Fatalf("expected not ready")
 	}
 
-	runAgent(proxy.agent, stopCh)
-
-	// Wait for agent to register on proxy server
-	time.Sleep(time.Second)
+	clientset := runAgent(proxy.agent, stopCh)
+	waitForHealthyClients(t, 1, clientset)
 
 	ready, _ = server.Readiness.Ready()
 	if !ready {

--- a/tests/readiness_test.go
+++ b/tests/readiness_test.go
@@ -20,7 +20,7 @@ func TestReadiness(t *testing.T) {
 	}
 
 	clientset := runAgent(proxy.agent, stopCh)
-	waitForHealthyClients(t, 1, clientset)
+	waitForConnectedServerCount(t, 1, clientset)
 
 	ready, _ = server.Readiness.Ready()
 	if !ready {

--- a/tests/tcp_server_test.go
+++ b/tests/tcp_server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc"
 	"k8s.io/klog/v2"
@@ -56,10 +55,8 @@ func TestEchoServer(t *testing.T) {
 	}
 	defer cleanup()
 
-	runAgent(proxy.agent, stopCh)
-
-	// Wait for agent to register on proxy server
-	time.Sleep(time.Second)
+	clientset := runAgent(proxy.agent, stopCh)
+	waitForHealthyClients(t, 1, clientset)
 
 	// run test client
 	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())

--- a/tests/tcp_server_test.go
+++ b/tests/tcp_server_test.go
@@ -56,7 +56,7 @@ func TestEchoServer(t *testing.T) {
 	defer cleanup()
 
 	clientset := runAgent(proxy.agent, stopCh)
-	waitForHealthyClients(t, 1, clientset)
+	waitForConnectedServerCount(t, 1, clientset)
 
 	// run test client
 	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())


### PR DESCRIPTION
This PR does some miscellaneous test cleanup, including:

- Elimanite uses of `time.Sleep`. At best, it slows down tests, and at worst it makes them flaky. This PR eliminates uses of `time.Sleep` by replacing it with methods that poll for a desired state (`waitForHealthyClients` and `waitForBackends`), or coordinated execution order with using channels (`waitingServer`)
- Fixes https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/378
- More accurate & helpful error messages when an error doesn't match the expected message

Note: The first 2 commits are from https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/374, which this is based on top of.