### PR TITLE
Adjust proxy-server agent KeepaliveEnforcementPolicy

### DIFF
--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -321,6 +322,10 @@ func (p *Proxy) runAgentServer(o *options.ProxyRunOptions, server *server.ProxyS
 	agentServerOptions := []grpc.ServerOption{
 		grpc.Creds(credentials.NewTLS(tlsConfig)),
 		grpc.KeepaliveParams(keepalive.ServerParameters{Time: o.KeepaliveTime}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             30 * time.Second,
+			PermitWithoutStream: true,
+		}),
 	}
 	grpcServer := grpc.NewServer(agentServerOptions...)
 	agent.RegisterAgentServiceServer(grpcServer, server)


### PR DESCRIPTION
The agent currently sets `PermitWithoutStream` on its KeepAlive strategy, but the serve enforcement policy uses the default (`PermitWithoutStream=false`). This mismatch could cause the server to forcibly disconnect the agent when it starts sending keepalive pings.

Also, lower the minimum KeepAlive ping time from the default 5 minutes to 30 seconds, to allow more aggressive agent KeepAlive strategies.

Fixes https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/388

/assign @cheftako 