### PR TITLE
Update server and agent to 1.18.9

### DIFF
--- a/artifacts/images/agent-build.Dockerfile
+++ b/artifacts/images/agent-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-agent binary
-FROM golang:1.18.5 as builder
+FROM golang:1.18.9 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/server-build.Dockerfile
+++ b/artifacts/images/server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-server binary
-FROM golang:1.18.5 as builder
+FROM golang:1.18.9 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy


### PR DESCRIPTION
[CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622)

This is a continuation of https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/428 by @ipochi, who is unavailable for a couple weeks.