### PR TITLE
konnectivity-client: add dial failures metric by reason.

### DIFF
--- a/konnectivity-client/pkg/client/metrics/metrics.go
+++ b/konnectivity-client/pkg/client/metrics/metrics.go
@@ -41,29 +41,67 @@ type ClientMetrics struct {
 	registerOnce  sync.Once
 	streamPackets *prometheus.CounterVec
 	streamErrors  *prometheus.CounterVec
+	dialFailures  *prometheus.CounterVec
 }
 
+type DialFailureReason string
+
+const (
+	DialFailureUnknown DialFailureReason = "unknown"
+	// DialFailureTimeout indicates the hard 30 second timeout was hit.
+	DialFailureTimeout DialFailureReason = "timeout"
+	// DialFailureContext indicates that the context was cancelled or reached it's deadline before
+	// the dial response was returned.
+	DialFailureContext DialFailureReason = "context"
+	// DialFailureEndpoint indicates that the konnectivity-agent was unable to reach the backend endpoint.
+	DialFailureEndpoint DialFailureReason = "endpoint"
+	// DialFailureDialClosed indicates that the client received a CloseDial response, indicating the
+	// connection was closed before the dial could complete.
+	DialFailureDialClosed DialFailureReason = "dialclosed"
+	// DialFailureTunnelClosed indicates that the client connection was closed before the dial could
+	// complete.
+	DialFailureTunnelClosed DialFailureReason = "tunnelclosed"
+)
+
 func newMetrics() *ClientMetrics {
+	// The denominator (total dials started) for both
+	// dial_failure_total and dial_duration_seconds is the
+	// stream_packets_total (common metric), where segment is
+	// "from_client" and packet_type is "DIAL_REQ".
+	dialFailures := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "dial_failure_total",
+			Help:      "Number of dial failures observed, by reason (example: remote endpoint error)",
+		},
+		[]string{
+			"reason",
+		},
+	)
 	return &ClientMetrics{
 		streamPackets: commonmetrics.MakeStreamPacketsTotalMetric(Namespace, Subsystem),
 		streamErrors:  commonmetrics.MakeStreamErrorsTotalMetric(Namespace, Subsystem),
+		dialFailures:  dialFailures,
 	}
 }
 
 // RegisterMetrics registers all metrics with the client application.
-func (c *ClientMetrics) RegisterMetrics(r prometheus.Registerer, namespace, subsystem string) {
+func (c *ClientMetrics) RegisterMetrics(r prometheus.Registerer) {
 	c.registerOnce.Do(func() {
 		r.MustRegister(c.streamPackets)
 		r.MustRegister(c.streamErrors)
+		r.MustRegister(c.dialFailures)
 	})
 }
 
 // LegacyRegisterMetrics registers all metrics via MustRegister func.
 // TODO: remove this once https://github.com/kubernetes/kubernetes/pull/114293 is available.
-func (c *ClientMetrics) LegacyRegisterMetrics(mustRegisterFn func(...prometheus.Collector), namespace, subsystem string) {
+func (c *ClientMetrics) LegacyRegisterMetrics(mustRegisterFn func(...prometheus.Collector)) {
 	c.registerOnce.Do(func() {
 		mustRegisterFn(c.streamPackets)
 		mustRegisterFn(c.streamErrors)
+		mustRegisterFn(c.dialFailures)
 	})
 }
 
@@ -71,6 +109,11 @@ func (c *ClientMetrics) LegacyRegisterMetrics(mustRegisterFn func(...prometheus.
 func (c *ClientMetrics) Reset() {
 	c.streamPackets.Reset()
 	c.streamErrors.Reset()
+	c.dialFailures.Reset()
+}
+
+func (c *ClientMetrics) ObserveDialFailure(reason DialFailureReason) {
+	c.dialFailures.WithLabelValues(string(reason)).Inc()
 }
 
 func (c *ClientMetrics) ObservePacket(segment commonmetrics.Segment, packetType client.PacketType) {

--- a/konnectivity-client/pkg/common/metrics/testing/metrics.go
+++ b/konnectivity-client/pkg/common/metrics/testing/metrics.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics"
+)
+
+const (
+	clientDialFailureHeader = `
+# HELP konnectivity_network_proxy_client_dial_failure_total Number of dial failures observed, by reason (example: remote endpoint error)
+# TYPE konnectivity_network_proxy_client_dial_failure_total counter`
+	clientDialFailureSample = `konnectivity_network_proxy_client_dial_failure_total{reason="%s"} %d`
+)
+
+func ExpectClientDialFailures(expected map[metrics.DialFailureReason]int) error {
+	expect := clientDialFailureHeader + "\n"
+	for r, v := range expected {
+		expect += fmt.Sprintf(clientDialFailureSample+"\n", r, v)
+	}
+	return ExpectMetric(metrics.Namespace, metrics.Subsystem, "dial_failure_total", expect)
+}
+
+func ExpectClientDialFailure(reason metrics.DialFailureReason, count int) error {
+	return ExpectClientDialFailures(map[metrics.DialFailureReason]int{reason: count})
+}
+
+func ExpectMetric(namespace, subsystem, name, expected string) error {
+	fqName := prometheus.BuildFQName(namespace, subsystem, name)
+	return promtest.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expected), fqName)
+}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -20,13 +20,17 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog/v2"
+
+	metricsclient "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics"
 )
 
 func TestMain(m *testing.M) {
 	fs := flag.NewFlagSet("mock-flags", flag.PanicOnError)
 	klog.InitFlags(fs)
 	fs.Set("v", "1") // Set klog verbosity.
+	metricsclient.Metrics.RegisterMetrics(prometheus.DefaultRegisterer)
 
 	m.Run()
 }


### PR DESCRIPTION
konnectivity-client: add dial failures metric by reason.

This takes advantage of recent client metrics support (#423), and the instrumentation at #389

Also trim unused parameters in client metrics Register function (wrongfully left by https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/423)