### PR TITLE
ServerID & AgentID logging cleanup

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -86,7 +86,7 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.IntVar(&o.AdminServerPort, "admin-server-port", o.AdminServerPort, "The port the admin server is listening on.")
 	flags.BoolVar(&o.EnableProfiling, "enable-profiling", o.EnableProfiling, "enable pprof at host:admin-port/debug/pprof")
 	flags.BoolVar(&o.EnableContentionProfiling, "enable-contention-profiling", o.EnableContentionProfiling, "enable contention profiling at host:admin-port/debug/pprof/block. \"--enable-profiling\" must also be set.")
-	flags.StringVar(&o.AgentID, "agent-id", o.AgentID, "The unique ID of this agent. Default to a generated uuid if not set.")
+	flags.StringVar(&o.AgentID, "agent-id", o.AgentID, "The unique ID of this agent. Can also be set by the 'PROXY_AGENT_ID' environment variable. Default to a generated uuid if not set.")
 	flags.DurationVar(&o.SyncInterval, "sync-interval", o.SyncInterval, "The initial interval by which the agent periodically checks if it has connections to all instances of the proxy server.")
 	flags.DurationVar(&o.ProbeInterval, "probe-interval", o.ProbeInterval, "The interval by which the agent periodically checks if its connections to the proxy server are ready.")
 	flags.DurationVar(&o.SyncIntervalCap, "sync-interval-cap", o.SyncIntervalCap, "The maximum interval for the SyncInterval to back off to when unable to connect to the proxy server")
@@ -200,7 +200,7 @@ func NewGrpcProxyAgentOptions() *GrpcProxyAgentOptions {
 		AdminServerPort:           8094,
 		EnableProfiling:           false,
 		EnableContentionProfiling: false,
-		AgentID:                   uuid.New().String(),
+		AgentID:                   defaultAgentID(),
 		AgentIdentifiers:          "",
 		SyncInterval:              1 * time.Second,
 		ProbeInterval:             1 * time.Second,
@@ -211,4 +211,13 @@ func NewGrpcProxyAgentOptions() *GrpcProxyAgentOptions {
 		SyncForever:               false,
 	}
 	return &o
+}
+
+func defaultAgentID() string {
+	// Default to the value set by the PROXY_AGENT_ID environment variable. If both the flag &
+	// environment variable are set, the flag always wins.
+	if id := os.Getenv("PROXY_AGENT_ID"); id != "" {
+		return id
+	}
+	return uuid.New().String()
 }

--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -111,7 +111,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.DurationVar(&o.FrontendKeepaliveTime, "frontend-keepalive-time", o.FrontendKeepaliveTime, "Time for gRPC frontend server keepalive.")
 	flags.BoolVar(&o.EnableProfiling, "enable-profiling", o.EnableProfiling, "enable pprof at host:admin-port/debug/pprof")
 	flags.BoolVar(&o.EnableContentionProfiling, "enable-contention-profiling", o.EnableContentionProfiling, "enable contention profiling at host:admin-port/debug/pprof/block. \"--enable-profiling\" must also be set.")
-	flags.StringVar(&o.ServerID, "server-id", o.ServerID, "The unique ID of this server.")
+	flags.StringVar(&o.ServerID, "server-id", o.ServerID, "The unique ID of this server. Can also be set by the 'PROXY_SERVER_ID' environment variable.")
 	flags.UintVar(&o.ServerCount, "server-count", o.ServerCount, "The number of proxy server instances, should be 1 unless it is an HA server.")
 	flags.StringVar(&o.AgentNamespace, "agent-namespace", o.AgentNamespace, "Expected agent's namespace during agent authentication (used with agent-service-account, authentication-audience, kubeconfig).")
 	flags.StringVar(&o.AgentServiceAccount, "agent-service-account", o.AgentServiceAccount, "Expected agent's service account during agent authentication (used with agent-namespace, authentication-audience, kubeconfig).")
@@ -327,7 +327,7 @@ func NewProxyRunOptions() *ProxyRunOptions {
 		FrontendKeepaliveTime:     1 * time.Hour,
 		EnableProfiling:           false,
 		EnableContentionProfiling: false,
-		ServerID:                  uuid.New().String(),
+		ServerID:                  defaultServerID(),
 		ServerCount:               1,
 		AgentNamespace:            "",
 		AgentServiceAccount:       "",
@@ -339,4 +339,13 @@ func NewProxyRunOptions() *ProxyRunOptions {
 		CipherSuites:              "",
 	}
 	return &o
+}
+
+func defaultServerID() string {
+	// Default to the value set by the PROXY_SERVER_ID environment variable. If both the flag &
+	// environment variable are set, the flag always wins.
+	if id := os.Getenv("PROXY_SERVER_ID"); id != "" {
+		return id
+	}
+	return uuid.New().String()
 }

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -351,7 +351,7 @@ func (a *Client) Serve() {
 		for _, connCtx := range a.connManager.List() {
 			connCtx.cleanup()
 		}
-		klog.V(2).InfoS("cleanup all of conn contexts when client exits", "agentID", a.agentID)
+		klog.V(2).InfoS("cleanup all of conn contexts when client exits")
 	}()
 
 	klog.V(2).InfoS("Start serving", "serverID", a.serverID)

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -354,7 +354,7 @@ func (a *Client) Serve() {
 		klog.V(2).InfoS("cleanup all of conn contexts when client exits")
 	}()
 
-	klog.V(2).InfoS("Start serving", "serverID", a.serverID)
+	klog.V(2).InfoS("Start serving", "serverID", a.serverID, "agentID", a.agentID)
 	go a.probe()
 	for {
 		select {
@@ -383,7 +383,7 @@ func (a *Client) Serve() {
 
 		switch pkt.Type {
 		case client.PacketType_DIAL_REQ:
-			klog.V(4).InfoS("received DIAL_REQ")
+			klog.V(4).InfoS("received DIAL_REQ", "serverID", a.serverID, "agentID", a.agentID)
 			dialResp := &client.Packet{
 				Type:    client.PacketType_DIAL_RSP,
 				Payload: &client.Packet_DialResponse{DialResponse: &client.DialResponse{}},

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -224,7 +224,6 @@ func (cs *ClientSet) connectOnce() error {
 	klog.V(2).InfoS("sync added client connecting to proxy server", "serverID", c.serverID)
 
 	labels := runpprof.Labels(
-		"agentID", cs.agentID,
 		"agentIdentifiers", cs.agentIdentifiers,
 		"serverAddress", cs.address,
 		"serverID", c.serverID,
@@ -235,7 +234,6 @@ func (cs *ClientSet) connectOnce() error {
 
 func (cs *ClientSet) Serve() {
 	labels := runpprof.Labels(
-		"agentID", cs.agentID,
 		"agentIdentifiers", cs.agentIdentifiers,
 		"serverAddress", cs.address,
 	)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -369,7 +369,7 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 		return fmt.Errorf("failed to get context")
 	}
 	userAgent := md.Get(header.UserAgent)
-	klog.V(2).InfoS("proxy request from client", "userAgent", userAgent)
+	klog.V(2).InfoS("Proxy request from client", "userAgent", userAgent, "serverID", s.serverID)
 
 	recvCh := make(chan *client.Packet, xfrChannelSize)
 	stopCh := make(chan error)
@@ -665,7 +665,7 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 		return err
 	}
 
-	klog.V(2).InfoS("Connect request from agent", "agentID", agentID)
+	klog.V(2).InfoS("Connect request from agent", "agentID", agentID, "serverID", s.serverID)
 	labels := runpprof.Labels(
 		"serverCount", strconv.Itoa(s.serverCount),
 		"agentID", agentID,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -375,7 +375,6 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 	stopCh := make(chan error)
 
 	labels := runpprof.Labels(
-		"serverID", s.serverID,
 		"serverCount", strconv.Itoa(s.serverCount),
 		"userAgent", strings.Join(userAgent, ", "),
 	)
@@ -668,7 +667,6 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 
 	klog.V(2).InfoS("Connect request from agent", "agentID", agentID)
 	labels := runpprof.Labels(
-		"serverID", s.serverID,
 		"serverCount", strconv.Itoa(s.serverCount),
 		"agentID", agentID,
 	)


### PR DESCRIPTION
1. Allow serverID and agentID to be set by an environment variable. This makes it easier to set them using the [kubernetes downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) when running as a pod. For example, in a container spec:
```yaml
      env:
        - name: PROXY_SERVER_ID
          valueFrom:
            fieldRef:
              fieldPath: metadata.uid
```
2. Exclude the serverID from proxy-server logs (except startup flag logging), and likewise agentID for agent logs. These values are set at startup and never change, and are redundant with the log source.
3. (RFC) Also remove the redundant serverID / agentID from their respective go-routine labeling. I don't feel strongly about whether to include them here.