### PR TITLE
Fix broken `make lint`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 INSTALL_LOCATION:=$(shell go env GOPATH)/bin
-GOLANGCI_LINT_VERSION ?= 1.45.2
+GOLANGCI_LINT_VERSION ?= 1.50.1
 GOSEC_VERSION ?= 2.13.1
 
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
@@ -88,7 +88,7 @@ bin/proxy-server: proto/agent/agent_grpc.pb.go konnectivity-client/proto/client/
 .PHONY: lint
 lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(INSTALL_LOCATION) v$(GOLANGCI_LINT_VERSION)
-	$(INSTALL_LOCATION)/golangci-lint run --no-config --disable-all --enable=gofmt,golint,gosec,govet,unused --fix --verbose --timeout 3m
+	$(INSTALL_LOCATION)/golangci-lint run --no-config --disable-all --enable=gofmt,revive,gosec,govet,unused --fix --verbose --timeout 3m
 
 ## --------------------------------------
 ## Go

--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package options
 
 import (
-	"testing"
-	"reflect"
-	"time"
-	"github.com/stretchr/testify/assert"
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+	"time"
 )
 
 /*

--- a/cmd/server/app/options/options_test.go
+++ b/cmd/server/app/options/options_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package options
 
 import (
-	"testing"
-	"reflect"
-	"time"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+	"time"
 )
 
 /*

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -399,9 +399,10 @@ func (p *Proxy) runAdminServer(o *options.ProxyRunOptions, server *server.ProxyS
 		}
 	}
 	adminServer := &http.Server{
-		Addr:           net.JoinHostPort(o.AdminBindAddress, strconv.Itoa(o.AdminPort)),
-		Handler:        muxHandler,
-		MaxHeaderBytes: 1 << 20,
+		Addr:              net.JoinHostPort(o.AdminBindAddress, strconv.Itoa(o.AdminPort)),
+		Handler:           muxHandler,
+		MaxHeaderBytes:    1 << 20,
+		ReadHeaderTimeout: ReadHeaderTimeout,
 	}
 
 	labels := runpprof.Labels(


### PR DESCRIPTION
Fix broken `make lint`.

Replace deprecated `golint` with `revive`.

Upgrade linter to latest version. Apply lint fixes found.

```
golangci/golangci-lint info found version: 1.45.2 for v1.45.2/linux/amd64
golangci/golangci-lint info installed /home/prow/go/bin/golangci-lint
/home/prow/go/bin/golangci-lint run --no-config --disable-all --enable=gofmt,golint,gosec,govet,unused --fix --verbose --timeout 3m
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
goroutine 1 [running]:
github.com/go-critic/go-critic/checkers.init.[22](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_apiserver-network-proxy/441/pull-apiserver-network-proxy-make-lint/1605312805089579008#1:build-log.txt%3A22)()
	github.com/go-critic/go-critic@v0.6.2/checkers/embedded_rules.go:46 +0x4b4
make: *** [Makefile:91: lint] Error 2
```
