### PR TITLE
Prepare 0.0.34

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@
 /easy-rsa-master/
 /easy-rsa.tar.gz
 /easy-rsa
+
+# editor and IDE paraphernalia
+.idea
+.vscode
+
+# macOS paraphernalia
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 INSTALL_LOCATION:=$(shell go env GOPATH)/bin
-GOLANGCI_LINT_VERSION ?= 1.45.2
+GOLANGCI_LINT_VERSION ?= 1.50.1
 GOSEC_VERSION ?= 2.13.1
 
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
@@ -88,7 +88,7 @@ bin/proxy-server: proto/agent/agent.pb.go konnectivity-client/proto/client/clien
 .PHONY: lint
 lint:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(INSTALL_LOCATION) v$(GOLANGCI_LINT_VERSION)
-	$(INSTALL_LOCATION)/golangci-lint run --no-config --disable-all --enable=gofmt,golint,gosec,govet,unused --fix --verbose --timeout 3m
+	$(INSTALL_LOCATION)/golangci-lint run --no-config --disable-all --enable=gofmt,revive,gosec,govet,unused --fix --verbose --timeout 3m
 
 ## --------------------------------------
 ## Go

--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package options
 
 import (
-	"testing"
-	"reflect"
-	"time"
-	"github.com/stretchr/testify/assert"
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+	"time"
 )
 
 /*

--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -152,6 +152,9 @@ func (a *Agent) runAdminServer(o *options.GrpcProxyAgentOptions) error {
 	if o.EnableProfiling {
 		muxHandler.HandleFunc("/debug/pprof", util.RedirectTo("/debug/pprof/"))
 		muxHandler.HandleFunc("/debug/pprof/", pprof.Index)
+		muxHandler.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		muxHandler.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		muxHandler.HandleFunc("/debug/pprof/trace", pprof.Trace)
 		if o.EnableContentionProfiling {
 			runtime.SetBlockProfileRate(1)
 		}

--- a/cmd/server/app/options/options_test.go
+++ b/cmd/server/app/options/options_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package options
 
 import (
-	"testing"
-	"reflect"
-	"time"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+	"time"
 )
 
 /*

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -391,6 +391,9 @@ func (p *Proxy) runAdminServer(o *options.ProxyRunOptions, server *server.ProxyS
 	if o.EnableProfiling {
 		muxHandler.HandleFunc("/debug/pprof", util.RedirectTo("/debug/pprof/"))
 		muxHandler.HandleFunc("/debug/pprof/", netpprof.Index)
+		muxHandler.HandleFunc("/debug/pprof/profile", netpprof.Profile)
+		muxHandler.HandleFunc("/debug/pprof/symbol", netpprof.Symbol)
+		muxHandler.HandleFunc("/debug/pprof/trace", netpprof.Trace)
 		if o.EnableContentionProfiling {
 			runtime.SetBlockProfileRate(1)
 		}

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -399,9 +399,10 @@ func (p *Proxy) runAdminServer(o *options.ProxyRunOptions, server *server.ProxyS
 		}
 	}
 	adminServer := &http.Server{
-		Addr:           net.JoinHostPort(o.AdminBindAddress, strconv.Itoa(o.AdminPort)),
-		Handler:        muxHandler,
-		MaxHeaderBytes: 1 << 20,
+		Addr:              net.JoinHostPort(o.AdminBindAddress, strconv.Itoa(o.AdminPort)),
+		Handler:           muxHandler,
+		MaxHeaderBytes:    1 << 20,
+		ReadHeaderTimeout: ReadHeaderTimeout,
 	}
 
 	labels := runpprof.Labels(

--- a/konnectivity-client/pkg/client/metrics/metrics.go
+++ b/konnectivity-client/pkg/client/metrics/metrics.go
@@ -41,29 +41,67 @@ type ClientMetrics struct {
 	registerOnce  sync.Once
 	streamPackets *prometheus.CounterVec
 	streamErrors  *prometheus.CounterVec
+	dialFailures  *prometheus.CounterVec
 }
 
+type DialFailureReason string
+
+const (
+	DialFailureUnknown DialFailureReason = "unknown"
+	// DialFailureTimeout indicates the hard 30 second timeout was hit.
+	DialFailureTimeout DialFailureReason = "timeout"
+	// DialFailureContext indicates that the context was cancelled or reached it's deadline before
+	// the dial response was returned.
+	DialFailureContext DialFailureReason = "context"
+	// DialFailureEndpoint indicates that the konnectivity-agent was unable to reach the backend endpoint.
+	DialFailureEndpoint DialFailureReason = "endpoint"
+	// DialFailureDialClosed indicates that the client received a CloseDial response, indicating the
+	// connection was closed before the dial could complete.
+	DialFailureDialClosed DialFailureReason = "dialclosed"
+	// DialFailureTunnelClosed indicates that the client connection was closed before the dial could
+	// complete.
+	DialFailureTunnelClosed DialFailureReason = "tunnelclosed"
+)
+
 func newMetrics() *ClientMetrics {
+	// The denominator (total dials started) for both
+	// dial_failure_total and dial_duration_seconds is the
+	// stream_packets_total (common metric), where segment is
+	// "from_client" and packet_type is "DIAL_REQ".
+	dialFailures := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "dial_failure_total",
+			Help:      "Number of dial failures observed, by reason (example: remote endpoint error)",
+		},
+		[]string{
+			"reason",
+		},
+	)
 	return &ClientMetrics{
 		streamPackets: commonmetrics.MakeStreamPacketsTotalMetric(Namespace, Subsystem),
 		streamErrors:  commonmetrics.MakeStreamErrorsTotalMetric(Namespace, Subsystem),
+		dialFailures:  dialFailures,
 	}
 }
 
 // RegisterMetrics registers all metrics with the client application.
-func (c *ClientMetrics) RegisterMetrics(r prometheus.Registerer, namespace, subsystem string) {
+func (c *ClientMetrics) RegisterMetrics(r prometheus.Registerer) {
 	c.registerOnce.Do(func() {
 		r.MustRegister(c.streamPackets)
 		r.MustRegister(c.streamErrors)
+		r.MustRegister(c.dialFailures)
 	})
 }
 
 // LegacyRegisterMetrics registers all metrics via MustRegister func.
 // TODO: remove this once https://github.com/kubernetes/kubernetes/pull/114293 is available.
-func (c *ClientMetrics) LegacyRegisterMetrics(mustRegisterFn func(...prometheus.Collector), namespace, subsystem string) {
+func (c *ClientMetrics) LegacyRegisterMetrics(mustRegisterFn func(...prometheus.Collector)) {
 	c.registerOnce.Do(func() {
 		mustRegisterFn(c.streamPackets)
 		mustRegisterFn(c.streamErrors)
+		mustRegisterFn(c.dialFailures)
 	})
 }
 
@@ -71,6 +109,11 @@ func (c *ClientMetrics) LegacyRegisterMetrics(mustRegisterFn func(...prometheus.
 func (c *ClientMetrics) Reset() {
 	c.streamPackets.Reset()
 	c.streamErrors.Reset()
+	c.dialFailures.Reset()
+}
+
+func (c *ClientMetrics) ObserveDialFailure(reason DialFailureReason) {
+	c.dialFailures.WithLabelValues(string(reason)).Inc()
 }
 
 func (c *ClientMetrics) ObservePacket(segment commonmetrics.Segment, packetType client.PacketType) {

--- a/konnectivity-client/pkg/common/metrics/testing/metrics.go
+++ b/konnectivity-client/pkg/common/metrics/testing/metrics.go
@@ -30,6 +30,11 @@ const (
 # HELP konnectivity_network_proxy_client_dial_failure_total Number of dial failures observed, by reason (example: remote endpoint error)
 # TYPE konnectivity_network_proxy_client_dial_failure_total counter`
 	clientDialFailureSample = `konnectivity_network_proxy_client_dial_failure_total{reason="%s"} %d`
+
+	clientConnsHeader = `
+# HELP konnectivity_network_proxy_client_client_connections Number of open client connections, by status (Example: dialing)
+# TYPE konnectivity_network_proxy_client_client_connections gauge`
+	clientConnsSample = `konnectivity_network_proxy_client_client_connections{status="%s"} %d`
 )
 
 func ExpectClientDialFailures(expected map[metrics.DialFailureReason]int) error {
@@ -42,6 +47,18 @@ func ExpectClientDialFailures(expected map[metrics.DialFailureReason]int) error 
 
 func ExpectClientDialFailure(reason metrics.DialFailureReason, count int) error {
 	return ExpectClientDialFailures(map[metrics.DialFailureReason]int{reason: count})
+}
+
+func ExpectClientConnections(expected map[metrics.ClientConnectionStatus]int) error {
+	expect := clientConnsHeader + "\n"
+	for r, v := range expected {
+		expect += fmt.Sprintf(clientConnsSample+"\n", r, v)
+	}
+	return ExpectMetric(metrics.Namespace, metrics.Subsystem, "client_connections", expect)
+}
+
+func ExpectClientConnection(status metrics.ClientConnectionStatus, count int) error {
+	return ExpectClientConnections(map[metrics.ClientConnectionStatus]int{status: count})
 }
 
 func ExpectMetric(namespace, subsystem, name, expected string) error {

--- a/konnectivity-client/pkg/common/metrics/testing/metrics.go
+++ b/konnectivity-client/pkg/common/metrics/testing/metrics.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics"
+)
+
+const (
+	clientDialFailureHeader = `
+# HELP konnectivity_network_proxy_client_dial_failure_total Number of dial failures observed, by reason (example: remote endpoint error)
+# TYPE konnectivity_network_proxy_client_dial_failure_total counter`
+	clientDialFailureSample = `konnectivity_network_proxy_client_dial_failure_total{reason="%s"} %d`
+)
+
+func ExpectClientDialFailures(expected map[metrics.DialFailureReason]int) error {
+	expect := clientDialFailureHeader + "\n"
+	for r, v := range expected {
+		expect += fmt.Sprintf(clientDialFailureSample+"\n", r, v)
+	}
+	return ExpectMetric(metrics.Namespace, metrics.Subsystem, "dial_failure_total", expect)
+}
+
+func ExpectClientDialFailure(reason metrics.DialFailureReason, count int) error {
+	return ExpectClientDialFailures(map[metrics.DialFailureReason]int{reason: count})
+}
+
+func ExpectMetric(namespace, subsystem, name, expected string) error {
+	fqName := prometheus.BuildFQName(namespace, subsystem, name)
+	return promtest.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expected), fqName)
+}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -20,13 +20,17 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog/v2"
+
+	metricsclient "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics"
 )
 
 func TestMain(m *testing.M) {
 	fs := flag.NewFlagSet("mock-flags", flag.PanicOnError)
 	klog.InitFlags(fs)
 	fs.Set("v", "1") // Set klog verbosity.
+	metricsclient.Metrics.RegisterMetrics(prometheus.DefaultRegisterer)
 
 	m.Run()
 }


### PR DESCRIPTION
Pick recent commits from master into release-0.0.

Take new metrics and pprof options, but omit grpc library update.

After this I want to cut 0.0.34 tag from release-0.0, and likely we should create 0.1.0 from master to set precedent.