### PR TITLE
[konnectivity-client] Ensure grpc tunnel is closed on dial failure

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -320,7 +320,11 @@ func (t *grpcTunnel) DialContext(requestCtx context.Context, protocol, address s
 
 	klog.V(5).Infoln("DIAL_REQ sent to proxy server")
 
-	c := &conn{stream: t.stream, random: random}
+	c := &conn{
+		stream:      t.stream,
+		random:      random,
+		closeTunnel: t.closeTunnel,
+	}
 
 	select {
 	case res := <-resCh:
@@ -366,7 +370,10 @@ func (t *grpcTunnel) closeDial(dialID int64) {
 	if err := t.stream.Send(req); err != nil {
 		klog.V(5).InfoS("Failed to send DIAL_CLS", "err", err, "dialID", dialID)
 	}
+	t.closeTunnel()
+}
 
+func (t *grpcTunnel) closeTunnel() {
 	atomic.StoreUint32(&t.closing, 1)
 	t.clientConn.Close()
 }

--- a/konnectivity-client/pkg/client/client_test.go
+++ b/konnectivity-client/pkg/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,7 +41,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestDial(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	ctx := context.Background()
 	s, ps := pipe()
@@ -71,7 +72,7 @@ func TestDial(t *testing.T) {
 // TestDialRace exercises the scenario where serve() observes and handles DIAL_RSP
 // before DialContext() does any work after sending the DIAL_REQ.
 func TestDialRace(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	ctx := context.Background()
 	s, ps := pipe()
@@ -117,7 +118,7 @@ func (s fakeSlowSend) Send(p *client.Packet) error {
 }
 
 func TestData(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	ctx := context.Background()
 	s, ps := pipe()
@@ -173,7 +174,7 @@ func TestData(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	ctx := context.Background()
 	s, ps := pipe()
@@ -208,7 +209,7 @@ func TestCloseTimeout(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	ctx := context.Background()
 	s, ps := pipe()
@@ -248,7 +249,7 @@ func TestCloseTimeout(t *testing.T) {
 }
 
 func TestCreateSingleUseGrpcTunnel_NoLeakOnFailure(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	tunnel, err := CreateSingleUseGrpcTunnel(context.Background(), "127.0.0.1:12345", grpc.WithInsecure())
 	if tunnel != nil {
@@ -260,7 +261,7 @@ func TestCreateSingleUseGrpcTunnel_NoLeakOnFailure(t *testing.T) {
 }
 
 func TestCreateSingleUseGrpcTunnelWithContext_NoLeakOnFailure(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	tunnel, err := CreateSingleUseGrpcTunnelWithContext(context.Background(), context.Background(), "127.0.0.1:12345", grpc.WithInsecure())
 	if tunnel != nil {
@@ -272,7 +273,7 @@ func TestCreateSingleUseGrpcTunnelWithContext_NoLeakOnFailure(t *testing.T) {
 }
 
 func TestDialAfterTunnelCancelled(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -292,17 +293,15 @@ func TestDialAfterTunnelCancelled(t *testing.T) {
 		t.Fatalf("expect err when dialing after tunnel closed")
 	}
 
-	t.Log("Wait for tunnel to close")
 	select {
 	case <-tunnel.Done():
-		t.Log("Tunnel closed successfully")
 	case <-time.After(30 * time.Second):
 		t.Errorf("Timed out waiting for tunnel to close")
 	}
 }
 
 func TestDial_RequestContextCancelled(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	reqCtx, reqCancel := context.WithCancel(context.Background())
 	s, ps := pipe()
@@ -336,7 +335,7 @@ func TestDial_RequestContextCancelled(t *testing.T) {
 }
 
 func TestDial_BackendError(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
 	s, ps := pipe()
 	ts := testServer(ps, 100)
@@ -369,10 +368,59 @@ func TestDial_BackendError(t *testing.T) {
 	if !isDialFailure {
 		t.Errorf("Unexpected non-dial failure error: %v", err)
 	} else if reason != DialFailureEndpoint {
-		t.Errorf("Expected DialFailureContext, got %v", reason)
+		t.Errorf("Expected DialFailureEndpoint, got %v", reason)
 	}
 
 	ts.assertPacketType(0, client.PacketType_DIAL_REQ)
+}
+
+func TestDial_Closed(t *testing.T) {
+	defer goleakVerifyNone(t, goleak.IgnoreCurrent())
+
+	s, ps := pipe()
+	defer ps.Close()
+	defer s.Close()
+
+	ts := testServer(ps, 100)
+	ts.handlers[client.PacketType_DIAL_REQ] = func(pkt *client.Packet) *client.Packet {
+		return &client.Packet{
+			Type: client.PacketType_DIAL_CLS,
+			Payload: &client.Packet_CloseDial{
+				CloseDial: &client.CloseDial{
+					Random: pkt.GetDialRequest().Random,
+				},
+			},
+		}
+	}
+	go ts.serve()
+
+	func() {
+		// Verify that the tunnel goroutines are not leaked before cleaning up the test server.
+		goleakVerifyNone(t, goleak.IgnoreCurrent())
+
+		tunnel := newUnstartedTunnel(s)
+		go tunnel.serve(context.Background(), &fakeConn{})
+
+		_, err := tunnel.DialContext(context.Background(), "tcp", "127.0.0.1:80")
+		if err == nil {
+			t.Fatalf("Expected dial error, got none")
+		}
+
+		isDialFailure, reason := GetDialFailureReason(err)
+		if !isDialFailure {
+			t.Errorf("Unexpected non-dial failure error: %v", err)
+		} else if reason != DialFailureDialClosed {
+			t.Errorf("Expected DialFailureDialClosed, got %v", reason)
+		}
+
+		ts.assertPacketType(0, client.PacketType_DIAL_REQ)
+
+		select {
+		case <-tunnel.Done():
+		case <-time.After(30 * time.Second):
+			t.Errorf("Timed out waiting for tunnel to close")
+		}
+	}()
 }
 
 // TODO: Move to common testing library
@@ -449,7 +497,9 @@ type proxyServer struct {
 	handlers map[client.PacketType]handler
 	connid   int64
 	data     bytes.Buffer
-	packets  []*client.Packet
+
+	packets     []*client.Packet
+	packetsLock sync.Mutex
 }
 
 func testServer(s client.ProxyService_ProxyClient, connid int64) *proxyServer {
@@ -479,7 +529,9 @@ func (s *proxyServer) serve() {
 			return
 		}
 
+		s.packetsLock.Lock()
 		s.packets = append(s.packets, pkt)
+		s.packetsLock.Unlock()
 
 		if handler, ok := s.handlers[pkt.Type]; ok {
 			req := handler(pkt)
@@ -493,6 +545,9 @@ func (s *proxyServer) serve() {
 }
 
 func (s *proxyServer) assertPacketType(index int, expectedType client.PacketType) {
+	s.packetsLock.Lock()
+	defer s.packetsLock.Unlock()
+
 	if index >= len(s.packets) {
 		s.t.Fatalf("Expected %v packet[%d], but have only received %d packets", expectedType, index, len(s.packets))
 	}
@@ -538,5 +593,15 @@ func (s *proxyServer) handleData(pkt *client.Packet) *client.Packet {
 				Data:      append([]byte("echo: "), pkt.GetData().Data...),
 			},
 		},
+	}
+}
+
+// Override goleakVerifyNone to set t.Helper.
+// TODO: delete this once goleak has been updated to include
+// https://github.com/uber-go/goleak/commit/2dfebe88ddf19de216c4ab15a1189fc640b1ea9f
+func goleakVerifyNone(t *testing.T, options ...goleak.Option) {
+	t.Helper()
+	if err := goleak.Find(options...); err != nil {
+		t.Error(err)
 	}
 }

--- a/konnectivity-client/pkg/client/client_test.go
+++ b/konnectivity-client/pkg/client/client_test.go
@@ -566,9 +566,11 @@ func (s *proxyServer) serve() {
 			return
 		}
 
-		s.packetsLock.Lock()
-		s.packets = append(s.packets, pkt)
-		s.packetsLock.Unlock()
+		func() {
+			s.packetsLock.Lock()
+			defer s.packetsLock.Unlock()
+			s.packets = append(s.packets, pkt)
+		}()
 
 		if handler, ok := s.handlers[pkt.Type]; ok {
 			req := handler(pkt)

--- a/konnectivity-client/pkg/client/conn.go
+++ b/konnectivity-client/pkg/client/conn.go
@@ -41,6 +41,9 @@ type conn struct {
 	readCh  chan []byte
 	closeCh chan string
 	rdata   []byte
+
+	// closeTunnel is an optional callback to close the underlying grpc connection.
+	closeTunnel func()
 }
 
 var _ net.Conn = &conn{}
@@ -116,6 +119,10 @@ func (c *conn) SetWriteDeadline(t time.Time) error {
 // proxy service to notify remote to drop the connection.
 func (c *conn) Close() error {
 	klog.V(4).Infoln("closing connection")
+	if c.closeTunnel != nil {
+		defer c.closeTunnel()
+	}
+
 	var req *client.Packet
 	if c.connID != 0 {
 		req = &client.Packet{


### PR DESCRIPTION
3 commits:
1. Handle DIAL_CLS packets in the client - treat it similarly to a DIAL_RSP with a failure
2. Send a best-effort DIAL_CLS to the server if the client times out (or the request is canceled)
3. Explicitly close the client connection and stop serving the tunnel on dial failures

**Note to reviewers:** I'm hoping to backport this to older Kubernetes versions, so consider backwards compatibility (both with older k8s, as well as older proxy-servers). I think it's OK, but would appreciate extra attention on this detail.

/assign @cheftako 