### PR TITLE
Agent: add several new metrics.

### DIFF
--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/metrics"
 )
 
 // ClientSet consists of clients connected to each instance of an HA proxy server.
@@ -105,6 +106,7 @@ func (cs *ClientSet) addClientLocked(serverID string, c *Client) error {
 		return &DuplicateServerError{ServerID: serverID}
 	}
 	cs.clients[serverID] = c
+	metrics.Metrics.SetServerConnectionsCount(len(cs.clients))
 	return nil
 
 }
@@ -123,6 +125,7 @@ func (cs *ClientSet) RemoveClient(serverID string) {
 	}
 	cs.clients[serverID].Close()
 	delete(cs.clients, serverID)
+	metrics.Metrics.SetServerConnectionsCount(len(cs.clients))
 }
 
 type ClientSetConfig struct {

--- a/pkg/agent/metrics/metrics.go
+++ b/pkg/agent/metrics/metrics.go
@@ -20,13 +20,23 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/status"
+	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 )
 
 type Direction string
 
 const (
-	namespace = "konnectivity_network_proxy"
-	subsystem = "agent"
+	Namespace = "konnectivity_network_proxy"
+	Subsystem = "agent"
+
+	DialLatencyMetric         = "dial_duration_seconds"
+	ServerFailuresMetric      = "server_connection_failure_count"
+	DialFailuresMetric        = "dial_failure_count"
+	ServerConnectionsMetric   = "open_server_connections"
+	EndpointConnectionsMetric = "open_endpoint_connections"
+	PacketsMetric             = "packets"
+	StreamErrorsMetric        = "stream_errors"
 
 	// DirectionToServer indicates that the agent attempts to send a packet
 	// to the proxy server.
@@ -46,49 +56,158 @@ var (
 
 // AgentMetrics includes all the metrics of the proxy agent.
 type AgentMetrics struct {
-	latencies *prometheus.HistogramVec
-	failures  *prometheus.CounterVec
+	dialLatencies       *prometheus.HistogramVec
+	serverFailures      *prometheus.CounterVec
+	dialFailures        *prometheus.CounterVec
+	serverConnections   *prometheus.GaugeVec
+	endpointConnections *prometheus.GaugeVec
+	packets             *prometheus.CounterVec
+	streamErrors        *prometheus.CounterVec
 }
 
 // newAgentMetrics create a new AgentMetrics, configured with default metric names.
 func newAgentMetrics() *AgentMetrics {
-	latencies := prometheus.NewHistogramVec(
+	dialLatencies := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "dial_duration_seconds",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      DialLatencyMetric,
 			Help:      "Latency of dial to the remote endpoint in seconds",
 			Buckets:   latencyBuckets,
 		},
 		[]string{},
 	)
-	failures := prometheus.NewCounterVec(
+	serverFailures := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "server_connection_failure_count",
-			Help:      "Count of failures to send to or receive from the proxy server, labeled by the direction (from_server or to_server)",
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      ServerFailuresMetric,
+			Help:      "Count of failures to send to or receive from the proxy server, labeled by the direction (from_server or to_server). DEPRECATED, please use stream_errors",
 		},
 		[]string{"direction"},
 	)
-	prometheus.MustRegister(failures)
-	prometheus.MustRegister(latencies)
-	return &AgentMetrics{failures: failures, latencies: latencies}
+	dialFailures := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      DialFailuresMetric,
+			Help:      "Number of failures dialing the remote endpoint, by reason (example: timeout).",
+		},
+		[]string{"reason"},
+	)
+	serverConnections := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      ServerConnectionsMetric,
+			Help:      "Current number of open server connections.",
+		},
+		[]string{},
+	)
+	endpointConnections := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      EndpointConnectionsMetric,
+			Help:      "Current number of open endpoint connections.",
+		},
+		[]string{},
+	)
+	packets := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      PacketsMetric,
+			Help:      "Count of packets processed, by direction (from_server or to_server) and packet type (example: DIAL_REQ)",
+		},
+		[]string{"direction", "packet_type"},
+	)
+	streamErrors := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      StreamErrorsMetric,
+			Help:      "Count of stream_errors, by direction, grpc Code, packet type. (example: to_server, Code.Unavailable, DIAL_RSP)",
+		},
+		[]string{"direction", "code", "packet_type"},
+	)
+	prometheus.MustRegister(dialLatencies)
+	prometheus.MustRegister(serverFailures)
+	prometheus.MustRegister(dialFailures)
+	prometheus.MustRegister(serverConnections)
+	prometheus.MustRegister(endpointConnections)
+	prometheus.MustRegister(packets)
+	prometheus.MustRegister(streamErrors)
+	return &AgentMetrics{
+		dialLatencies:       dialLatencies,
+		serverFailures:      serverFailures,
+		dialFailures:        dialFailures,
+		serverConnections:   serverConnections,
+		endpointConnections: endpointConnections,
+		packets:             packets,
+		streamErrors:        streamErrors,
+	}
+
 }
 
 // Reset resets the metrics.
 func (a *AgentMetrics) Reset() {
-	a.failures.Reset()
-	a.latencies.Reset()
+	a.dialLatencies.Reset()
+	a.serverFailures.Reset()
+	a.dialFailures.Reset()
+	a.serverConnections.Reset()
+	a.endpointConnections.Reset()
+	a.packets.Reset()
+	a.streamErrors.Reset()
 }
 
-// ObserveFailure records a failure to send to or receive from the proxy
+// ObserveServerFailure records a failure to send to or receive from the proxy
 // server, labeled by the direction.
-func (a *AgentMetrics) ObserveFailure(direction Direction) {
-	a.failures.WithLabelValues(string(direction)).Inc()
+func (a *AgentMetrics) ObserveServerFailure(direction Direction) {
+	a.serverFailures.WithLabelValues(string(direction)).Inc()
 }
+
+type DialFailureReason string
+
+const (
+	DialFailureTimeout DialFailureReason = "timeout"
+	DialFailureUnknown DialFailureReason = "unknown"
+)
 
 // ObserveDialLatency records the latency of dial to the remote endpoint.
 func (a *AgentMetrics) ObserveDialLatency(elapsed time.Duration) {
-	a.latencies.WithLabelValues().Observe(elapsed.Seconds())
+	a.dialLatencies.WithLabelValues().Observe(elapsed.Seconds())
+}
+
+// ObserveDialFailure records a remote endpoint dial failure.
+func (a *AgentMetrics) ObserveDialFailure(reason DialFailureReason) {
+	a.dialFailures.WithLabelValues(string(reason)).Inc()
+}
+
+func (a *AgentMetrics) SetServerConnectionsCount(count int) {
+	a.serverConnections.WithLabelValues().Set(float64(count))
+}
+
+// EndpointConnectionInc increments a new endpoint connection.
+func (a *AgentMetrics) EndpointConnectionInc() {
+	a.endpointConnections.WithLabelValues().Inc()
+}
+
+// EndpointConnectionDec decrements a finished endpoint connection.
+func (a *AgentMetrics) EndpointConnectionDec() {
+	a.endpointConnections.WithLabelValues().Dec()
+}
+
+func (a *AgentMetrics) ObservePacket(direction Direction, packetType client.PacketType) {
+	a.packets.WithLabelValues(string(direction), packetType.String()).Inc()
+}
+
+func (a *AgentMetrics) ObserveStreamSendError(err error, packetType client.PacketType) {
+	code := status.Code(err)
+	a.streamErrors.WithLabelValues(string(DirectionToServer), code.String(), packetType.String()).Inc()
+}
+
+func (a *AgentMetrics) ObserveStreamReceiveError(err error) {
+	code := status.Code(err)
+	a.streamErrors.WithLabelValues(string(DirectionFromServer), code.String(), "Unknown").Inc()
 }

--- a/pkg/testing/metrics/metrics.go
+++ b/pkg/testing/metrics/metrics.go
@@ -22,29 +22,47 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	agent "sigs.k8s.io/apiserver-network-proxy/pkg/agent/metrics"
 	server "sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
 )
 
 const (
-	dialFailureHeader = `
+	serverDialFailureHeader = `
 # HELP konnectivity_network_proxy_server_dial_failure_count Number of dial failures observed. Multiple failures can occur for a single dial request.
 # TYPE konnectivity_network_proxy_server_dial_failure_count counter`
-	dialFailureSample = `konnectivity_network_proxy_server_dial_failure_count{reason="%s"} %d`
+	serverDialFailureSample = `konnectivity_network_proxy_server_dial_failure_count{reason="%s"} %d`
+
+	agentDialFailureHeader = `
+# HELP konnectivity_network_proxy_agent_dial_failure_count Number of failures dialing the remote endpoint, by reason (example: timeout).
+# TYPE konnectivity_network_proxy_agent_dial_failure_count counter`
+	agentDialFailureSample = `konnectivity_network_proxy_agent_dial_failure_count{reason="%s"} %d`
 )
 
-func ExpectDialFailures(expected map[server.DialFailureReason]int) error {
-	expect := dialFailureHeader + "\n"
+func ExpectServerDialFailures(expected map[server.DialFailureReason]int) error {
+	expect := serverDialFailureHeader + "\n"
 	for r, v := range expected {
-		expect += fmt.Sprintf(dialFailureSample+"\n", r, v)
+		expect += fmt.Sprintf(serverDialFailureSample+"\n", r, v)
 	}
-	return ExpectMetric(server.Subsystem, server.DialFailuresMetric, expect)
+	return ExpectMetric(server.Namespace, server.Subsystem, server.DialFailuresMetric, expect)
 }
 
-func ExpectDialFailure(reason server.DialFailureReason, count int) error {
-	return ExpectDialFailures(map[server.DialFailureReason]int{reason: count})
+func ExpectServerDialFailure(reason server.DialFailureReason, count int) error {
+	return ExpectServerDialFailures(map[server.DialFailureReason]int{reason: count})
 }
 
-func ExpectMetric(subsystem, name, expected string) error {
-	fqName := prometheus.BuildFQName(server.Namespace, subsystem, name)
+func ExpectAgentDialFailures(expected map[agent.DialFailureReason]int) error {
+	expect := agentDialFailureHeader + "\n"
+	for r, v := range expected {
+		expect += fmt.Sprintf(agentDialFailureSample+"\n", r, v)
+	}
+	return ExpectMetric(agent.Namespace, agent.Subsystem, agent.DialFailuresMetric, expect)
+}
+
+func ExpectAgentDialFailure(reason agent.DialFailureReason, count int) error {
+	return ExpectAgentDialFailures(map[agent.DialFailureReason]int{reason: count})
+}
+
+func ExpectMetric(namespace, subsystem, name, expected string) error {
+	fqName := prometheus.BuildFQName(namespace, subsystem, name)
 	return promtest.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expected), fqName)
 }


### PR DESCRIPTION
Add several new metrics:

* dial_failure_count
* open_server_connections
* open_endpoint_connections
* packets
* stream_errors

Note that server_connection_failure_count metric (konnectivity-server dials) was easy to mistake for dial_failure_count (endpoint dials).

Includes some of the ideas in https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/410