### PR TITLE
Trim obsolete docker images (test-only).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,8 +261,6 @@ release-staging: ## Builds and push container images to the staging bucket.
 release-alias-tag: # Adds the tag to the last build tag. BASE_REF comes from the cloudbuild.yaml
 	gcloud container images add-tag $(AGENT_FULL_IMAGE):$(TAG) $(AGENT_FULL_IMAGE):$(BASE_REF)
 	gcloud container images add-tag $(SERVER_FULL_IMAGE):$(TAG) $(SERVER_FULL_IMAGE):$(BASE_REF)
-	gcloud container images add-tag $(TEST_CLIENT_FULL_IMAGE):$(TAG) $(TEST_CLIENT_FULL_IMAGE):$(BASE_REF)
-	gcloud container images add-tag $(TEST_SERVER_FULL_IMAGE):$(TAG) $(TEST_SERVER_FULL_IMAGE):$(BASE_REF)
 
 ## --------------------------------------
 ## Cleanup / Verification


### PR DESCRIPTION
Fixes https://prow.k8s.io/?job=apiserver-network-proxy-push-images

which is failing with:

```
gcloud container images add-tag gcr.io/k8s-staging-kas-network-proxy/proxy-test-client:v20221227-konnectivity-clientv0.0.33-39-g823c619 gcr.io/k8s-staging-kas-network-proxy/proxy-test-client:master
ERROR: (gcloud.builds.submit) build b3da18bb-ff3e-4465-8e2c-058c345d8545 completed with status "FAILURE"
```

Probably this has been silently failing since https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/308
