### PR TITLE
[server] Block Proxy from returning on both go-routines exiting

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -265,9 +265,6 @@ func baseServerProxyTestWithoutBackend(t *testing.T, validate func(*agentmock.Mo
 	validate(frontendConn)
 
 	proxyServer.Proxy(frontendConn)
-
-	// add a sleep to make sure `serveRecvFrontend` ends after `Proxy` finished.
-	time.Sleep(1 * time.Second)
 }
 
 func baseServerProxyTestWithBackend(t *testing.T, validate func(*agentmock.MockAgentService_ConnectServer, *agentmock.MockAgentService_ConnectServer)) {
@@ -284,9 +281,6 @@ func baseServerProxyTestWithBackend(t *testing.T, validate func(*agentmock.MockA
 	validate(frontendConn, agentConn)
 
 	proxyServer.Proxy(frontendConn)
-
-	// add a sleep to make sure `serveRecvFrontend` ends after `Proxy` finished.
-	time.Sleep(1 * time.Second)
 }
 
 func TestServerProxyNoBackend(t *testing.T) {


### PR DESCRIPTION
This PR prevents the server's `Proxy` method from returning until both `readFrontendToChannel` and `serveRecvFrontend` have completed. This lets us remove the `time.Sleep` from `server_test.go` and de-flake the test.

This also has the added benefit of reducing the number of go-routines started by Proxy by 1.

/assign @jkh52 