### PR TITLE
Dial metrics

### DIFF
--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -168,7 +168,6 @@ func (a *ServerMetrics) Reset() {
 	a.latencies.Reset()
 	a.frontendLatencies.Reset()
 	a.connections.Reset()
-	a.httpConnections.Set(0)
 	a.backend.Reset()
 	a.pendingDials.Reset()
 	a.fullRecvChannels.Reset()
@@ -219,9 +218,9 @@ func (a *ServerMetrics) FullRecvChannel(serviceMethod string) prometheus.Gauge {
 type DialFailureReason string
 
 const (
-	DialFailureEndpoint             DialFailureReason = "endpoint"              // Dial failure reported by the agent back to the server.
+	DialFailureErrorResponse        DialFailureReason = "error_response"        // Dial failure reported by the agent back to the server.
 	DialFailureUnrecognizedResponse DialFailureReason = "unrecognized_response" // Dial repsonse received for unrecognozide dial ID.
-	DialFailureSend                 DialFailureReason = "send"                  // Successful dial response from agent, but failed to send to frontend.
+	DialFailureSendResponse         DialFailureReason = "send_rsp"              // Successful dial response from agent, but failed to send to frontend.
 	DialFailureBackendClose         DialFailureReason = "backend_close"         // Received a DIAL_CLS from the backend before the dial completed.
 	DialFailureFrontendClose        DialFailureReason = "frontend_close"        // Received a DIAL_CLS from the frontend before the dial completed.
 )

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -23,12 +23,20 @@ import (
 )
 
 const (
-	namespace = "konnectivity_network_proxy"
-	subsystem = "server"
+	Namespace = "konnectivity_network_proxy"
+	Subsystem = "server"
+
+	DialLatencyMetric        = "dial_duration_seconds"
+	FrontendLatencyMetric    = "frontend_write_duration_seconds"
+	GRPCConnectionsMetric    = "grpc_connections"
+	HTTPConnectionsMetric    = "http_connections"
+	BackendConnectionsMetric = "ready_backend_connections"
+	PendingDialsMetric       = "pending_backend_dials"
+	FullRecvChannelMetric    = "full_receive_channels"
+	DialFailuresMetric       = "dial_failure_count"
 
 	// Proxy is the ProxyService method used to handle incoming streams.
 	Proxy = "Proxy"
-
 	// Connect is the AgentService method used to establish next hop.
 	Connect = "Connect"
 )
@@ -57,9 +65,9 @@ type ServerMetrics struct {
 func newServerMetrics() *ServerMetrics {
 	latencies := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "dial_duration_seconds",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      DialLatencyMetric,
 			Help:      "Latency of dial to the remote endpoint in seconds",
 			Buckets:   latencyBuckets,
 		},
@@ -67,9 +75,9 @@ func newServerMetrics() *ServerMetrics {
 	)
 	frontendLatencies := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "frontend_write_duration_seconds",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      FrontendLatencyMetric,
 			Help:      "Latency of write to the frontend in seconds",
 			Buckets:   latencyBuckets,
 		},
@@ -77,9 +85,9 @@ func newServerMetrics() *ServerMetrics {
 	)
 	connections := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "grpc_connections",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      GRPCConnectionsMetric,
 			Help:      "Number of current grpc connections, partitioned by service method.",
 		},
 		[]string{
@@ -88,35 +96,35 @@ func newServerMetrics() *ServerMetrics {
 	)
 	httpConnections := prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "http_connections",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      HTTPConnectionsMetric,
 			Help:      "Number of current HTTP CONNECT connections",
 		},
 	)
 	backend := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "ready_backend_connections",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      BackendConnectionsMetric,
 			Help:      "Number of konnectivity agent connected to the proxy server",
 		},
 		[]string{},
 	)
 	pendingDials := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "pending_backend_dials",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      PendingDialsMetric,
 			Help:      "Current number of pending backend dial requests",
 		},
 		[]string{},
 	)
 	fullRecvChannels := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "full_receive_channels",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      FullRecvChannelMetric,
 			Help:      "Number of current connections blocked by a full receive channel, partitioned by service method.",
 		},
 		[]string{
@@ -125,9 +133,9 @@ func newServerMetrics() *ServerMetrics {
 	)
 	dialFailures := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "dial_failure_count",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      DialFailuresMetric,
 			Help:      "Number of dial failures observed. Multiple failures can occur for a single dial request.",
 		},
 		[]string{
@@ -159,6 +167,12 @@ func newServerMetrics() *ServerMetrics {
 func (a *ServerMetrics) Reset() {
 	a.latencies.Reset()
 	a.frontendLatencies.Reset()
+	a.connections.Reset()
+	a.httpConnections.Set(0)
+	a.backend.Reset()
+	a.pendingDials.Reset()
+	a.fullRecvChannels.Reset()
+	a.dialFailures.Reset()
 }
 
 // ObserveDialLatency records the latency of dial to the remote endpoint.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -776,7 +776,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 				if resp.Error != "" {
 					// Dial response with error should not contain a valid ConnID.
 					klog.ErrorS(errors.New(resp.Error), "DIAL_RSP contains failure", "dialID", resp.Random, "agentID", agentID)
-					metrics.Metrics.ObserveDialFailure(metrics.DialFailureEndpoint)
+					metrics.Metrics.ObserveDialFailure(metrics.DialFailureErrorResponse)
 					dialErr = true
 				}
 				err := frontend.send(pkt)
@@ -785,7 +785,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 					klog.ErrorS(err, "DIAL_RSP send to frontend stream failure",
 						"dialID", resp.Random, "agentID", agentID, "connectionID", resp.ConnectID)
 					if !dialErr { // Avoid double-counting.
-						metrics.Metrics.ObserveDialFailure(metrics.DialFailureSend)
+						metrics.Metrics.ObserveDialFailure(metrics.DialFailureSendResponse)
 					}
 					// If we never finish setting up the tunnel for ConnectID, then the connection is dead.
 					// Currently, the agent will no resend DIAL_RSP, so connection is dead.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -501,6 +501,7 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 					"dialAddress", pd.dialAddress,
 					"dialDuration", time.Since(pd.start),
 				)
+				metrics.Metrics.ObserveDialFailure(metrics.DialFailureFrontendClose)
 			}
 
 		case client.PacketType_DATA:
@@ -766,6 +767,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 
 			if frontend, ok := s.PendingDial.Get(resp.Random); !ok {
 				klog.V(2).InfoS("DIAL_RSP not recognized; dropped", "dialID", resp.Random, "agentID", agentID, "connectionID", resp.ConnectID)
+				metrics.Metrics.ObserveDialFailure(metrics.DialFailureUnrecognizedResponse)
 				if resp.ConnectID != 0 {
 					s.sendCloseRequest(stream, resp.ConnectID, resp.Random, "failed to notify agent of closing due to unknown dial id")
 				}
@@ -774,6 +776,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 				if resp.Error != "" {
 					// Dial response with error should not contain a valid ConnID.
 					klog.ErrorS(errors.New(resp.Error), "DIAL_RSP contains failure", "dialID", resp.Random, "agentID", agentID)
+					metrics.Metrics.ObserveDialFailure(metrics.DialFailureEndpoint)
 					dialErr = true
 				}
 				err := frontend.send(pkt)
@@ -781,6 +784,9 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 				if err != nil {
 					klog.ErrorS(err, "DIAL_RSP send to frontend stream failure",
 						"dialID", resp.Random, "agentID", agentID, "connectionID", resp.ConnectID)
+					if !dialErr { // Avoid double-counting.
+						metrics.Metrics.ObserveDialFailure(metrics.DialFailureSend)
+					}
 					// If we never finish setting up the tunnel for ConnectID, then the connection is dead.
 					// Currently, the agent will no resend DIAL_RSP, so connection is dead.
 					// We already attempted to tell the frontend that. We should ensure we tell the backend.
@@ -823,6 +829,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 						"dialAddress", frontend.dialAddress,
 						"dialDuration", time.Since(frontend.start),
 					)
+					metrics.Metrics.ObserveDialFailure(metrics.DialFailureBackendClose)
 				}
 			}
 

--- a/pkg/testing/metrics/metrics.go
+++ b/pkg/testing/metrics/metrics.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	server "sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
+)
+
+const (
+	dialFailureHeader = `
+# HELP konnectivity_network_proxy_server_dial_failure_count Number of dial failures observed. Multiple failures can occur for a single dial request.
+# TYPE konnectivity_network_proxy_server_dial_failure_count counter`
+	dialFailureSample = `konnectivity_network_proxy_server_dial_failure_count{reason="%s"} %d`
+)
+
+func ExpectDialFailures(expected map[server.DialFailureReason]int) error {
+	expect := dialFailureHeader + "\n"
+	for r, v := range expected {
+		expect += fmt.Sprintf(dialFailureSample+"\n", r, v)
+	}
+	return ExpectMetric(server.Subsystem, server.DialFailuresMetric, expect)
+}
+
+func ExpectDialFailure(reason server.DialFailureReason, count int) error {
+	return ExpectDialFailures(map[server.DialFailureReason]int{reason: count})
+}
+
+func ExpectMetric(subsystem, name, expected string) error {
+	fqName := prometheus.BuildFQName(server.Namespace, subsystem, name)
+	return promtest.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expected), fqName)
+}

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -169,7 +169,7 @@ func TestProxyHandleDialError_GRPC(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	if err := metricstest.ExpectDialFailure(metrics.DialFailureEndpoint, 1); err != nil {
+	if err := metricstest.ExpectDialFailure(metrics.DialFailureErrorResponse, 1); err != nil {
 		t.Error(err)
 	}
 	metrics.Metrics.Reset() // For clean shutdown.
@@ -353,7 +353,7 @@ func TestProxyDial_AgentTimeout_GRPC(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
-		if err := metricstest.ExpectDialFailure(metrics.DialFailureEndpoint, 1); err != nil {
+		if err := metricstest.ExpectDialFailure(metrics.DialFailureErrorResponse, 1); err != nil {
 			t.Error(err)
 		}
 		metrics.Metrics.Reset() // For clean shutdown.
@@ -607,7 +607,7 @@ func TestFailedDial_HTTPCONN(t *testing.T) {
 		t.Errorf("while waiting for connection to be closed: %v", err)
 	}
 
-	if err := metricstest.ExpectDialFailure(metrics.DialFailureEndpoint, 1); err != nil {
+	if err := metricstest.ExpectDialFailure(metrics.DialFailureErrorResponse, 1); err != nil {
 		t.Error(err)
 	}
 	metrics.Metrics.Reset() // For clean shutdown.


### PR DESCRIPTION
Introduce a new server-side metric to track dial failures, as observed from the proxy-server. Also introduce a new metrics-testing library (which I spent an embarrassing amount of time on).

/assign @cheftako @andrewsykim 