### PR TITLE
Added goroutine labels to goroutine calls.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,11 @@ proto/agent/agent.pb.go: proto/agent/agent.proto
 ## --------------------------------------
 
 easy-rsa.tar.gz:
-	curl -L -o easy-rsa.tar.gz --connect-timeout 20 --retry 6 --retry-delay 2 https://github.com/OpenVPN/easy-rsa/archive/refs/tags/v3.0.8.tar.gz
+	curl -L -o easy-rsa.tar.gz --connect-timeout 20 --retry 6 --retry-delay 2 https://storage.googleapis.com/kubernetes-release/easy-rsa/easy-rsa.tar.gz
 
 easy-rsa: easy-rsa.tar.gz
 	tar xvf easy-rsa.tar.gz
-	mv easy-rsa-3.0.8 easy-rsa
+	mv easy-rsa-master easy-rsa
 
 cfssl:
 	@if ! command -v cfssl &> /dev/null; then \

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -40,6 +40,7 @@ import (
 
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
+	runpprof "runtime/pprof"
 )
 
 func main() {
@@ -254,42 +255,48 @@ func (c *Client) run(o *GrpcProxyClientOptions) error {
 	for i := 1; i <= o.testRequests; i++ {
 		i := i
 		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			dialer, err := c.getDialer(o)
-			if err != nil {
-				ch <- fmt.Errorf("failed to get dialer for client, got %v", err)
-				return
-			}
-			transport := &http.Transport{
-				DialContext: dialer,
-			}
-			if o.enableHTTP2HealthChecks {
-				err = configureHTTP2Transport(transport)
+		labels := runpprof.Labels(
+			"core", "testClient",
+			"testID", strconv.Itoa(i),
+		)
+		go runpprof.Do(context.Background(), labels, func(context.Context) {
+			func() {
+				defer wg.Done()
+				dialer, err := c.getDialer(o)
 				if err != nil {
-					klog.V(1).Error(err, "error initializing HTTP2 health checking parameters. Using default transport.")
+					ch <- fmt.Errorf("failed to get dialer for client, got %v", err)
+					return
 				}
-			}
-			client := &http.Client{
-				Transport: transport,
-			}
-			if o.closeIdleConn {
-				defer client.CloseIdleConnections()
-			}
+				transport := &http.Transport{
+					DialContext: dialer,
+				}
+				if o.enableHTTP2HealthChecks {
+					err = configureHTTP2Transport(transport)
+					if err != nil {
+						klog.V(1).Error(err, "error initializing HTTP2 health checking parameters. Using default transport.")
+					}
+				}
+				client := &http.Client{
+					Transport: transport,
+				}
+				if o.closeIdleConn {
+					defer client.CloseIdleConnections()
+				}
 
-			err = c.makeRequest(o, client)
-			if err != nil {
-				ch <- err
-				return
-			}
+				err = c.makeRequest(o, client)
+				if err != nil {
+					ch <- err
+					return
+				}
 
-			if i != o.testRequests {
-				klog.V(1).InfoS("Waiting for next connection test.", "seconds", o.testDelaySec, "iteration", i, "test requests", o.testRequests)
-				wait := time.Duration(o.testDelaySec) * time.Second
-				time.Sleep(wait)
-			}
-			ch <- nil
-		}()
+				if i != o.testRequests {
+					klog.V(1).InfoS("Waiting for next connection test.", "seconds", o.testDelaySec, "iteration", i, "test requests", o.testRequests)
+					wait := time.Duration(o.testDelaySec) * time.Second
+					time.Sleep(wait)
+				}
+				ch <- nil
+			}()
+		})
 	}
 	wg.Wait()
 	close(ch)
@@ -404,13 +411,20 @@ func (c *Client) getUDSDialer(o *GrpcProxyClientOptions) (func(ctx context.Conte
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch)
 
-	go func() {
-		<-ch
-		if proxyConn != nil {
-			err := proxyConn.Close()
-			klog.ErrorS(err, "connection closed")
-		}
-	}()
+	labels := runpprof.Labels(
+		"core", "testUdsDialer",
+		"requestPath", o.requestPath,
+		"udsName", o.proxyUdsName,
+	)
+	go runpprof.Do(context.Background(), labels, func(context.Context) {
+		func() {
+			<-ch
+			if proxyConn != nil {
+				err := proxyConn.Close()
+				klog.ErrorS(err, "connection closed")
+			}
+		}()
+	})
 
 	switch o.mode {
 	case "grpc":
@@ -482,13 +496,20 @@ func (c *Client) getMTLSDialer(o *GrpcProxyClientOptions) (func(ctx context.Cont
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch)
 
-	go func() {
-		<-ch
-		if proxyConn != nil {
-			err := proxyConn.Close()
-			klog.ErrorS(err, "connection closed")
-		}
-	}()
+	labels := runpprof.Labels(
+		"core", "testMtlsDialer",
+		"requestPath", o.requestPath,
+		"requestPort", strconv.Itoa(o.requestPort),
+	)
+	go runpprof.Do(context.Background(), labels, func(context.Context) {
+		func() {
+			<-ch
+			if proxyConn != nil {
+				err := proxyConn.Close()
+				klog.ErrorS(err, "connection closed")
+			}
+		}()
+	})
 
 	switch o.mode {
 	case "grpc":

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -8,11 +8,12 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/http/pprof"
+	netpprof "net/http/pprof"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	runpprof "runtime/pprof"
 	"strconv"
 	"strings"
 	"sync"
@@ -151,12 +152,17 @@ func SetupSignalHandler() (stopCh <-chan struct{}) {
 	stop := make(chan struct{})
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, shutdownSignals...)
-	go func() {
-		<-c
-		close(stop)
-		<-c
-		os.Exit(1) // second signal. Exit directly.
-	}()
+	labels := runpprof.Labels(
+		"core", "signalHandler",
+	)
+	go runpprof.Do(context.Background(), labels, func(context.Context) {
+		func() {
+			<-c
+			close(stop)
+			<-c
+			os.Exit(1) // second signal. Exit directly.
+		}()
+	})
 
 	return stop
 }
@@ -198,7 +204,11 @@ func (p *Proxy) runUDSFrontendServer(ctx context.Context, o *options.ProxyRunOpt
 		if err != nil {
 			return nil, fmt.Errorf("failed to get uds listener: %v", err)
 		}
-		go grpcServer.Serve(lis)
+		labels := runpprof.Labels(
+			"core", "udsGrpcFrontend",
+			"udsFile", o.UdsName,
+		)
+		go runpprof.Do(context.Background(), labels, func(context.Context) { grpcServer.Serve(lis) })
 		stop = grpcServer.GracefulStop
 	} else {
 		// http-connect
@@ -212,20 +222,26 @@ func (p *Proxy) runUDSFrontendServer(ctx context.Context, o *options.ProxyRunOpt
 			err := server.Shutdown(ctx)
 			klog.ErrorS(err, "error shutting down server")
 		}
-		go func() {
-			udsListener, err := getUDSListener(ctx, o.UdsName)
-			if err != nil {
-				klog.ErrorS(err, "failed to get uds listener")
-			}
-			defer func() {
-				err := udsListener.Close()
-				klog.ErrorS(err, "failed to close uds listener")
+		labels := runpprof.Labels(
+			"core", "udsHttpFrontend",
+			"udsFile", o.UdsName,
+		)
+		go runpprof.Do(context.Background(), labels, func(context.Context) {
+			func() {
+				udsListener, err := getUDSListener(ctx, o.UdsName)
+				if err != nil {
+					klog.ErrorS(err, "failed to get uds listener")
+				}
+				defer func() {
+					err := udsListener.Close()
+					klog.ErrorS(err, "failed to close uds listener")
+				}()
+				err = server.Serve(udsListener)
+				if err != nil {
+					klog.ErrorS(err, "failed to serve uds requests")
+				}
 			}()
-			err = server.Serve(udsListener)
-			if err != nil {
-				klog.ErrorS(err, "failed to serve uds requests")
-			}
-		}()
+		})
 	}
 
 	return stop, nil
@@ -286,7 +302,11 @@ func (p *Proxy) runMTLSFrontendServer(ctx context.Context, o *options.ProxyRunOp
 		if err != nil {
 			return nil, fmt.Errorf("failed to listen on %s: %v", addr, err)
 		}
-		go grpcServer.Serve(lis)
+		labels := runpprof.Labels(
+			"core", "mtlsGrpcFrontend",
+			"port", strconv.FormatUint(uint64(o.ServerPort), 10),
+		)
+		go runpprof.Do(context.Background(), labels, func(context.Context) { grpcServer.Serve(lis) })
 		stop = grpcServer.GracefulStop
 	} else {
 		// http-connect
@@ -305,12 +325,18 @@ func (p *Proxy) runMTLSFrontendServer(ctx context.Context, o *options.ProxyRunOp
 				klog.ErrorS(err, "failed to shutdown server")
 			}
 		}
-		go func() {
-			err := server.ListenAndServeTLS("", "") // empty files defaults to tlsConfig
-			if err != nil {
-				klog.ErrorS(err, "failed to listen on frontend port")
-			}
-		}()
+		labels := runpprof.Labels(
+			"core", "mtlsHttpFrontend",
+			"port", strconv.FormatUint(uint64(o.ServerPort), 10),
+		)
+		go runpprof.Do(context.Background(), labels, func(context.Context) {
+			func() {
+				err := server.ListenAndServeTLS("", "") // empty files defaults to tlsConfig
+				if err != nil {
+					klog.ErrorS(err, "failed to listen on frontend port")
+				}
+			}()
+		})
 	}
 
 	return stop, nil
@@ -338,7 +364,11 @@ func (p *Proxy) runAgentServer(o *options.ProxyRunOptions, server *server.ProxyS
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %v", addr, err)
 	}
-	go grpcServer.Serve(lis)
+	labels := runpprof.Labels(
+		"core", "agentListener",
+		"port", strconv.FormatUint(uint64(o.AgentPort), 10),
+	)
+	go runpprof.Do(context.Background(), labels, func(context.Context) { grpcServer.Serve(lis) })
 
 	return nil
 }
@@ -348,7 +378,7 @@ func (p *Proxy) runAdminServer(o *options.ProxyRunOptions, server *server.ProxyS
 	muxHandler.Handle("/metrics", promhttp.Handler())
 	if o.EnableProfiling {
 		muxHandler.HandleFunc("/debug/pprof", util.RedirectTo("/debug/pprof/"))
-		muxHandler.HandleFunc("/debug/pprof/", pprof.Index)
+		muxHandler.HandleFunc("/debug/pprof/", netpprof.Index)
 		if o.EnableContentionProfiling {
 			runtime.SetBlockProfileRate(1)
 		}
@@ -359,13 +389,19 @@ func (p *Proxy) runAdminServer(o *options.ProxyRunOptions, server *server.ProxyS
 		MaxHeaderBytes: 1 << 20,
 	}
 
-	go func() {
-		err := adminServer.ListenAndServe()
-		if err != nil {
-			klog.ErrorS(err, "admin server could not listen")
-		}
-		klog.V(1).Infoln("Admin server stopped listening")
-	}()
+	labels := runpprof.Labels(
+		"core", "adminListener",
+		"port", strconv.FormatUint(uint64(o.AdminPort), 10),
+	)
+	go runpprof.Do(context.Background(), labels, func(context.Context) {
+		func() {
+			err := adminServer.ListenAndServe()
+			if err != nil {
+				klog.ErrorS(err, "admin server could not listen")
+			}
+			klog.V(1).Infoln("Admin server stopped listening")
+		}()
+	})
 
 	return nil
 }
@@ -397,13 +433,19 @@ func (p *Proxy) runHealthServer(o *options.ProxyRunOptions, server *server.Proxy
 		ReadHeaderTimeout: ReadHeaderTimeout,
 	}
 
-	go func() {
-		err := healthServer.ListenAndServe()
-		if err != nil {
-			klog.ErrorS(err, "health server could not listen")
-		}
-		klog.V(1).Infoln("Health server stopped listening")
-	}()
+	labels := runpprof.Labels(
+		"core", "healthListener",
+		"port", strconv.FormatUint(uint64(o.HealthPort), 10),
+	)
+	go runpprof.Do(context.Background(), labels, func(context.Context) {
+		func() {
+			err := healthServer.ListenAndServe()
+			if err != nil {
+				klog.ErrorS(err, "health server could not listen")
+			}
+			klog.V(1).Infoln("Health server stopped listening")
+		}()
+	})
 
 	return nil
 }

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/metrics"
 	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
+	runpprof "runtime/pprof"
 )
 
 const dialTimeout = 5 * time.Second
@@ -354,7 +355,13 @@ func (a *Client) Serve() {
 	}()
 
 	klog.V(2).InfoS("Start serving", "serverID", a.serverID)
-	go a.probe()
+	labels := runpprof.Labels(
+		"agentID", a.agentID,
+		"agentIdentifiers", a.agentIdentifiers,
+		"serverAddress", a.address,
+		"serverID", a.serverID,
+	)
+	go runpprof.Do(context.Background(), labels, func(context.Context) { a.probe() })
 	for {
 		select {
 		case <-a.stopCh:
@@ -430,36 +437,64 @@ func (a *Client) Serve() {
 					klog.ErrorS(fmt.Errorf("connection is nil"), "cannot send CLOSE_RESP to nil connection")
 				}
 			}
-			go func() {
-				defer close(dialDone)
-				start := time.Now()
-				conn, err := net.DialTimeout(dialReq.Protocol, dialReq.Address, dialTimeout)
-				if err != nil {
-					klog.ErrorS(err, "error dialing backend", "dialID", dialReq.Random)
-					dialResp.GetDialResponse().Error = err.Error()
+			labels := runpprof.Labels(
+				"agentID", a.agentID,
+				"agentIdentifiers", a.agentIdentifiers,
+				"serverAddress", a.address,
+				"serverID", a.serverID,
+				"dialID", strconv.FormatInt(dialReq.Random, 10),
+				"dialAddress", dialReq.Address,
+			)
+			go runpprof.Do(context.Background(), labels, func(context.Context) {
+				func() {
+					defer close(dialDone)
+					start := time.Now()
+					conn, err := net.DialTimeout(dialReq.Protocol, dialReq.Address, dialTimeout)
+					if err != nil {
+						klog.ErrorS(err, "error dialing backend", "dialID", dialReq.Random)
+						dialResp.GetDialResponse().Error = err.Error()
+						if err := a.Send(dialResp); err != nil {
+							klog.ErrorS(err, "could not send dialResp")
+						}
+						// Cannot invoke clean up as we have no conn yet.
+						return
+					}
+					metrics.Metrics.ObserveDialLatency(time.Since(start))
+					connCtx.conn = conn
+					a.connManager.Add(connID, connCtx)
+					dialResp.GetDialResponse().ConnectID = connID
 					if err := a.Send(dialResp); err != nil {
 						klog.ErrorS(err, "could not send dialResp")
+						// clean-up is normally called from remoteToProxy which we will never invoke.
+						// So we are invoking it here to force the clean-up to occur.
+						// However, cleanup will block until dialDone is closed.
+						// So placing cleanup on its own goroutine to wait for the deferred close(dialDone) to kick in.
+						labels := runpprof.Labels(
+							"agentID", a.agentID,
+							"agentIdentifiers", a.agentIdentifiers,
+							"serverAddress", a.address,
+							"serverID", a.serverID,
+							"connectionID", strconv.FormatInt(connID, 10),
+							"dialAddress", dialReq.Address,
+
+						)
+						go runpprof.Do(context.Background(), labels, func(context.Context) { connCtx.cleanup() })
+						return
 					}
-					// Cannot invoke clean up as we have no conn yet.
-					return
-				}
-				metrics.Metrics.ObserveDialLatency(time.Since(start))
-				connCtx.conn = conn
-				a.connManager.Add(connID, connCtx)
-				dialResp.GetDialResponse().ConnectID = connID
-				if err := a.Send(dialResp); err != nil {
-					klog.ErrorS(err, "could not send dialResp")
-					// clean-up is normally called from remoteToProxy which we will never invoke.
-					// So we are invoking it here to force the clean-up to occur.
-					// However, cleanup will block until dialDone is closed.
-					// So placing cleanup on its own goroutine to wait for the deferred close(dialDone) to kick in.
-					go connCtx.cleanup()
-					return
-				}
-				klog.V(3).InfoS("Proxying new connection", "connectionID", connID)
-				go a.remoteToProxy(connID, connCtx)
-				go a.proxyToRemote(connID, connCtx)
-			}()
+					klog.V(3).InfoS("Proxying new connection", "connectionID", connID)
+					labels := runpprof.Labels(
+						"agentID", a.agentID,
+						"agentIdentifiers", a.agentIdentifiers,
+						"serverAddress", a.address,
+						"serverID", a.serverID,
+						"connectionID", strconv.FormatInt(connID, 10),
+						"dialAddress", dialReq.Address,
+
+					)
+					go runpprof.Do(context.Background(), labels, func(context.Context) { a.remoteToProxy(connID, connCtx) })
+					go runpprof.Do(context.Background(), labels, func(context.Context) { a.proxyToRemote(connID, connCtx) })
+				}()
+			})
 
 		case client.PacketType_DATA:
 			data := pkt.GetData()

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -17,7 +17,9 @@ limitations under the License.
 package agent
 
 import (
+	"context"
 	"math"
+	runpprof "runtime/pprof"
 	"sync"
 	"time"
 
@@ -25,8 +27,6 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	runpprof "runtime/pprof"
-	"context"
 )
 
 // ClientSet consists of clients connected to each instance of an HA proxy server.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -33,13 +33,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	runpprof "runtime/pprof"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 	pkgagent "sigs.k8s.io/apiserver-network-proxy/pkg/agent"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
 	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
-	runpprof "runtime/pprof"
 )
 
 const xfrChannelSize = 10
@@ -384,40 +384,40 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 	}()
 
 	// Start goroutine to receive packets from frontend and push to recvCh
-	go runpprof.Do(context.Background(), labels, func(context.Context) {
-		func() {
-			for {
-				in, err := stream.Recv()
-				if err == io.EOF {
-					klog.V(2).InfoS("Receive stream from frontend closed", "userAgent", userAgent, "serverID", s.serverID)
-					close(stopCh)
-					return
-				}
-				if err != nil {
-					if status.Code(err) == codes.Canceled {
-						klog.V(2).InfoS("Stream read from frontend cancelled", "userAgent", userAgent, "serverID", s.serverID)
-					} else {
-						klog.ErrorS(err, "Stream read from frontend failure", "userAgent", userAgent, "serverID", s.serverID)
-					}
-					stopCh <- err
-					close(stopCh)
-					return
-				}
-
-				select {
-				case recvCh <- in: // Send didn't block, carry on.
-				default: // Send blocked; record it and try again.
-					klog.V(2).InfoS("Receive channel from frontend is full", "userAgent", userAgent, "serverID", s.serverID)
-					fullRecvChannelMetric := metrics.Metrics.FullRecvChannel(metrics.Proxy)
-					fullRecvChannelMetric.Inc()
-					recvCh <- in
-					fullRecvChannelMetric.Dec()
-				}
-			}
-		}()
-	})
+	go runpprof.Do(context.Background(), labels, func(context.Context) { s.readFrontendToChannel(stream, userAgent, recvCh, stopCh) })
 
 	return <-stopCh
+}
+
+func (s *ProxyServer) readFrontendToChannel(stream client.ProxyService_ProxyServer, userAgent []string, recvCh chan *client.Packet, stopCh chan error) {
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			klog.V(2).InfoS("Receive stream from frontend closed", "userAgent", userAgent, "serverID", s.serverID)
+			close(stopCh)
+			return
+		}
+		if err != nil {
+			if status.Code(err) == codes.Canceled {
+				klog.V(2).InfoS("Stream read from frontend cancelled", "userAgent", userAgent, "serverID", s.serverID)
+			} else {
+				klog.ErrorS(err, "Stream read from frontend failure", "userAgent", userAgent, "serverID", s.serverID)
+			}
+			stopCh <- err
+			close(stopCh)
+			return
+		}
+
+		select {
+		case recvCh <- in: // Send didn't block, carry on.
+		default: // Send blocked; record it and try again.
+			klog.V(2).InfoS("Receive channel from frontend is full", "userAgent", userAgent, "serverID", s.serverID)
+			fullRecvChannelMetric := metrics.Metrics.FullRecvChannel(metrics.Proxy)
+			fullRecvChannelMetric.Inc()
+			recvCh <- in
+			fullRecvChannelMetric.Dec()
+		}
+	}
 }
 
 func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, recvCh <-chan *client.Packet) {
@@ -655,6 +655,13 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 	}
 
 	klog.V(2).InfoS("Connect request from agent", "agentID", agentID)
+	labels := runpprof.Labels(
+		"serverID", s.serverID,
+		"serverCount", strconv.Itoa(s.serverCount),
+		"agentID", agentID,
+	)
+	ctx := runpprof.WithLabels(context.Background(), labels)
+	runpprof.SetGoroutineLabels(ctx)
 
 	if s.AgentAuthenticationOptions.Enabled {
 		if err := s.authenticateAgentViaToken(stream.Context()); err != nil {
@@ -674,12 +681,7 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 
 	recvCh := make(chan *client.Packet, xfrChannelSize)
 
-	labels := runpprof.Labels(
-		"serverID", s.serverID,
-		"serverCount", strconv.Itoa(s.serverCount),
-		"agentID", agentID,
-	)
-	go runpprof.Do(context.Background(), labels, func(context.Context) { go s.serveRecvBackend(backend, stream, agentID, recvCh) })
+	go runpprof.Do(context.Background(), labels, func(context.Context) { s.serveRecvBackend(backend, stream, agentID, recvCh) })
 
 	defer func() {
 		klog.V(2).InfoS("Receive channel from agent is stopping", "agentID", agentID, "serverID", s.serverID)
@@ -687,36 +689,36 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 	}()
 
 	stopCh := make(chan error)
-	go runpprof.Do(context.Background(), labels, func(context.Context) {
-		func() {
-			for {
-				in, err := stream.Recv()
-				if err == io.EOF {
-					klog.V(2).InfoS("Receive stream from agent is closed", "agentID", agentID, "serverID", s.serverID)
-					close(stopCh)
-					return
-				}
-				if err != nil {
-					klog.ErrorS(err, "Receive stream from agent read failure")
-					stopCh <- err
-					close(stopCh)
-					return
-				}
-
-				select {
-				case recvCh <- in: // Send didn't block, carry on.
-				default: // Send blocked; record it and try again.
-					klog.V(2).InfoS("Receive channel from agent is full", "agentID", agentID, "serverID", s.serverID)
-					fullRecvChannelMetric := metrics.Metrics.FullRecvChannel(metrics.Connect)
-					fullRecvChannelMetric.Inc()
-					recvCh <- in
-					fullRecvChannelMetric.Dec()
-				}
-			}
-		}()
-	})
+	go runpprof.Do(context.Background(), labels, func(context.Context) { s.readBackendToChannel(stream, recvCh, stopCh) })
 
 	return <-stopCh
+}
+
+func (s *ProxyServer) readBackendToChannel(stream agent.AgentService_ConnectServer, recvCh chan *client.Packet, stopCh chan error) {
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			klog.V(2).InfoS("Receive stream from agent is closed", "agentID", agentID, "serverID", s.serverID)
+			close(stopCh)
+			return
+		}
+		if err != nil {
+			klog.ErrorS(err, "Receive stream from agent read failure")
+			stopCh <- err
+			close(stopCh)
+			return
+		}
+
+		select {
+		case recvCh <- in: // Send didn't block, carry on.
+		default: // Send blocked; record it and try again.
+			klog.V(2).InfoS("Receive channel from agent is full", "agentID", agentID, "serverID", s.serverID)
+			fullRecvChannelMetric := metrics.Metrics.FullRecvChannel(metrics.Connect)
+			fullRecvChannelMetric.Inc()
+			recvCh <- in
+			fullRecvChannelMetric.Dec()
+		}
+	}
 }
 
 // route the packet back to the correct client


### PR DESCRIPTION
Added debug labels to goroutines.
Labels are intended to make it easier to understand go traces output.
Adding things like agentID and connectionID to understand the context
under which that goroutine is working. Also used 'core' to indicate what
the core service threads were doing. Eg. managing the adminListener.

Also fixed an issue where make certs was not working because of an issue
with cfssl and openssl version 3.0.X.

$ go tool pprof -traces -lines http://localhost:8095/debug/pprof/goroutine
now produces traces like (Please note the new labels at the beginning)
-----------+-------------------------------------------------------
   agentID:  7c7ce3b6-a66b-458c-8626-f965ed55e5c4
  serverID:  4a229717-ff51-40da-90d4-ee1265a27918
serverCount:  1
         1   go1.17.12/src/runtime/proc.go:366
             go1.17.12/src/runtime/chan.go:576
             go1.17.12/src/runtime/chan.go:444
             sigs.k8s.io/apiserver-network-proxy/pkg/server.(*ProxyServer).serveRecvBackend network-proxy/src/apiserver-network-proxy/pkg/server/server.go:747
-----------+-------------------------------------------------------
