### PR TITLE
Dial Timeout testing improvements

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -36,6 +36,9 @@ type Tunnel interface {
 	// Dial connects to the address on the named network, similar to
 	// what net.Dial does. The only supported protocol is tcp.
 	DialContext(requestCtx context.Context, protocol, address string) (net.Conn, error)
+	// Done returns a channel that is closed when the tunnel is no longer serving any connections,
+	// and can no longer be used.
+	Done() <-chan struct{}
 }
 
 type dialResult struct {
@@ -61,6 +64,10 @@ type grpcTunnel struct {
 	// The tunnel will be closed if the caller fails to read via conn.Read()
 	// more than readTimeoutSeconds after a packet has been received.
 	readTimeoutSeconds int
+
+	// The done channel is closed after the tunnel has cleaned up all connections and is no longer
+	// serving.
+	done chan struct{}
 }
 
 type clientConn interface {
@@ -104,6 +111,7 @@ func CreateSingleUseGrpcTunnelWithContext(createCtx, tunnelCtx context.Context, 
 		pendingDial:        make(map[int64]pendingDial),
 		conns:              make(map[int64]*conn),
 		readTimeoutSeconds: 10,
+		done:               make(chan struct{}),
 	}
 
 	go tunnel.serve(tunnelCtx, c)
@@ -123,6 +131,8 @@ func (t *grpcTunnel) serve(tunnelCtx context.Context, c clientConn) {
 			close(conn.readCh)
 		}
 		t.connsLock.Unlock()
+
+		close(t.done)
 	}()
 
 	for {
@@ -219,6 +229,12 @@ func (t *grpcTunnel) serve(tunnelCtx context.Context, c clientConn) {
 // Dial connects to the address on the named network, similar to
 // what net.Dial does. The only supported protocol is tcp.
 func (t *grpcTunnel) DialContext(requestCtx context.Context, protocol, address string) (net.Conn, error) {
+	select {
+	case <-t.done:
+		return nil, errors.New("tunnel is closed")
+	default: // Tunnel is open, carry on.
+	}
+
 	if protocol != "tcp" {
 		return nil, errors.New("protocol not supported")
 	}
@@ -282,6 +298,10 @@ func (t *grpcTunnel) DialContext(requestCtx context.Context, protocol, address s
 	}
 
 	return c, nil
+}
+
+func (t *grpcTunnel) Done() <-chan struct{} {
+	return t.done
 }
 
 func GetDialFailureReason(err error) (isDialFailure bool, reason DialFailureReason) {

--- a/tests/agent_disconnect_test.go
+++ b/tests/agent_disconnect_test.go
@@ -155,17 +155,16 @@ func TestProxy_Agent_Reconnect(t *testing.T) {
 
 func clientRequest(c *http.Client, addr string) ([]byte, error) {
 	r, err := c.Get(addr)
-
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("http GET %q: %w", addr, err)
 	}
 
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
 
-	defer r.Body.Close()
+	r.Body.Close()
 
 	return data, nil
 }
@@ -218,7 +217,7 @@ func createHTTPConnectClient(ctx context.Context, proxyAddr, addr string) (*http
 	}
 
 	c := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			Dial: dialer,
 		},

--- a/tests/concurrent_test.go
+++ b/tests/concurrent_test.go
@@ -101,8 +101,7 @@ func TestProxy_ConcurrencyHTTP(t *testing.T) {
 		data, err := clientRequest(tunnel, server.URL)
 		if err != nil {
 			t.Error(err)
-		}
-		if len(data) != length*chunks {
+		} else if len(data) != length*chunks {
 			t.Errorf("expect data length %d; got %d", length*chunks, len(data))
 		}
 	}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -1,0 +1,16 @@
+package tests
+
+import (
+	"flag"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+func TestMain(m *testing.M) {
+	fs := flag.NewFlagSet("mock-flags", flag.PanicOnError)
+	klog.InitFlags(fs)
+	fs.Set("v", "9") // Set klog to max verbosity.
+
+	m.Run()
+}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -10,7 +10,7 @@ import (
 func TestMain(m *testing.M) {
 	fs := flag.NewFlagSet("mock-flags", flag.PanicOnError)
 	klog.InitFlags(fs)
-	fs.Set("v", "9") // Set klog to max verbosity.
+	fs.Set("v", "1") // Set klog verbosity.
 
 	m.Run()
 }

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -687,11 +687,11 @@ func waitForConnectedServerCount(t *testing.T, expectedServerCount int, clientse
 		if hc == expectedServerCount {
 			return true, nil
 		}
-		cc := clientset.ClientsCount()
-		t.Logf("got %d clients, %d of them are healthy; waiting for %d", cc, hc, expectedServerCount)
 		return false, nil
 	})
 	if err != nil {
+		hc, cc := clientset.HealthyClientsCount(), clientset.ClientsCount()
+		t.Logf("got %d clients, %d of them are healthy; expected %d", cc, hc, expectedServerCount)
 		t.Fatalf("Error waiting for healthy clients: %v", err)
 	}
 }
@@ -705,10 +705,11 @@ func waitForConnectedAgentCount(t *testing.T, expectedAgentCount int, proxy *ser
 		if count == expectedAgentCount {
 			return true, nil
 		}
-		t.Logf("got %d backends; waiting for %d", count, expectedAgentCount)
 		return false, nil
 	})
 	if err != nil {
+		count := proxy.BackendManagers[0].NumBackends()
+		t.Logf("got %d backends; expected %d", count, expectedAgentCount)
 		t.Fatalf("Error waiting for backend count: %v", err)
 	}
 }


### PR DESCRIPTION
- Add a dial timeout test
- Fixes https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/379
- Fixes https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/393
- Introduce a `Done()` function & channel to the gRPC tunnel to indicate when the tunnel has been shutdown (currently only used for testing)

/assign @cheftako 