### PR TITLE
Fix agent shutdown dial race

### DIFF
--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -300,7 +300,7 @@ func TestFailedSend_DialResp_GRPC(t *testing.T) {
 			t.Error("expected timeout error, got none")
 		}
 
-		if conns := len(testClient.connManager.List()); conns > 0 {
+		if conns := len(testClient.connManager.connections); conns > 0 {
 			t.Errorf("Leaked %d connections", conns)
 		}
 	}()


### PR DESCRIPTION
If a dial is in progress while the agent client is shutting down, there is a race condition where the connection is registered after the connections were already cleaned up, which could lead to the connection being leaked.

This PR moves the closing responsibilities to the connection manager, and refuses to add new connections while the connection manager is shutting down. It also performs the connection cleanup in parallel.