### PR TITLE
proxy-server: add a dial failure metric reason for "no agent".

### DIFF
--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -230,6 +230,7 @@ func (s *ServerMetrics) FullRecvChannel(serviceMethod string) prometheus.Gauge {
 type DialFailureReason string
 
 const (
+	DialFailureNoAgent              DialFailureReason = "no_agent"              // No available agent is connected.
 	DialFailureErrorResponse        DialFailureReason = "error_response"        // Dial failure reported by the agent back to the server.
 	DialFailureUnrecognizedResponse DialFailureReason = "unrecognized_response" // Dial repsonse received for unrecognozide dial ID.
 	DialFailureSendResponse         DialFailureReason = "send_rsp"              // Successful dial response from agent, but failed to send to frontend.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -452,6 +452,7 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			backend, err = s.getBackend(address)
 			if err != nil {
 				klog.ErrorS(err, "Failed to get a backend", "dialID", random)
+				metrics.Metrics.ObserveDialFailure(metrics.DialFailureNoAgent)
 
 				resp := &client.Packet{
 					Type: client.PacketType_DIAL_RSP,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -39,6 +39,7 @@ import (
 
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
+	metricstest "sigs.k8s.io/apiserver-network-proxy/pkg/testing/metrics"
 	agentmock "sigs.k8s.io/apiserver-network-proxy/proto/agent/mocks"
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
@@ -321,6 +322,10 @@ func TestServerProxyNoBackend(t *testing.T) {
 
 	}
 	baseServerProxyTestWithoutBackend(t, validate)
+
+	if err := metricstest.ExpectServerDialFailure(metrics.DialFailureNoAgent, 1); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestServerProxyNormalClose(t *testing.T) {


### PR DESCRIPTION
Previous to this change, `proxy-server` would not emit any dial failure metric in this case, and the [client metric](https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/9ab611d9c0fdac24c838ed1903e41738b3594675/konnectivity-client/pkg/client/metrics/metrics.go#L50-L65) would also not cleanly identify it.