### PR TITLE
Improve agentID logging

### DIFF
--- a/pkg/server/default_route_backend_manager.go
+++ b/pkg/server/default_route_backend_manager.go
@@ -36,16 +36,16 @@ func NewDefaultRouteBackendManager() *DefaultRouteBackendManager {
 }
 
 // Backend tries to get a backend associating to the request destination host.
-func (dibm *DefaultRouteBackendManager) Backend(ctx context.Context) (Backend, error) {
+func (dibm *DefaultRouteBackendManager) Backend(ctx context.Context) (Backend, string, error) {
 	dibm.mu.RLock()
 	defer dibm.mu.RUnlock()
 	if len(dibm.backends) == 0 {
-		return nil, &ErrNotFound{}
+		return nil, "", &ErrNotFound{}
 	}
 	if len(dibm.defaultRouteAgentIDs) == 0 {
-		return nil, &ErrNotFound{}
+		return nil, "", &ErrNotFound{}
 	}
 	agentID := dibm.defaultRouteAgentIDs[dibm.random.Intn(len(dibm.defaultRouteAgentIDs))]
 	klog.V(4).InfoS("Picked agent as backend", "agentID", agentID)
-	return dibm.backends[agentID][0], nil
+	return dibm.backends[agentID][0], agentID, nil
 }

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -36,19 +36,19 @@ func NewDestHostBackendManager() *DestHostBackendManager {
 }
 
 // Backend tries to get a backend associating to the request destination host.
-func (dibm *DestHostBackendManager) Backend(ctx context.Context) (Backend, error) {
+func (dibm *DestHostBackendManager) Backend(ctx context.Context) (Backend, string, error) {
 	dibm.mu.RLock()
 	defer dibm.mu.RUnlock()
 	if len(dibm.backends) == 0 {
-		return nil, &ErrNotFound{}
+		return nil, "", &ErrNotFound{}
 	}
 	destHost := ctx.Value(destHost).(string)
 	if destHost != "" {
 		bes, exist := dibm.backends[destHost]
 		if exist && len(bes) > 0 {
 			klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
-			return dibm.backends[destHost][0], nil
+			return dibm.backends[destHost][0], destHost, nil
 		}
 	}
-	return nil, &ErrNotFound{}
+	return nil, "", &ErrNotFound{}
 }

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -82,16 +82,16 @@ func (s *singleTimeManager) RemoveBackend(agentID string, _ pkgagent.IdentifierT
 	delete(s.backends, agentID)
 }
 
-func (s *singleTimeManager) Backend(_ context.Context) (server.Backend, error) {
+func (s *singleTimeManager) Backend(_ context.Context) (server.Backend, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for k, v := range s.backends {
 		if _, ok := s.used[k]; !ok {
 			s.used[k] = struct{}{}
-			return v, nil
+			return v, k, nil
 		}
 	}
-	return nil, fmt.Errorf("cannot find backend to a new agent")
+	return nil, "", fmt.Errorf("cannot find backend to a new agent")
 }
 
 func (s *singleTimeManager) GetBackend(agentID string) server.Backend {


### PR DESCRIPTION
Include the agent ID when fetching a backend, and log the agent ID in relevant locations.