### PR TITLE
Add rudimentary data transfer benchmark tests

### DIFF
--- a/tests/benchmarks_test.go
+++ b/tests/benchmarks_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/grpc"
+	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
+)
+
+func BenchmarkLargeResponse_GRPC(b *testing.B) {
+	b.StopTimer()
+
+	expectCleanShutdown(b)
+
+	ctx := context.Background()
+	const length = 1 << 20 // 1M
+	const chunks = 10
+	server := httptest.NewServer(newSizedServer(length, chunks))
+	defer server.Close()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	proxy, cleanup, err := runGRPCProxyServer()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+
+	clientset := runAgent(proxy.agent, stopCh)
+	waitForConnectedServerCount(b, 1, clientset)
+
+	req, err := http.NewRequest("GET", server.URL, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	req.Close = true
+
+	for n := 0; n < b.N; n++ {
+		// run test client
+		tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		c := &http.Client{
+			Transport: &http.Transport{
+				DialContext: tunnel.DialContext,
+			},
+		}
+
+		r, err := c.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.StartTimer() // BEGIN CRITICAL SECTION
+
+		size, err := io.Copy(io.Discard, r.Body)
+		if err != nil {
+			b.Fatal(err)
+		}
+		r.Body.Close()
+
+		b.StopTimer() // END CRITICAL SECTION
+
+		if size != length*chunks {
+			b.Fatalf("expect data length %d; got %d", length*chunks, size)
+		}
+	}
+}
+
+func BenchmarkLargeRequest_GRPC(b *testing.B) {
+	b.StopTimer()
+
+	expectCleanShutdown(b)
+
+	const length = 10 << 20 // 10M
+
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		size, err := io.Copy(io.Discard, req.Body)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if size != length {
+			b.Fatalf("Expected data length %d; got %d", length, size)
+		}
+		req.Body.Close()
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	proxy, cleanup, err := runGRPCProxyServer()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+
+	clientset := runAgent(proxy.agent, stopCh)
+	waitForConnectedServerCount(b, 1, clientset)
+
+	bodyBytes := make([]byte, length)
+	body := bytes.NewReader(bodyBytes)
+	req, err := http.NewRequest("POST", server.URL, body)
+	if err != nil {
+		b.Fatal(err)
+	}
+	req.Close = true
+	for n := 0; n < b.N; n++ {
+		// run test client
+		tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		c := &http.Client{
+			Transport: &http.Transport{
+				DialContext: tunnel.DialContext,
+			},
+		}
+		body.Reset(bodyBytes) // We're reusing the request, so make sure to reset the body reader.
+
+		b.StartTimer() // BEGIN CRITICAL SECTION
+
+		if _, err := c.Do(req); err != nil {
+			b.Fatal(err)
+		}
+
+		b.StopTimer() // END CRITICAL SECTION
+	}
+}

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -786,7 +786,7 @@ func (a *unresponsiveAgent) Close() {
 
 // waitForConnectedServerCount waits for the agent ClientSet to have the expected number of health
 // server connections (HealthyClientsCount).
-func waitForConnectedServerCount(t *testing.T, expectedServerCount int, clientset *agent.ClientSet) {
+func waitForConnectedServerCount(t testing.TB, expectedServerCount int, clientset *agent.ClientSet) {
 	t.Helper()
 	err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
 		hc := clientset.HealthyClientsCount()
@@ -804,7 +804,7 @@ func waitForConnectedServerCount(t *testing.T, expectedServerCount int, clientse
 
 // waitForConnectedAgentCount waits for the proxy server to have the expected number of registered
 // agents (backends). This assumes the ProxyServer is using a single ProxyStrategy.
-func waitForConnectedAgentCount(t *testing.T, expectedAgentCount int, proxy *server.ProxyServer) {
+func waitForConnectedAgentCount(t testing.TB, expectedAgentCount int, proxy *server.ProxyServer) {
 	t.Helper()
 	err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
 		count := proxy.BackendManagers[0].NumBackends()
@@ -820,14 +820,14 @@ func waitForConnectedAgentCount(t *testing.T, expectedAgentCount int, proxy *ser
 	}
 }
 
-func assertNoDialFailures(t *testing.T) {
+func assertNoDialFailures(t testing.TB) {
 	t.Helper()
 	if err := metricstest.ExpectDialFailures(nil); err != nil {
 		t.Errorf("Unexpected %s metric: %v", metrics.DialFailuresMetric, err)
 	}
 }
 
-func expectCleanShutdown(t *testing.T) {
+func expectCleanShutdown(t testing.TB) {
 	metrics.Metrics.Reset()
 	currentGoRoutines := goleak.IgnoreCurrent()
 	t.Cleanup(func() {


### PR DESCRIPTION
It would be nice to have finer grained benchmarks of each component (client, server, agent), but as a start I ported the `TestProxy_LargeResponse` test to a benchmark format.

Sample output:
```
$ go test -run=NONE -bench=. -benchtime=30s -benchmem ./tests 
E1129 19:14:19.508038  335474 server.go:717] "Receive stream from agent read failure" err="rpc error: code = Canceled desc = context canceled"
E1129 19:14:19.508042  335474 client.go:373] "could not read stream" err="rpc error: code = Unavailable desc = error reading from server: EOF"
goos: linux
goarch: amd64
pkg: sigs.k8s.io/apiserver-network-proxy/tests
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkLargeResponse-8   	E1129 19:14:21.971631  335474 server.go:489] "CLOSE_REQ to Backend failed" err="rpc error: code = Unavailable desc = transport is closing" connectionID=100
E1129 19:14:21.971653  335474 server.go:717] "Receive stream from agent read failure" err="rpc error: code = Canceled desc = context canceled"
E1129 19:14:21.971682  335474 client.go:373] "could not read stream" err="rpc error: code = Unavailable desc = error reading from server: EOF"
E1129 19:15:24.853293  335474 server.go:717] "Receive stream from agent read failure" err="rpc error: code = Canceled desc = context canceled"
E1129 19:15:24.853340  335474 client.go:373] "could not read stream" err="rpc error: code = Unavailable desc = error reading from server: EOF"
    1707	  34989458 ns/op	75144562 B/op	  125625 allocs/op
E1129 19:15:25.022841  335474 server.go:717] "Receive stream from agent read failure" err="rpc error: code = Canceled desc = context canceled"
E1129 19:15:25.022933  335474 client.go:373] "could not read stream" err="rpc erroTestProxy_LargeResponser: code = Unavailable desc = error reading from server: EOF"
BenchmarkLargeRequest-8    	E1129 19:15:27.705732  335474 client.go:373] "could not read stream" err="rpc error: code = Unavailable desc = error reading from server: EOF"
E1129 19:15:27.705802  335474 server.go:717] "Receive stream from agent read failure" err="rpc error: code = Canceled desc = context canceled"
E1129 19:15:57.187120  335474 server.go:717] "Receive stream from agent read faiTestProxy_LargeResponselure" err="rpc error: code = Canceled desc = context canceled"
E1129 19:15:57.187125  335474 client.go:373] "could not read stream" err="rpc error: code = Unavailable desc = error reading from server: EOF"
E1129 19:16:32.190629  335474 server.go:489] "CLOSE_REQ to Backend failed" err="rpc error: code = Unavailable desc = transport is closing" connectionID=1935
E1129 19:16:32.190658  335474 server.go:717] "Receive stream from agent read failure" err="rpc error: code = Canceled desc = context canceled"
E1129 19:16:32.190723  335474 client.go:373] "could not read stream" err="rpc error: code = Unavailable desc = error reading from server: EOF"
    1935	  17354640 ns/op	75489542 B/op	   19326 allocs/op
PASS
ok  	sigs.k8s.io/apiserver-network-proxy/tests	132.885s
```

/assign @jkh52 