### PR TITLE
Fix test flake.

### DIFF
--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -129,6 +129,9 @@ func TestServeData_HTTP(t *testing.T) {
 		t.Errorf("expect nil closeErr; got %v", closeErr)
 	}
 
+	// give agent time to clean up.
+	time.Sleep(250 * time.Millisecond)
+
 	// Verify internal state is consistent
 	if _, ok := testClient.connManager.Get(connID); ok {
 		t.Error("client.connContext not released")

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -265,8 +265,8 @@ func baseServerProxyTestWithoutBackend(t *testing.T, validate func(*agentmock.Mo
 
 	proxyServer.Proxy(frontendConn)
 
-	// add a sleep to make sure `serveRecvFrontend` ends after `Proxy` finished.
-	time.Sleep(1 * time.Second)
+	// make sure `serveRecvFrontend` ends after `Proxy` finished.
+	time.Sleep(250 * time.Millisecond)
 }
 
 func baseServerProxyTestWithBackend(t *testing.T, validate func(*agentmock.MockAgentService_ConnectServer, *agentmock.MockAgentService_ConnectServer)) {
@@ -284,8 +284,8 @@ func baseServerProxyTestWithBackend(t *testing.T, validate func(*agentmock.MockA
 
 	proxyServer.Proxy(frontendConn)
 
-	// add a sleep to make sure `serveRecvFrontend` ends after `Proxy` finished.
-	time.Sleep(1 * time.Second)
+	// make sure `serveRecvFrontend` ends after `Proxy` finished.
+	time.Sleep(250 * time.Millisecond)
 }
 
 func TestServerProxyNoBackend(t *testing.T) {


### PR DESCRIPTION
--- FAIL: TestServeData_HTTP (0.01s)
    client_test.go:134: client.connContext not released

Also make test sleeps a bit more lean.