### PR TITLE
Improve server logging, especially around initial dial

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -511,7 +511,7 @@ func (a *Client) Serve() {
 			}
 
 		default:
-			klog.V(2).InfoS("unrecognized packet", "type", pkt)
+			klog.V(5).InfoS("unrecognized packet", "type", pkt)
 		}
 	}
 }


### PR DESCRIPTION
These changes ensure that we get the following information at `V(2)`:

1. Dial requests, along with destination address: logging the address makes it much easier to correlate dial & connection IDs with specific apiserver requests.
2. "Connection established": once the `DIAL_RSP` is received, make sure to log the transition with both connection & dial ID, to make it easier to connect those when tracing logs
3. On `DIAL_CLS`, log that the dial was canceled. These are logged at the error level, since it represents a "dial failure", even though it's not technically an error from the server perspective. This is inline with how we log agent errors in the dial response.

Also include several miscellaneous log cleanups.

/assign @cheftako @andrewsykim 