### PR TITLE
Close backend connection when frontend is not found

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -339,19 +339,14 @@ func (t *grpcTunnel) serve(tunnelCtx context.Context) {
 
 			if !ok {
 				klog.ErrorS(nil, "Connection not recognized", "connectionID", resp.ConnectID, "packetType", "DATA")
-				req := &client.Packet{
+				t.Send(&client.Packet{
 					Type: client.PacketType_CLOSE_REQ,
 					Payload: &client.Packet_CloseRequest{
 						CloseRequest: &client.CloseRequest{
 							ConnectID: resp.ConnectID,
 						},
 					},
-				}
-				const segment = commonmetrics.SegmentFromClient
-				metrics.Metrics.ObservePacket(segment, req.Type)
-				if err := t.stream.Send(req); err != nil {
-					metrics.Metrics.ObserveStreamError(segment, err, req.Type)
-				}
+				})
 				continue
 			}
 			timer := time.NewTimer((time.Duration)(t.readTimeoutSeconds) * time.Second)

--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -338,7 +338,15 @@ func (t *grpcTunnel) serve(tunnelCtx context.Context) {
 			conn, ok := t.conns.get(resp.ConnectID)
 
 			if !ok {
-				klog.V(1).InfoS("Connection not recognized", "connectionID", resp.ConnectID)
+				klog.ErrorS(nil, "Connection not recognized", "connectionID", resp.ConnectID)
+				t.stream.Send(&client.Packet{
+					Type: client.PacketType_CLOSE_REQ,
+					Payload: &client.Packet_CloseRequest{
+						CloseRequest: &client.CloseRequest{
+							ConnectID: resp.ConnectID,
+						},
+					},
+				})
 				continue
 			}
 			timer := time.NewTimer((time.Duration)(t.readTimeoutSeconds) * time.Second)

--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -334,6 +334,10 @@ func (t *grpcTunnel) serve(tunnelCtx context.Context) {
 
 		case client.PacketType_DATA:
 			resp := pkt.GetData()
+			if resp.ConnectID == 0 {
+				klog.ErrorS(nil, "Received packet missing ConnectID", "packetType", "DATA")
+				continue
+			}
 			// TODO: flow control
 			conn, ok := t.conns.get(resp.ConnectID)
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -497,6 +497,10 @@ func (a *Client) Serve() {
 		case client.PacketType_DATA:
 			data := pkt.GetData()
 			klog.V(4).InfoS("received DATA", "connectionID", data.ConnectID)
+			if data.ConnectID == 0 {
+				klog.ErrorS(nil, "Received packet missing ConnectID from frontend", "packetType", "DATA")
+				continue
+			}
 
 			ctx, ok := a.connManager.Get(data.ConnectID)
 			if ok {

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -602,9 +602,14 @@ func (a *Client) proxyToRemote(connID int64, ctx *connContext) {
 		// As the read side of the dataCh channel, we cannot close it.
 		// However serve() may be blocked writing to the channel,
 		// so we need to consume the channel until it is closed.
+		discardedPktCount := 0
 		for range ctx.dataCh {
 			// Ignore values as this indicates there was a problem
 			// with the remote connection.
+			discardedPktCount++
+		}
+		if discardedPktCount > 0 {
+			klog.V(2).InfoS("Discard packets while exiting proxyToRemote", "pktCount", discardedPktCount, "connectionID", connID)
 		}
 	}()
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -501,6 +501,18 @@ func (a *Client) Serve() {
 			ctx, ok := a.connManager.Get(data.ConnectID)
 			if ok {
 				ctx.send(data.Data)
+			} else {
+				klog.ErrorS(nil, "received DATA for unrecognized connection", "connectionID", data.ConnectID)
+				a.Send(&client.Packet{
+					Type: client.PacketType_CLOSE_RSP,
+					Payload: &client.Packet_CloseResponse{
+						CloseResponse: &client.CloseResponse{
+							ConnectID: data.ConnectID,
+							Error:     "unrecognized connectID",
+						},
+					},
+				})
+				continue
 			}
 
 		case client.PacketType_CLOSE_REQ:

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -502,7 +502,7 @@ func (a *Client) Serve() {
 			if ok {
 				ctx.send(data.Data)
 			} else {
-				klog.ErrorS(nil, "received DATA for unrecognized connection", "connectionID", data.ConnectID)
+				klog.V(2).InfoS("received DATA for unrecognized connection", "connectionID", data.ConnectID)
 				a.Send(&client.Packet{
 					Type: client.PacketType_CLOSE_RSP,
 					Payload: &client.Packet_CloseResponse{

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -59,7 +59,7 @@ func TestServeData_HTTP(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	// Stimulate sending KAS DIAL_REQ to (Agent) Client
+	// Simulate sending KAS DIAL_REQ to (Agent) Client
 	dialPacket := newDialPacket("tcp", ts.URL[len("http://"):], 111)
 	err = stream.Send(dialPacket)
 	if err != nil {
@@ -67,17 +67,17 @@ func TestServeData_HTTP(t *testing.T) {
 	}
 
 	// Expect receiving DIAL_RSP packet from (Agent) Client
-	pkg, err := stream.Recv()
+	pkt, err := stream.Recv()
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if pkg == nil {
+	if pkt == nil {
 		t.Fatal("unexpected nil packet")
 	}
-	if pkg.Type != client.PacketType_DIAL_RSP {
-		t.Errorf("expect PacketType_DIAL_RSP; got %v", pkg.Type)
+	if pkt.Type != client.PacketType_DIAL_RSP {
+		t.Errorf("expect PacketType_DIAL_RSP; got %v", pkt.Type)
 	}
-	dialRsp := pkg.Payload.(*client.Packet_DialResponse)
+	dialRsp := pkt.Payload.(*client.Packet_DialResponse)
 	connID := dialRsp.DialResponse.ConnectID
 	if dialRsp.DialResponse.Random != 111 {
 		t.Errorf("expect random=111; got %v", dialRsp.DialResponse.Random)
@@ -91,14 +91,14 @@ func TestServeData_HTTP(t *testing.T) {
 	}
 
 	// Expect receiving http response via (Agent) Client
-	pkg, _ = stream.Recv()
-	if pkg == nil {
+	pkt, _ = stream.Recv()
+	if pkt == nil {
 		t.Fatal("unexpected nil packet")
 	}
-	if pkg.Type != client.PacketType_DATA {
-		t.Errorf("expect PacketType_DATA; got %v", pkg.Type)
+	if pkt.Type != client.PacketType_DATA {
+		t.Errorf("expect PacketType_DATA; got %v", pkt.Type)
 	}
-	data := pkg.Payload.(*client.Packet_Data).Data.Data
+	data := pkt.Payload.(*client.Packet_Data).Data.Data
 
 	// Verify response data
 	//
@@ -117,14 +117,14 @@ func TestServeData_HTTP(t *testing.T) {
 	ts.Close()
 
 	// Verify receiving CLOSE_RSP
-	pkg, _ = stream.Recv()
-	if pkg == nil {
+	pkt, _ = stream.Recv()
+	if pkt == nil {
 		t.Fatal("unexpected nil packet")
 	}
-	if pkg.Type != client.PacketType_CLOSE_RSP {
-		t.Errorf("expect PacketType_CLOSE_RSP; got %v", pkg.Type)
+	if pkt.Type != client.PacketType_CLOSE_RSP {
+		t.Errorf("expect PacketType_CLOSE_RSP; got %v", pkt.Type)
 	}
-	closeErr := pkg.Payload.(*client.Packet_CloseResponse).CloseResponse.Error
+	closeErr := pkt.Payload.(*client.Packet_CloseResponse).CloseResponse.Error
 	if closeErr != "" {
 		t.Errorf("expect nil closeErr; got %v", closeErr)
 	}
@@ -159,7 +159,7 @@ func TestClose_Client(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	// Stimulate sending KAS DIAL_REQ to (Agent) Client
+	// Simulate sending KAS DIAL_REQ to (Agent) Client
 	dialPacket := newDialPacket("tcp", ts.URL[len("http://"):], 111)
 	err := stream.Send(dialPacket)
 	if err != nil {
@@ -167,14 +167,14 @@ func TestClose_Client(t *testing.T) {
 	}
 
 	// Expect receiving DIAL_RSP packet from (Agent) Client
-	pkg, _ := stream.Recv()
-	if pkg == nil {
+	pkt, _ := stream.Recv()
+	if pkt == nil {
 		t.Fatal("unexpected nil packet")
 	}
-	if pkg.Type != client.PacketType_DIAL_RSP {
-		t.Errorf("expect PacketType_DIAL_RSP; got %v", pkg.Type)
+	if pkt.Type != client.PacketType_DIAL_RSP {
+		t.Errorf("expect PacketType_DIAL_RSP; got %v", pkt.Type)
 	}
-	dialRsp := pkg.Payload.(*client.Packet_DialResponse)
+	dialRsp := pkt.Payload.(*client.Packet_DialResponse)
 	connID := dialRsp.DialResponse.ConnectID
 	if dialRsp.DialResponse.Random != 111 {
 		t.Errorf("expect random=111; got %v", dialRsp.DialResponse.Random)
@@ -186,14 +186,14 @@ func TestClose_Client(t *testing.T) {
 	}
 
 	// Expect receiving close response via (Agent) Client
-	pkg, _ = stream.Recv()
-	if pkg == nil {
+	pkt, _ = stream.Recv()
+	if pkt == nil {
 		t.Error("unexpected nil packet")
 	}
-	if pkg.Type != client.PacketType_CLOSE_RSP {
-		t.Errorf("expect PacketType_CLOSE_RSP; got %v", pkg.Type)
+	if pkt.Type != client.PacketType_CLOSE_RSP {
+		t.Errorf("expect PacketType_CLOSE_RSP; got %v", pkt.Type)
 	}
-	closeErr := pkg.Payload.(*client.Packet_CloseResponse).CloseResponse.Error
+	closeErr := pkt.Payload.(*client.Packet_CloseResponse).CloseResponse.Error
 	if closeErr != "" {
 		t.Errorf("expect nil closeErr; got %v", closeErr)
 	}
@@ -209,14 +209,14 @@ func TestClose_Client(t *testing.T) {
 	}
 
 	// Expect receiving close response via (Agent) Client
-	pkg, _ = stream.Recv()
-	if pkg == nil {
+	pkt, _ = stream.Recv()
+	if pkt == nil {
 		t.Error("unexpected nil packet")
 	}
-	if pkg.Type != client.PacketType_CLOSE_RSP {
-		t.Errorf("expect PacketType_CLOSE_RSP; got %+v", pkg)
+	if pkt.Type != client.PacketType_CLOSE_RSP {
+		t.Errorf("expect PacketType_CLOSE_RSP; got %+v", pkt)
 	}
-	closeErr = pkg.Payload.(*client.Packet_CloseResponse).CloseResponse.Error
+	closeErr = pkt.Payload.(*client.Packet_CloseResponse).CloseResponse.Error
 	if closeErr != "Unknown connectID" {
 		t.Errorf("expect Unknown connectID; got %v", closeErr)
 	}
@@ -326,7 +326,7 @@ func TestFailedSend_DialResp_GRPC(t *testing.T) {
 		time.Sleep(time.Second)
 		defer goleakVerifyNone(t, goleak.IgnoreCurrent())
 
-		// Stimulate sending KAS DIAL_REQ to (Agent) Client
+		// Simulate sending KAS DIAL_REQ to (Agent) Client
 		dialPacket := newDialPacket("tcp", strings.TrimPrefix(ts.URL, "http://"), 111)
 		err := stream.Send(dialPacket)
 		if err != nil {
@@ -368,9 +368,9 @@ func (s *fakeStream) Send(packet *client.Packet) error {
 
 func (s *fakeStream) Recv() (*client.Packet, error) {
 	select {
-	case pkg := <-s.r:
-		klog.V(4).InfoS("[DEBUG] recv", "packet", pkg)
-		return pkg, nil
+	case pkt := <-s.r:
+		klog.V(4).InfoS("[DEBUG] recv", "packet", pkt)
+		return pkt, nil
 	case <-time.After(5 * time.Second):
 		return nil, errors.New("timeout recv")
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -507,8 +507,7 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			connID := pkt.GetCloseRequest().ConnectID
 			klog.V(5).InfoS("Received CLOSE_REQ", "connectionID", connID)
 			if backend == nil {
-				klog.V(2).InfoS("Backend has not been initialized for requested connection. Client should send a Dial Request first",
-					"connectionID", connID)
+				klog.V(2).InfoS("Backend has not been initialized for this connection", "connectionID", connID)
 				s.sendFrontendClose(stream, connID, "backend uninitialized")
 				continue
 			}
@@ -540,7 +539,7 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			data := pkt.GetData().Data
 			klog.V(5).InfoS("Received data from connection", "bytes", len(data), "connectionID", connID)
 			if backend == nil {
-				klog.V(2).InfoS("Backend has not been initialized for the connection. Client should send a Dial Request first", "connectionID", connID)
+				klog.V(2).InfoS("Backend has not been initialized for this connection", "connectionID", connID)
 				s.sendFrontendClose(stream, connID, "backend not initialized")
 				return
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -874,7 +874,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 			klog.V(5).InfoS("Received data from agent", "bytes", len(resp.Data), "agentID", agentID, "connectionID", resp.ConnectID)
 			frontend, err := s.getFrontend(agentID, resp.ConnectID)
 			if err != nil {
-				klog.ErrorS(err, "could not get frontend client; closing conenction", "agentID", agentID, "connectionID", resp.ConnectID)
+				klog.V(2).InfoS("could not get frontend client; closing conenction", "agentID", agentID, "connectionID", resp.ConnectID, "error", err)
 				s.sendBackendClose(stream, resp.ConnectID, 0, "missing frontend")
 				break
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -509,11 +509,13 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			if backend == nil {
 				klog.V(2).InfoS("Backend has not been initialized for requested connection. Client should send a Dial Request first",
 					"connectionID", connID)
+				s.sendFrontendClose(stream, connID, "backend uninitialized")
 				continue
 			}
 			if err := backend.Send(pkt); err != nil {
 				// TODO: retry with other backends connecting to this agent.
 				klog.ErrorS(err, "CLOSE_REQ to Backend failed", "connectionID", connID)
+				s.sendFrontendClose(stream, connID, "CLOSE_REQ to backend failed")
 			} else {
 				klog.V(5).InfoS("CLOSE_REQ sent to backend", "connectionID", connID)
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -544,6 +544,11 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 				return
 			}
 
+			if connID == 0 {
+				klog.ErrorS(nil, "Received packet missing ConnectID from frontend", "packetType", "DATA")
+				continue
+			}
+
 			if firstConnID == 0 {
 				firstConnID = connID
 			} else if firstConnID != connID {
@@ -892,6 +897,11 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 		case client.PacketType_DATA:
 			resp := pkt.GetData()
 			klog.V(5).InfoS("Received data from agent", "bytes", len(resp.Data), "agentID", agentID, "connectionID", resp.ConnectID)
+			if resp.ConnectID == 0 {
+				klog.ErrorS(nil, "Received packet missing ConnectID from agent", "packetType", "DATA")
+				continue
+			}
+
 			frontend, err := s.getFrontend(agentID, resp.ConnectID)
 			if err != nil {
 				klog.V(2).InfoS("could not get frontend client; closing connection", "agentID", agentID, "connectionID", resp.ConnectID, "error", err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -361,9 +361,6 @@ func TestServerProxyNormalClose(t *testing.T) {
 			agentConn.EXPECT().Send(dialReq).Return(nil).Times(1),
 			agentConn.EXPECT().Send(data).Return(nil).Times(1),
 			agentConn.EXPECT().Send(closeReqPkt(connectID)).Return(nil).Times(1),
-			// This extra close is unwanted and should be removed; see
-			// https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/307
-			agentConn.EXPECT().Send(closeReqPkt(connectID)).Return(nil).Times(1),
 		)
 	}
 	baseServerProxyTestWithBackend(t, validate)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -527,10 +527,10 @@ func TestServerProxyConnectionMismatch(t *testing.T) {
 			agentConn.EXPECT().Send(dialReq).Return(nil),
 			agentConn.EXPECT().Send(data).Return(nil),
 		)
-		agentConn.EXPECT().Send(closeReqPkt(firstConnectID)).Return(nil)
 		agentConn.EXPECT().Send(closeReqPkt(secondConnectID)).Return(nil)
-		frontendConn.EXPECT().Send(closeRspPkt(firstConnectID, "mismatched connection IDs")).Return(nil)
+		agentConn.EXPECT().Send(closeReqPkt(firstConnectID)).Return(nil)
 		frontendConn.EXPECT().Send(closeRspPkt(secondConnectID, "mismatched connection IDs")).Return(nil)
+		frontendConn.EXPECT().Send(closeRspPkt(firstConnectID, "mismatched connection IDs")).Return(nil)
 	})
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -354,16 +354,16 @@ func TestServerProxyNormalClose(t *testing.T) {
 		gomock.InOrder(
 			frontendConn.EXPECT().Recv().Return(dialReq, nil).Times(1),
 			frontendConn.EXPECT().Recv().Return(data, nil).Times(1),
-			frontendConn.EXPECT().Recv().Return(closePacket(connectID), nil).Times(1),
+			frontendConn.EXPECT().Recv().Return(closeReqPkt(connectID), nil).Times(1),
 			frontendConn.EXPECT().Recv().Return(nil, io.EOF).Times(1),
 		)
 		gomock.InOrder(
 			agentConn.EXPECT().Send(dialReq).Return(nil).Times(1),
 			agentConn.EXPECT().Send(data).Return(nil).Times(1),
-			agentConn.EXPECT().Send(closePacket(connectID)).Return(nil).Times(1),
+			agentConn.EXPECT().Send(closeReqPkt(connectID)).Return(nil).Times(1),
 			// This extra close is unwanted and should be removed; see
 			// https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/307
-			agentConn.EXPECT().Send(closePacket(connectID)).Return(nil).Times(1),
+			agentConn.EXPECT().Send(closeReqPkt(connectID)).Return(nil).Times(1),
 		)
 	}
 	baseServerProxyTestWithBackend(t, validate)
@@ -440,7 +440,7 @@ func TestServerProxyRecvChanFull(t *testing.T) {
 				return data, nil
 			}),
 
-			frontendConn.EXPECT().Recv().Return(closePacket(1), nil),
+			frontendConn.EXPECT().Recv().Return(closeReqPkt(1), nil),
 			frontendConn.EXPECT().Recv().Return(nil, io.EOF),
 		)
 		gomock.InOrder(
@@ -455,21 +455,103 @@ func TestServerProxyRecvChanFull(t *testing.T) {
 				return nil
 			}),
 			agentConn.EXPECT().Send(data).Return(nil).Times(xfrChannelSize+1), // Expect the remaining packets to be sent.
-			agentConn.EXPECT().Send(closePacket(1)).Return(nil),
+			agentConn.EXPECT().Send(closeReqPkt(1)).Return(nil),
 			// This extra close is unwanted and should be removed; see
 			// https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/307
-			agentConn.EXPECT().Send(closePacket(1)).Return(nil),
+			agentConn.EXPECT().Send(closeReqPkt(1)).Return(nil),
 		)
 	}
 	baseServerProxyTestWithBackend(t, validate)
 }
 
-func closePacket(connectID int64) *client.Packet {
+func TestServerProxyNoDial(t *testing.T) {
+	baseServerProxyTestWithBackend(t, func(frontendConn, agentConn *agentmock.MockAgentService_ConnectServer) {
+		const connectID = 123456
+		data := &client.Packet{
+			Type: client.PacketType_DATA,
+			Payload: &client.Packet_Data{
+				Data: &client.Data{
+					ConnectID: connectID,
+				},
+			},
+		}
+
+		gomock.InOrder(
+			frontendConn.EXPECT().Recv().Return(data, nil),
+			frontendConn.EXPECT().Recv().Return(nil, io.EOF),
+		)
+		frontendConn.EXPECT().Send(closeRspPkt(connectID, "backend not initialized")).Return(nil)
+	})
+}
+
+func TestServerProxyConnectionMismatch(t *testing.T) {
+	baseServerProxyTestWithBackend(t, func(frontendConn, agentConn *agentmock.MockAgentService_ConnectServer) {
+		const firstConnectID = 123456
+		const secondConnectID = 654321
+		dialReq := &client.Packet{
+			Type: client.PacketType_DIAL_REQ,
+			Payload: &client.Packet_DialRequest{
+				DialRequest: &client.DialRequest{
+					Protocol: "tcp",
+					Address:  "127.0.0.1:8080",
+					Random:   111,
+				},
+			},
+		}
+		data := &client.Packet{
+			Type: client.PacketType_DATA,
+			Payload: &client.Packet_Data{
+				Data: &client.Data{
+					ConnectID: firstConnectID,
+					Data:      []byte("hello"),
+				},
+			},
+		}
+		mismatchedData := &client.Packet{
+			Type: client.PacketType_DATA,
+			Payload: &client.Packet_Data{
+				Data: &client.Data{
+					ConnectID: secondConnectID,
+					Data:      []byte("world"),
+				},
+			},
+		}
+
+		gomock.InOrder(
+			frontendConn.EXPECT().Recv().Return(dialReq, nil),
+			frontendConn.EXPECT().Recv().Return(data, nil),
+			frontendConn.EXPECT().Recv().Return(mismatchedData, nil),
+			frontendConn.EXPECT().Recv().Return(nil, io.EOF),
+		)
+		gomock.InOrder(
+			agentConn.EXPECT().Send(dialReq).Return(nil),
+			agentConn.EXPECT().Send(data).Return(nil),
+		)
+		agentConn.EXPECT().Send(closeReqPkt(firstConnectID)).Return(nil)
+		agentConn.EXPECT().Send(closeReqPkt(secondConnectID)).Return(nil)
+		frontendConn.EXPECT().Send(closeRspPkt(firstConnectID, "mismatched connection IDs")).Return(nil)
+		frontendConn.EXPECT().Send(closeRspPkt(secondConnectID, "mismatched connection IDs")).Return(nil)
+	})
+}
+
+func closeReqPkt(connectID int64) *client.Packet {
 	return &client.Packet{
 		Type: client.PacketType_CLOSE_REQ,
 		Payload: &client.Packet_CloseRequest{
 			CloseRequest: &client.CloseRequest{
 				ConnectID: connectID,
 			}},
+	}
+}
+
+func closeRspPkt(connectID int64, errMsg string) *client.Packet {
+	return &client.Packet{
+		Type: client.PacketType_CLOSE_RSP,
+		Payload: &client.Packet_CloseResponse{
+			CloseResponse: &client.CloseResponse{
+				ConnectID: connectID,
+				Error:     errMsg,
+			},
+		},
 	}
 }


### PR DESCRIPTION
I don't actually understand how we're getting into this state, but this log line shows up with some frequency:

```
"could not get frontend client" err="can't find connID 2 in the frontends[a19ff692-407c-4326-89e2-c53d8e4d2617]" serverID="1768996f-7935-40e8-9e24-51de50e81663" agentID="a19ff692-407c-4326-89e2-c53d8e4d2617" connectionID=2
```

This is a non-recoverable condition, indicating that somehow the frontend was disconnected but left the backend connection open. When this happens, reply to the backend with a close request.