### PR TITLE
Improve dial response logging

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -222,7 +222,11 @@ func (t *grpcTunnel) serve(tunnelCtx context.Context) {
 				//   2. grpcTunnel.DialContext() returned early due to a dial timeout or the client canceling the context
 				//
 				// In either scenario, we should return here and close the tunnel as it is no longer needed.
-				klog.V(1).InfoS("DialResp not recognized; dropped", "connectionID", resp.ConnectID, "dialID", resp.Random)
+				kvs := []interface{}{"dialID", resp.Random, "connectID", resp.ConnectID}
+				if resp.Error != "" {
+					kvs = append(kvs, "error", resp.Error)
+				}
+				klog.V(1).InfoS("DialResp not recognized; dropped", kvs...)
 				return
 			}
 


### PR DESCRIPTION
While investigating a konnectivity issue, I noticed a lot of log lines like the following:
```
"DialResp not recognized; dropped" connectionID=0 dialID=3266472531351727827
```

Notably, a `connectionID` should only be 0 in a dial response if an error occurred, but we don't log the error in this case. With this change, the log would instead look like:

```
"DialResp not recognized; dropped" dialID=3266472531351727827 connectionID=0 error="hello?"
```