### PR TITLE
[konnectivity-client] Fix GetDialFailureReason

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -310,7 +310,7 @@ func (t *grpcTunnel) Done() <-chan struct{} {
 
 func GetDialFailureReason(err error) (isDialFailure bool, reason DialFailureReason) {
 	var df *dialFailure
-	if errors.As(err, df) {
+	if errors.As(err, &df) {
 		return true, df.reason
 	}
 	return false, DialFailureUnknown
@@ -321,7 +321,7 @@ type dialFailure struct {
 	reason DialFailureReason
 }
 
-func (df dialFailure) Error() string {
+func (df *dialFailure) Error() string {
 	return df.msg
 }
 


### PR DESCRIPTION
The way I called `errors.As` was incorrect, leading to a nil-pointer panic. I fixed that, and added unit tests.