### PR TITLE
Adjust server log verbosity to improve signal:noise

### DIFF
--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -188,7 +188,7 @@ func (s *DefaultBackendStorage) AddBackend(identifier string, idType pkgagent.Id
 		klog.V(4).InfoS("fail to add backend", "backend", identifier, "error", &ErrWrongIDType{idType, s.idTypes})
 		return nil
 	}
-	klog.V(2).InfoS("Register backend for agent", "connection", conn, "agentID", identifier)
+	klog.V(5).InfoS("Register backend for agent", "connection", conn, "agentID", identifier)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	_, ok := s.backends[identifier]
@@ -218,7 +218,7 @@ func (s *DefaultBackendStorage) RemoveBackend(identifier string, idType pkgagent
 		klog.ErrorS(&ErrWrongIDType{idType, s.idTypes}, "fail to remove backend")
 		return
 	}
-	klog.V(2).InfoS("Remove connection for agent", "connection", conn, "identifier", identifier)
+	klog.V(5).InfoS("Remove connection for agent", "connection", conn, "identifier", identifier)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	backends, ok := s.backends[identifier]
@@ -299,7 +299,7 @@ func (s *DefaultBackendStorage) GetRandomBackend() (Backend, error) {
 		return nil, &ErrNotFound{}
 	}
 	agentID := s.agentIDs[s.random.Intn(len(s.agentIDs))]
-	klog.V(4).InfoS("Pick agent as backend", "agentID", agentID)
+	klog.V(5).InfoS("Pick agent as backend", "agentID", agentID)
 	// always return the first connection to an agent, because the agent
 	// will close later connections if there are multiple.
 	return s.backends[agentID][0], nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -271,7 +271,6 @@ func (s *ProxyServer) removeBackend(agentID string, conn agent.AgentService_Conn
 }
 
 func (s *ProxyServer) addFrontend(agentID string, connID int64, p *ProxyClientConnection) {
-	klog.V(2).InfoS("Register frontend for agent", "frontend", p, "agentID", agentID, "connectionID", connID)
 	s.fmu.Lock()
 	defer s.fmu.Unlock()
 	if _, ok := s.frontends[agentID]; !ok {
@@ -292,12 +291,10 @@ func (s *ProxyServer) removeFrontend(agentID string, connID int64) {
 		klog.V(2).InfoS("Cannot find connection for agent in the frontends", "connectionID", connID, "agentID", agentID)
 		return
 	}
-	klog.V(2).InfoS("Remove frontend for agent", "frontend", conns[connID], "agentID", agentID, "connectionID", connID)
 	delete(s.frontends[agentID], connID)
 	if len(s.frontends[agentID]) == 0 {
 		delete(s.frontends, agentID)
 	}
-	return
 }
 
 func (s *ProxyServer) getFrontend(agentID string, connID int64) (*ProxyClientConnection, error) {
@@ -369,7 +366,7 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 		return fmt.Errorf("failed to get context")
 	}
 	userAgent := md.Get(header.UserAgent)
-	klog.V(2).InfoS("Proxy request from client", "userAgent", userAgent, "serverID", s.serverID)
+	klog.V(5).InfoS("Proxy request from client", "userAgent", userAgent, "serverID", s.serverID)
 
 	recvCh := make(chan *client.Packet, xfrChannelSize)
 	stopCh := make(chan error)
@@ -381,7 +378,6 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 	go runpprof.Do(context.Background(), labels, func(context.Context) { s.serveRecvFrontend(stream, recvCh) })
 
 	defer func() {
-		klog.V(2).InfoS("Receive channel from frontend is stopping", "userAgent", userAgent)
 		close(recvCh)
 	}()
 
@@ -395,6 +391,7 @@ func (s *ProxyServer) readFrontendToChannel(stream client.ProxyService_ProxyServ
 	for {
 		in, err := stream.Recv()
 		if err == io.EOF {
+			// TODO: Log an error if the frontend connection stops without first closing any open connections.
 			klog.V(2).InfoS("Receive stream from frontend closed", "userAgent", userAgent)
 			close(stopCh)
 			return
@@ -531,6 +528,7 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 		}
 	}
 
+	// TODO: Log an error if the frontend stream is closed with an established tunnel still open.
 	klog.V(5).InfoS("Close streaming", "connectionID", firstConnID)
 
 	if backend == nil {
@@ -654,7 +652,7 @@ func (s *ProxyServer) authenticateAgentViaToken(ctx context.Context) error {
 		return fmt.Errorf("Failed to validate authentication token, err:%v", err)
 	}
 
-	klog.V(2).InfoS("Agent successfully authenticated via token", "username", username)
+	klog.V(5).InfoS("Agent successfully authenticated via token", "username", username)
 	return nil
 }
 
@@ -668,7 +666,7 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 		return err
 	}
 
-	klog.V(2).InfoS("Connect request from agent", "agentID", agentID, "serverID", s.serverID)
+	klog.V(5).InfoS("Connect request from agent", "agentID", agentID, "serverID", s.serverID)
 	labels := runpprof.Labels(
 		"serverCount", strconv.Itoa(s.serverCount),
 		"agentID", agentID,
@@ -689,6 +687,7 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 		return err
 	}
 
+	klog.V(2).InfoS("Agent connected", "agentID", agentID, "serverID", s.serverID)
 	backend := s.addBackend(agentID, stream)
 	defer s.removeBackend(agentID, stream)
 
@@ -697,7 +696,6 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 	go runpprof.Do(context.Background(), labels, func(context.Context) { s.serveRecvBackend(backend, stream, agentID, recvCh) })
 
 	defer func() {
-		klog.V(2).InfoS("Receive channel from agent is stopping", "agentID", agentID)
 		close(recvCh)
 	}()
 


### PR DESCRIPTION
We log a lot of redundant information when starting and stopping new connections. This PR moves most of those redundant logs to `V(5)` to cut down on log spam.

/assign @jkh52 