### PR TITLE
konnectivity-client: guard single use tunnels from duplicate dial.

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -130,6 +130,11 @@ type grpcTunnel struct {
 	// serving.
 	done chan struct{}
 
+	// started is an atomic bool represented as a 0 or 1, and set to true when a single-use tunnel has been started (dialed).
+	// started should only be accessed through atomic methods.
+	// TODO: switch this to an atomic.Bool once the client is exclusively buit with go1.19+
+	started uint32
+
 	// closing is an atomic bool represented as a 0 or 1, and set to true when the tunnel is being closed.
 	// closing should only be accessed through atomic methods.
 	// TODO: switch this to an atomic.Bool once the client is exclusively buit with go1.19+
@@ -195,6 +200,7 @@ func newUnstartedTunnel(stream client.ProxyService_ProxyClient, c clientConn) *g
 		conns:              connectionManager{conns: make(map[int64]*conn)},
 		readTimeoutSeconds: 10,
 		done:               make(chan struct{}),
+		started:            0,
 	}
 	s := metrics.ClientConnectionStatusCreated
 	t.prevStatus.Store(s)
@@ -382,6 +388,11 @@ func (t *grpcTunnel) DialContext(requestCtx context.Context, protocol, address s
 }
 
 func (t *grpcTunnel) dialContext(requestCtx context.Context, protocol, address string) (net.Conn, error) {
+	prevStarted := atomic.SwapUint32(&t.started, 1)
+	if prevStarted != 0 {
+		return nil, &dialFailure{"single-use dialer already dialed", metrics.DialFailureAlreadyStarted}
+	}
+
 	select {
 	case <-t.done:
 		return nil, errors.New("tunnel is closed")

--- a/konnectivity-client/pkg/client/metrics/metrics.go
+++ b/konnectivity-client/pkg/client/metrics/metrics.go
@@ -62,6 +62,8 @@ const (
 	// DialFailureTunnelClosed indicates that the client connection was closed before the dial could
 	// complete.
 	DialFailureTunnelClosed DialFailureReason = "tunnelclosed"
+	// DialFailureAlreadyStarted indicates that a single-use tunnel dialer was already used once.
+	DialFailureAlreadyStarted DialFailureReason = "tunnelstarted"
 )
 
 type ClientConnectionStatus string


### PR DESCRIPTION
konnectivity-client: guard single use tunnels from duplicate dial.

The only client is egress_selector.go, and the only expected fallout from this guard is the concurrent_test.go change (locally).