### PR TITLE
Release picks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,8 +263,6 @@ release-staging: ## Builds and push container images to the staging bucket.
 release-alias-tag: # Adds the tag to the last build tag. BASE_REF comes from the cloudbuild.yaml
 	gcloud container images add-tag $(AGENT_FULL_IMAGE):$(TAG) $(AGENT_FULL_IMAGE):$(BASE_REF)
 	gcloud container images add-tag $(SERVER_FULL_IMAGE):$(TAG) $(SERVER_FULL_IMAGE):$(BASE_REF)
-	gcloud container images add-tag $(TEST_CLIENT_FULL_IMAGE):$(TAG) $(TEST_CLIENT_FULL_IMAGE):$(BASE_REF)
-	gcloud container images add-tag $(TEST_SERVER_FULL_IMAGE):$(TAG) $(TEST_SERVER_FULL_IMAGE):$(BASE_REF)
 
 ## --------------------------------------
 ## Cleanup / Verification

--- a/artifacts/images/agent-build.Dockerfile
+++ b/artifacts/images/agent-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-agent binary
-FROM golang:1.18.5 as builder
+FROM golang:1.18.9 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/server-build.Dockerfile
+++ b/artifacts/images/server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-server binary
-FROM golang:1.18.5 as builder
+FROM golang:1.18.9 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy


### PR DESCRIPTION
Cherry picks into release-0.0:

Merges cleanly.

* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/446
* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/436
  * CVE issue: [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622)

Touching release-0.0 branch will have an additional benefit that test-infra will now trigger image builds for this release branch, since https://github.com/kubernetes/test-infra/pull/28328. (The v0.0.34 tag is currently missing images in k8s staging repo).