### PR TITLE
Metrics bugfix: restore ObservePacket.

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -501,11 +501,16 @@ func (t *grpcTunnel) Recv() (*client.Packet, error) {
 	t.recvLock.Lock()
 	defer t.recvLock.Unlock()
 
+	const segment = commonmetrics.SegmentToClient
 	pkt, err := t.stream.Recv()
 	if err != nil && err != io.EOF {
-		metrics.Metrics.ObserveStreamErrorNoPacket(commonmetrics.SegmentToClient, err)
+		metrics.Metrics.ObserveStreamErrorNoPacket(segment, err)
 	}
-	return pkt, err
+	if err != nil {
+		return pkt, err
+	}
+	metrics.Metrics.ObservePacket(segment, pkt.Type)
+	return pkt, nil
 }
 
 func GetDialFailureReason(err error) (isDialFailure bool, reason metrics.DialFailureReason) {

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
 	"strings"
 	"sync"
@@ -90,7 +91,7 @@ func (b *backend) Send(p *client.Packet) error {
 	const segment = commonmetrics.SegmentToAgent
 	metrics.Metrics.ObservePacket(segment, p.Type)
 	err := b.conn.Send(p)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		metrics.Metrics.ObserveStreamError(segment, err, p.Type)
 	}
 	return err


### PR DESCRIPTION
This was lost in the client at https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/451, but was missing in the agent wrapper.