### PR TITLE
[konnectivity-client] Expose dial failure reasons

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -265,7 +265,7 @@ func (t *grpcTunnel) DialContext(requestCtx context.Context, protocol, address s
 	select {
 	case res := <-resCh:
 		if res.err != "" {
-			return nil, errors.New(res.err)
+			return nil, &dialFailure{res.err, DialFailureEndpoint}
 		}
 		c.connID = res.connid
 		c.readCh = make(chan []byte, 10)
@@ -275,11 +275,41 @@ func (t *grpcTunnel) DialContext(requestCtx context.Context, protocol, address s
 		t.connsLock.Unlock()
 	case <-time.After(30 * time.Second):
 		klog.V(5).InfoS("Timed out waiting for DialResp", "dialID", random)
-		return nil, errors.New("dial timeout, backstop")
+		return nil, &dialFailure{"dial timeout, backstop", DialFailureTimeout}
 	case <-requestCtx.Done():
 		klog.V(5).InfoS("Context canceled waiting for DialResp", "ctxErr", requestCtx.Err(), "dialID", random)
-		return nil, errors.New("dial timeout, context")
+		return nil, &dialFailure{"dial timeout, context", DialFailureContext}
 	}
 
 	return c, nil
 }
+
+func GetDialFailureReason(err error) (isDialFailure bool, reason DialFailureReason) {
+	var df *dialFailure
+	if errors.As(err, df) {
+		return true, df.reason
+	}
+	return false, DialFailureUnknown
+}
+
+type dialFailure struct {
+	msg    string
+	reason DialFailureReason
+}
+
+func (df dialFailure) Error() string {
+	return df.msg
+}
+
+type DialFailureReason string
+
+const (
+	DialFailureUnknown DialFailureReason = "unknown"
+	// DialFailureTimeout indicates the hard 30 second timeout was hit.
+	DialFailureTimeout DialFailureReason = "timeout"
+	// DialFailureContext indicates that the context was cancelled or reached it's deadline before
+	// the dial response was returned.
+	DialFailureContext DialFailureReason = "context"
+	// DialFailureEndpoint indicates that the konnectivity-agent was unable to reach the backend endpoint.
+	DialFailureEndpoint DialFailureReason = "endpoint"
+)


### PR DESCRIPTION
Expose a machine-readable `DialFailureReason` through a `GetDialFailureReason` function, to surface different sources of dial failures to the caller of `DialContext`.

The motivation for this change is to separate out `proxy` dial failure reasons in the kube-apiserver.

/assign @cheftako 