### PR TITLE
Handle broken dial in agent.

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -404,13 +404,22 @@ func (a *Client) Serve() {
 				<-dialDone
 				if connCtx.conn != nil {
 					klog.V(4).InfoS("close connection", "connectionID", connID)
-					closeResp := &client.Packet{
-						Type:    client.PacketType_CLOSE_RSP,
-						Payload: &client.Packet_CloseResponse{CloseResponse: &client.CloseResponse{}},
+					var closePkt *client.Packet
+					if connID == 0 {
+						closePkt = &client.Packet{
+							Type:    client.PacketType_DIAL_CLS,
+							Payload: &client.Packet_CloseDial{CloseDial: &client.CloseDial{}},
+						}
+						closePkt.GetCloseDial().Random = dialReq.Random
+					} else {
+						closePkt = &client.Packet{
+							Type:    client.PacketType_CLOSE_RSP,
+							Payload: &client.Packet_CloseResponse{CloseResponse: &client.CloseResponse{}},
+						}
+						closePkt.GetCloseResponse().ConnectID = connID
 					}
-					closeResp.GetCloseResponse().ConnectID = connID
-					if err := a.Send(closeResp); err != nil {
-						klog.ErrorS(err, "close response failure")
+					if err := a.Send(closePkt); err != nil {
+						klog.ErrorS(err, "close response failure", "")
 					}
 					close(dataCh)
 					a.connManager.Delete(connID)
@@ -431,6 +440,7 @@ func (a *Client) Serve() {
 					if err := a.Send(dialResp); err != nil {
 						klog.ErrorS(err, "could not send dialResp")
 					}
+					// Cannot invoke clean up as we have no function yet.
 					return
 				}
 				metrics.Metrics.ObserveDialLatency(time.Since(start))
@@ -439,6 +449,9 @@ func (a *Client) Serve() {
 				dialResp.GetDialResponse().ConnectID = connID
 				if err := a.Send(dialResp); err != nil {
 					klog.ErrorS(err, "could not send dialResp")
+					// clean-up is normally called from remoteToProxy which we will never invoke.
+					// So we are invoking it here to force the clean-up to occur.
+					connCtx.cleanup()
 					return
 				}
 				klog.V(3).InfoS("Proxying new connection", "connectionID", connID)

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -259,7 +259,7 @@ func TestFailedSend_DialResp_GRPC(t *testing.T) {
 
 	// Start test http server as remote service
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Log(">>>> Request Received") // FIXME
+		t.Log("Request Received", "url", r.URL, "userAgent", r.UserAgent())
 		fmt.Fprint(w, "hello, world")
 	}))
 	defer ts.Close()
@@ -268,7 +268,7 @@ func TestFailedSend_DialResp_GRPC(t *testing.T) {
 		defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 		// Stimulate sending KAS DIAL_REQ to (Agent) Client
-		dialPacket := newDialPacket("tcp", ts.URL[len("http://"):], 111)
+		dialPacket := newDialPacket("tcp", strings.TrimPrefix(ts.URL, "http://"), 111)
 		err := stream.Send(dialPacket)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -241,6 +241,12 @@ func TestFailedSend_DialResp_GRPC(t *testing.T) {
 		stopCh:      stopCh,
 		cs:          cs,
 	}
+	defer func() {
+		close(stopCh)
+		// Give a.probe() time to clean up
+		// This is terrible and racy
+		time.Sleep(time.Second)
+	}()
 
 	clientStream, stream := pipe()
 	testClient.stream = &brokenStream{
@@ -250,7 +256,6 @@ func TestFailedSend_DialResp_GRPC(t *testing.T) {
 
 	// Start agent
 	go testClient.Serve()
-	defer close(stopCh)
 
 	// Start test http server as remote service
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -20,9 +20,14 @@ func TestServeData_HTTP(t *testing.T) {
 	var err error
 	var stream agent.AgentService_ConnectClient
 	stopCh := make(chan struct{})
+	cs := &ClientSet{
+		clients: make(map[string]*Client),
+		stopCh:  stopCh,
+	}
 	testClient := &Client{
 		connManager: newConnectionManager(),
 		stopCh:      stopCh,
+		cs:          cs,
 	}
 	testClient.stream, stream = pipe()
 
@@ -116,9 +121,14 @@ func TestServeData_HTTP(t *testing.T) {
 func TestClose_Client(t *testing.T) {
 	var stream agent.AgentService_ConnectClient
 	stopCh := make(chan struct{})
+	cs := &ClientSet{
+		clients: make(map[string]*Client),
+		stopCh:  stopCh,
+	}
 	testClient := &Client{
 		connManager: newConnectionManager(),
 		stopCh:      stopCh,
+		cs:          cs,
 	}
 	testClient.stream, stream = pipe()
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -776,7 +776,6 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 				klog.V(2).InfoS("DIAL_CLS not recognized; dropped", "dialID", resp.Random, "agentID", agentID)
 			} else {
 				if err := frontend.send(pkt); err != nil {
-					// Normal when frontend closes it.
 					klog.ErrorS(err, "DIAL_CLS send to client stream error", "serverID", s.serverID, "agentID", agentID, "dialID", resp.Random)
 				} else {
 					klog.V(5).InfoS("DIAL_CLS sent to frontend", "dialID", resp.Random)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -760,7 +760,10 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 							},
 						},
 					}
-					_ = stream.Send(pkt)
+					if err := stream.Send(pkt); err != nil {
+						klog.V(5).ErrorS(err, "failed to notify server of closing due to dial error",
+							"dialID", resp.Random, "serverID", s.serverID, "agentID", agentID, "connectionID", resp.ConnectID)
+					}
 					dialErr = true
 				}
 				// Avoid adding the frontend if there was an error dialing the destination


### PR DESCRIPTION
When the ANP server gets a request broken in dial, it sends a DIAL_CLS.
This allows the random to be sent back and proper close logic invoked.
CLOSE_REQ is a problem because it uses connection id.
During dial the connection is is zero.
Now extending the ANP agent to also send DIAL_CLS for breakage
during a dial request.
Also added some clean up code for related cases.