### PR TITLE
Add more pprof functions to server and agent’s admin server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@
 /easy-rsa-master/
 /easy-rsa.tar.gz
 /easy-rsa
+
+# editor and IDE paraphernalia
+.idea
+.vscode
+
+# macOS paraphernalia
+.DS_Store

--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -152,6 +152,9 @@ func (a *Agent) runAdminServer(o *options.GrpcProxyAgentOptions) error {
 	if o.EnableProfiling {
 		muxHandler.HandleFunc("/debug/pprof", util.RedirectTo("/debug/pprof/"))
 		muxHandler.HandleFunc("/debug/pprof/", pprof.Index)
+		muxHandler.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		muxHandler.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		muxHandler.HandleFunc("/debug/pprof/trace", pprof.Trace)
 		if o.EnableContentionProfiling {
 			runtime.SetBlockProfileRate(1)
 		}

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -391,6 +391,9 @@ func (p *Proxy) runAdminServer(o *options.ProxyRunOptions, server *server.ProxyS
 	if o.EnableProfiling {
 		muxHandler.HandleFunc("/debug/pprof", util.RedirectTo("/debug/pprof/"))
 		muxHandler.HandleFunc("/debug/pprof/", netpprof.Index)
+		muxHandler.HandleFunc("/debug/pprof/profile", netpprof.Profile)
+		muxHandler.HandleFunc("/debug/pprof/symbol", netpprof.Symbol)
+		muxHandler.HandleFunc("/debug/pprof/trace", netpprof.Trace)
 		if o.EnableContentionProfiling {
 			runtime.SetBlockProfileRate(1)
 		}


### PR DESCRIPTION
This PR added some missing pprof functions to the server and agent’s admin server.
It also updated .gitignore to include some common paraphernalia. 