### PR TITLE
Remove a DialFailureReason metric case.

### DIFF
--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -136,7 +136,7 @@ func newServerMetrics() *ServerMetrics {
 			Namespace: Namespace,
 			Subsystem: Subsystem,
 			Name:      DialFailuresMetric,
-			Help:      "Number of dial failures observed. Multiple failures can occur for a single dial request.",
+			Help:      "Number of dial failures observed.",
 		},
 		[]string{
 			"reason",
@@ -219,8 +219,8 @@ type DialFailureReason string
 
 const (
 	DialFailureErrorResponse        DialFailureReason = "error_response"        // Dial failure reported by the agent back to the server.
-	DialFailureUnrecognizedResponse DialFailureReason = "unrecognized_response" // Dial repsonse received for unrecognozide dial ID.
-	DialFailureSendResponse         DialFailureReason = "send_rsp"              // Successful dial response from agent, but failed to send to frontend.
+	DialFailureUnrecognizedResponse DialFailureReason = "unrecognized_response" // Dial repsonse received for unrecognized dial ID.
+	DialFailureSendResponse         DialFailureReason = "send_rsp"              // Deprecated.
 	DialFailureBackendClose         DialFailureReason = "backend_close"         // Received a DIAL_CLS from the backend before the dial completed.
 	DialFailureFrontendClose        DialFailureReason = "frontend_close"        // Received a DIAL_CLS from the frontend before the dial completed.
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -784,9 +784,6 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 				if err != nil {
 					klog.ErrorS(err, "DIAL_RSP send to frontend stream failure",
 						"dialID", resp.Random, "agentID", agentID, "connectionID", resp.ConnectID)
-					if !dialErr { // Avoid double-counting.
-						metrics.Metrics.ObserveDialFailure(metrics.DialFailureSendResponse)
-					}
 					// If we never finish setting up the tunnel for ConnectID, then the connection is dead.
 					// Currently, the agent will no resend DIAL_RSP, so connection is dead.
 					// We already attempted to tell the frontend that. We should ensure we tell the backend.

--- a/pkg/testing/metrics/metrics.go
+++ b/pkg/testing/metrics/metrics.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	dialFailureHeader = `
-# HELP konnectivity_network_proxy_server_dial_failure_count Number of dial failures observed. Multiple failures can occur for a single dial request.
+# HELP konnectivity_network_proxy_server_dial_failure_count Number of dial failures observed.
 # TYPE konnectivity_network_proxy_server_dial_failure_count counter`
 	dialFailureSample = `konnectivity_network_proxy_server_dial_failure_count{reason="%s"} %d`
 )


### PR DESCRIPTION
It is superceded by:
https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/423


/hold 
Wait on https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/423