### PR TITLE
[WIP] konnectivity-client: fix a potential leak when tunnel context is cancelled while receiving data from stream 

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -294,6 +294,7 @@ func (t *grpcTunnel) serve(tunnelCtx context.Context) {
 				return
 			case <-tunnelCtx.Done():
 				klog.V(1).InfoS("Tunnel has been closed, the grpc connection to the proxy server will be closed", "connectionID", conn.connID)
+				return
 			}
 
 		case client.PacketType_CLOSE_RSP:


### PR DESCRIPTION
Started fiddling with a unit test after this review https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/360#discussion_r967418965, and I was able to create a unit test that reproduces a leak when the tunnel context is cancelled while the stream is receiving data. 

This PR adds an early return when tunnel context is cancelled, which will eventually close out the goroutine for that stream. I also added a unit test that was able to reproduce the leak as well as the fix.