### PR TITLE
[release-0.0 branch] Backports from 0.1.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,16 +4,38 @@ Please note this guide is only intended for the admins of this repository, and r
 
 Creating a new release of network proxy involves releasing a new version of the client library (konnectivity-client) and new images for the proxy agent and server. Generally we also want to upgrade kubernetes/kubernetes with the latest version of the images and library, but this is a GCE specific change.
 
-1. The first step involves creating a new git tag for the release, following semvar for go libraries. A tag is required for both the repository and the konnectivity-client library. For example releasing the `0.0.15` version will have two tags `v0.0.15` and `konnectivity-client/v0.0.15` on the appropriate commit.
+1. The first step involves creating a new git tag for the release, following semver for go libraries. A tag is required for both the repository and the konnectivity-client library. For example releasing the `0.0.15` version will have two tags `v0.0.15` and `konnectivity-client/v0.0.15` on the appropriate commit.
 
-    The exact commands are
+    In the master branch, choose the appropriate commit, and determine a patch version for the latest minor version (currently 0.1).
+
+    Example commands for `HEAD` of `master` branch. (Assumes you have `git remote add upstream git@github.com:kubernetes-sigs/apiserver-network-proxy.git`.)
 
     ```
-    # Check out the appropriate commit (usually head of master)
-    git tag -a v0.0.15
-    git tag konnectivity-client/v0.0.15
-    git push upstream v0.0.15
-    git push upstream konnectivity-client/v0.0.15
+    # Assuming v0.1.1 exists
+    export TAG=v0.1.2
+    export MESSAGE="Meaningful description of change."
+
+    git fetch upstream
+    git tag -a "${TAG}" -m "${MESSAGE}" upstream/master
+    git tag -a "konnectivity-client/${TAG}" -m "${MESSAGE}" upstream/master
+    git push upstream "${TAG}"
+    git push upstream "konnectivity-client/${TAG}"
+    ```
+
+    In a release branch, the process is similar but corresponds to earlier minor versions.
+
+    Example commands for `HEAD` of `release-0.0` branch:
+
+    ```
+    # Assuming v0.0.35 exists
+    export TAG=v0.0.36
+    export MESSAGE="Meaningful description of change."
+
+    git fetch upstream
+    git tag -a "${TAG}" -m "${MESSAGE}" upstream/release-0.0
+    git tag -a "konnectivity-client/${TAG}" -m "${MESSAGE}" upstream/release-0.0
+    git push upstream "${TAG}"
+    git push upstream "konnectivity-client/${TAG}"
     ```
 
     Once the two tags are created, the konnectivity-client can be imported as a library in kubernetes/kubernetes and other go programs.
@@ -41,6 +63,6 @@ Creating a new release of network proxy involves releasing a new version of the 
 
     ```
     ./hack/pin-dependency.sh sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15
-    make clean generated_files
+    ./hack/update-codegen.sh
     ./hack/update-vendor.sh
     ```

--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -513,11 +513,16 @@ func (t *grpcTunnel) Recv() (*client.Packet, error) {
 	t.recvLock.Lock()
 	defer t.recvLock.Unlock()
 
+	const segment = commonmetrics.SegmentToClient
 	pkt, err := t.stream.Recv()
 	if err != nil && err != io.EOF {
-		metrics.Metrics.ObserveStreamErrorNoPacket(commonmetrics.SegmentToClient, err)
+		metrics.Metrics.ObserveStreamErrorNoPacket(segment, err)
 	}
-	return pkt, err
+	if err != nil {
+		return pkt, err
+	}
+	metrics.Metrics.ObservePacket(segment, pkt.Type)
+	return pkt, nil
 }
 
 func GetDialFailureReason(err error) (isDialFailure bool, reason metrics.DialFailureReason) {

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -235,7 +235,7 @@ func (a *Client) Connect() (int, error) {
 		if ctx, err = a.initializeAuthContext(ctx); err != nil {
 			err := conn.Close()
 			if err != nil {
-				klog.ErrorS(err, "failed to close connection")
+				klog.ErrorS(err, "failed to close gRPC connection", "agentID", a.agentID)
 			}
 			return 0, err
 		}
@@ -258,18 +258,18 @@ func (a *Client) Connect() (int, error) {
 	a.conn = conn
 	a.stream = stream
 	a.serverID = serverID
-	klog.V(2).InfoS("Connect to", "server", serverID)
+	klog.V(2).InfoS("Connect to server", "serverID", serverID)
 	return serverCount, nil
 }
 
-// Close closes the underlying connection.
+// Close closes the Connect gRPC connection.
 func (a *Client) Close() {
 	if a.conn == nil {
 		klog.Errorln("Unexpected empty AgentClient.conn")
 	}
 	err := a.conn.Close()
 	if err != nil {
-		klog.ErrorS(err, "failed to close underlying connection")
+		klog.ErrorS(err, "failed to close gRPC connection", "serverID", a.serverID, "agentID", a.agentID)
 	}
 	close(a.stopCh)
 }
@@ -377,10 +377,10 @@ func (a *Client) Serve() {
 		pkt, err := a.Recv()
 		if err != nil {
 			if err == io.EOF {
-				klog.V(2).InfoS("received EOF, exit")
+				klog.V(2).InfoS("received EOF, exit", "serverID", a.serverID, "agentID", a.agentID)
 				return
 			}
-			klog.ErrorS(err, "could not read stream")
+			klog.ErrorS(err, "could not read stream", "serverID", a.serverID, "agentID", a.agentID)
 			return
 		}
 
@@ -412,32 +412,33 @@ func (a *Client) Serve() {
 			connCtx.cleanFunc = func() {
 				// block on purpose
 				<-dialDone
-				if connCtx.conn != nil {
-					klog.V(4).InfoS("close connection", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
-					var closePkt *client.Packet
-					if connID == 0 {
-						closePkt = &client.Packet{
-							Type:    client.PacketType_DIAL_CLS,
-							Payload: &client.Packet_CloseDial{CloseDial: &client.CloseDial{}},
-						}
-						closePkt.GetCloseDial().Random = dialReq.Random
-					} else {
-						closePkt = &client.Packet{
-							Type:    client.PacketType_CLOSE_RSP,
-							Payload: &client.Packet_CloseResponse{CloseResponse: &client.CloseResponse{}},
-						}
-						closePkt.GetCloseResponse().ConnectID = connID
+				if connCtx.conn == nil {
+					// TODO: move this guard lower
+					klog.ErrorS(fmt.Errorf("remote connection is nil"), "could not send CLOSE_RESP to nil connection")
+					return
+				}
+				klog.V(4).InfoS("close connection", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
+				var closePkt *client.Packet
+				if connID == 0 {
+					closePkt = &client.Packet{
+						Type:    client.PacketType_DIAL_CLS,
+						Payload: &client.Packet_CloseDial{CloseDial: &client.CloseDial{}},
 					}
-					if err := a.Send(closePkt); err != nil {
-						klog.ErrorS(err, "close response failure", "")
-					}
-					close(dataCh)
-					a.connManager.Delete(connID)
-					if err := connCtx.conn.Close(); err != nil {
-						klog.ErrorS(err, "failed to close connection")
-					}
+					closePkt.GetCloseDial().Random = dialReq.Random
 				} else {
-					klog.ErrorS(fmt.Errorf("connection is nil"), "cannot send CLOSE_RESP to nil connection")
+					closePkt = &client.Packet{
+						Type:    client.PacketType_CLOSE_RSP,
+						Payload: &client.Packet_CloseResponse{CloseResponse: &client.CloseResponse{}},
+					}
+					closePkt.GetCloseResponse().ConnectID = connID
+				}
+				if err := a.Send(closePkt); err != nil {
+					klog.ErrorS(err, "close response failure", "")
+				}
+				close(dataCh)
+				a.connManager.Delete(connID)
+				if err := connCtx.conn.Close(); err != nil {
+					klog.ErrorS(err, "failed to close connection to remote", "dialID", dialReq.Random, "connectID", connID)
 				}
 			}
 			labels := runpprof.Labels(
@@ -458,10 +459,11 @@ func (a *Client) Serve() {
 						reason = metrics.DialFailureTimeout
 					}
 					metrics.Metrics.ObserveDialFailure(reason)
-					klog.ErrorS(err, "error dialing backend", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
+					// Do not log agent errors for remote unavailable.
+					klog.V(1).InfoS("error dialing backend", "error", err, "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
 					dialResp.GetDialResponse().Error = err.Error()
 					if err := a.Send(dialResp); err != nil {
-						klog.ErrorS(err, "could not send dialResp", "dialID", dialReq.Random, "connectionID", connID)
+						klog.ErrorS(err, "could not send DIAL_RSP with error", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
 					}
 					// Cannot invoke clean up as we have no conn yet.
 					return
@@ -480,7 +482,7 @@ func (a *Client) Serve() {
 					"dialAddress", dialReq.Address,
 				)
 				if err := a.Send(dialResp); err != nil {
-					klog.ErrorS(err, "could not send dialResp", "dialID", dialReq.Random)
+					klog.ErrorS(err, "could not send DIAL_RSP", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
 					// clean-up is normally called from remoteToProxy which we will never invoke.
 					// So we are invoking it here to force the clean-up to occur.
 					// However, cleanup will block until dialDone is closed.
@@ -519,7 +521,7 @@ func (a *Client) Serve() {
 				resp.GetCloseResponse().ConnectID = connID
 				resp.GetCloseResponse().Error = "Unknown connectID"
 				if err := a.Send(resp); err != nil {
-					klog.ErrorS(err, "close response send failure", err)
+					klog.ErrorS(err, "could not send CLOSE_RSP", err, "connectionID", connID)
 					continue
 				}
 			}
@@ -550,7 +552,7 @@ func (a *Client) remoteToProxy(connID int64, ctx *connContext) {
 		klog.V(5).InfoS("received data from remote", "bytes", n, "connectionID", connID)
 
 		if err == io.EOF {
-			klog.V(2).InfoS("connection EOF", "connectionID", connID)
+			klog.V(2).InfoS("remote connection EOF", "connectionID", connID)
 			return
 		} else if err != nil {
 			// "use of closed network connection" errors are expected upon receiving CLOSE_REQ
@@ -567,7 +569,7 @@ func (a *Client) remoteToProxy(connID int64, ctx *connContext) {
 				ConnectID: connID,
 			}}
 			if err := a.Send(resp); err != nil {
-				klog.ErrorS(err, "stream send failure", "connectionID", connID)
+				klog.ErrorS(err, "could not send DATA", "connectionID", connID)
 			}
 		}
 	}

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -216,11 +216,6 @@ func (cs *ClientSet) connectOnce() error {
 	}
 	cs.serverCount = serverCount
 	if err := cs.AddClient(c.serverID, c); err != nil {
-		if dse, ok := err.(*DuplicateServerError); ok {
-			klog.V(4).InfoS("closing connection to duplicate server", "serverID", dse.ServerID)
-		} else {
-			klog.ErrorS(err, "closing connection failure when adding a client")
-		}
 		c.Close()
 		return err
 	}

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/rand"
 	"strings"
 	"sync"
@@ -90,7 +91,7 @@ func (b *backend) Send(p *client.Packet) error {
 	const segment = commonmetrics.SegmentToAgent
 	metrics.Metrics.ObservePacket(segment, p.Type)
 	err := b.conn.Send(p)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		metrics.Metrics.ObserveStreamError(segment, err, p.Type)
 	}
 	return err

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -230,6 +230,7 @@ func (s *ServerMetrics) FullRecvChannel(serviceMethod string) prometheus.Gauge {
 type DialFailureReason string
 
 const (
+	DialFailureNoAgent              DialFailureReason = "no_agent"              // No available agent is connected.
 	DialFailureErrorResponse        DialFailureReason = "error_response"        // Dial failure reported by the agent back to the server.
 	DialFailureUnrecognizedResponse DialFailureReason = "unrecognized_response" // Dial repsonse received for unrecognozide dial ID.
 	DialFailureSendResponse         DialFailureReason = "send_rsp"              // Successful dial response from agent, but failed to send to frontend.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -452,6 +452,7 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			backend, err = s.getBackend(address)
 			if err != nil {
 				klog.ErrorS(err, "Failed to get a backend", "dialID", random)
+				metrics.Metrics.ObserveDialFailure(metrics.DialFailureNoAgent)
 
 				resp := &client.Packet{
 					Type: client.PacketType_DIAL_RSP,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -439,6 +439,21 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 	var backend Backend
 	var err error
 
+	defer func() {
+		// As the read side of the recvCh channel, we cannot close it.
+		// However readFrontendToChannel() may be blocked writing to the channel,
+		// so we need to consume the channel until it is closed.
+		discardedPktCount := 0
+		for range recvCh {
+			// Ignore values as this indicates there was a problem
+			// with the remote connection.
+			discardedPktCount++
+		}
+		if discardedPktCount > 0 {
+			klog.V(2).InfoS("Discard packets while exiting serveRecvFrontend", "pktCount", discardedPktCount, "connectionID", firstConnID)
+		}
+	}()
+
 	for pkt := range recvCh {
 		switch pkt.Type {
 		case client.PacketType_DIAL_REQ:
@@ -492,16 +507,19 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			connID := pkt.GetCloseRequest().ConnectID
 			klog.V(5).InfoS("Received CLOSE_REQ", "connectionID", connID)
 			if backend == nil {
-				klog.V(2).InfoS("Backend has not been initialized for requested connection. Client should send a Dial Request first",
-					"connectionID", connID)
+				klog.V(2).InfoS("Backend has not been initialized for this connection", "connectionID", connID)
+				s.sendFrontendClose(stream, connID, "backend uninitialized")
 				continue
 			}
 			if err := backend.Send(pkt); err != nil {
 				// TODO: retry with other backends connecting to this agent.
 				klog.ErrorS(err, "CLOSE_REQ to Backend failed", "connectionID", connID)
+				s.sendFrontendClose(stream, connID, "CLOSE_REQ to backend failed")
 			} else {
 				klog.V(5).InfoS("CLOSE_REQ sent to backend", "connectionID", connID)
 			}
+			klog.V(3).InfoS("Closing frontend streaming per CLOSE_REQ", "connectionID", connID)
+			return
 
 		case client.PacketType_DIAL_CLS:
 			random := pkt.GetCloseDial().Random
@@ -520,16 +538,29 @@ func (s *ProxyServer) serveRecvFrontend(stream client.ProxyService_ProxyServer, 
 			connID := pkt.GetData().ConnectID
 			data := pkt.GetData().Data
 			klog.V(5).InfoS("Received data from connection", "bytes", len(data), "connectionID", connID)
+			if backend == nil {
+				klog.V(2).InfoS("Backend has not been initialized for this connection", "connectionID", connID)
+				s.sendFrontendClose(stream, connID, "backend not initialized")
+				return
+			}
+
+			if connID == 0 {
+				klog.ErrorS(nil, "Received packet missing ConnectID from frontend", "packetType", "DATA")
+				continue
+			}
+
 			if firstConnID == 0 {
 				firstConnID = connID
 			} else if firstConnID != connID {
-				klog.V(5).InfoS("Data does not match first connection id", "fistConnectionID", firstConnID, "connectionID", connID)
+				klog.ErrorS(nil, "Data does not match first connection id", "firstConnectionID", firstConnID, "connectionID", connID)
+				// Something went very wrong if we get here. Close both connections to avoid leaks.
+				s.sendBackendClose(backend, connID, 0, "mismatched connection IDs")
+				s.sendBackendClose(backend, firstConnID, 0, "mismatched connection IDs")
+				s.sendFrontendClose(stream, connID, "mismatched connection IDs")
+				s.sendFrontendClose(stream, firstConnID, "mismatched connection IDs")
+				return
 			}
 
-			if backend == nil {
-				klog.V(2).InfoS("Backend has not been initialized for the connection. Client should send a Dial Request first", "connectionID", connID)
-				continue
-			}
 			if err := backend.Send(pkt); err != nil {
 				// TODO: retry with other backends connecting to this agent.
 				klog.ErrorS(err, "DATA to Backend failed", "connectionID", connID)
@@ -753,6 +784,18 @@ func (s *ProxyServer) readBackendToChannel(stream agent.AgentService_ConnectServ
 // route the packet back to the correct client
 func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentService_ConnectServer, agentID string, recvCh <-chan *client.Packet) {
 	defer func() {
+		// Drain recvCh to ensure that readBackendToChannel is not blocked on a channel write.
+		// This should never happen, as termination of this function should only be initiated by closing recvCh.
+		discardedPktCount := 0
+		for range recvCh {
+			discardedPktCount++
+		}
+		if discardedPktCount > 0 {
+			klog.V(2).InfoS("Discard packets while exiting serveRecvBackend", "pktCount", discardedPktCount, "agentID", agentID)
+		}
+	}()
+
+	defer func() {
 		// Close all connected frontends when the agent connection is closed
 		// TODO(#126): Frontends in PendingDial state that have not been added to the
 		//             list of frontends should also be closed.
@@ -787,7 +830,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 				klog.V(2).InfoS("DIAL_RSP not recognized; dropped", "dialID", resp.Random, "agentID", agentID, "connectionID", resp.ConnectID)
 				metrics.Metrics.ObserveDialFailure(metrics.DialFailureUnrecognizedResponse)
 				if resp.ConnectID != 0 {
-					s.sendCloseRequest(stream, resp.ConnectID, resp.Random, "failed to notify agent of closing due to unknown dial id")
+					s.sendBackendClose(stream, resp.ConnectID, resp.Random, "unknown dial id")
 				}
 			} else {
 				dialErr := false
@@ -808,7 +851,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 					// If we never finish setting up the tunnel for ConnectID, then the connection is dead.
 					// Currently, the agent will no resend DIAL_RSP, so connection is dead.
 					// We already attempted to tell the frontend that. We should ensure we tell the backend.
-					s.sendCloseRequest(stream, resp.ConnectID, resp.Random, "failed to notify agent of closing due to dial error")
+					s.sendBackendClose(stream, resp.ConnectID, resp.Random, "dial error")
 					dialErr = true
 				}
 				// Avoid adding the frontend if there was an error dialing the destination
@@ -854,9 +897,15 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 		case client.PacketType_DATA:
 			resp := pkt.GetData()
 			klog.V(5).InfoS("Received data from agent", "bytes", len(resp.Data), "agentID", agentID, "connectionID", resp.ConnectID)
+			if resp.ConnectID == 0 {
+				klog.ErrorS(nil, "Received packet missing ConnectID from agent", "packetType", "DATA")
+				continue
+			}
+
 			frontend, err := s.getFrontend(agentID, resp.ConnectID)
 			if err != nil {
-				klog.ErrorS(err, "could not get frontend client", "agentID", agentID, "connectionID", resp.ConnectID)
+				klog.V(2).InfoS("could not get frontend client; closing connection", "agentID", agentID, "connectionID", resp.ConnectID, "error", err)
+				s.sendBackendClose(stream, resp.ConnectID, 0, "missing frontend")
 				break
 			}
 			if err := frontend.send(pkt); err != nil {
@@ -890,7 +939,7 @@ func (s *ProxyServer) serveRecvBackend(backend Backend, stream agent.AgentServic
 	klog.V(5).InfoS("Close backend of agent", "backend", stream, "agentID", agentID)
 }
 
-func (s *ProxyServer) sendCloseRequest(stream agent.AgentService_ConnectServer, connectID int64, random int64, failMsg string) {
+func (s *ProxyServer) sendBackendClose(stream Backend, connectID int64, random int64, reason string) {
 	pkt := &client.Packet{
 		Type: client.PacketType_CLOSE_REQ,
 		Payload: &client.Packet_CloseRequest{
@@ -903,6 +952,24 @@ func (s *ProxyServer) sendCloseRequest(stream agent.AgentService_ConnectServer, 
 	metrics.Metrics.ObservePacket(segment, pkt.Type)
 	if err := stream.Send(pkt); err != nil {
 		metrics.Metrics.ObserveStreamError(segment, err, pkt.Type)
-		klog.V(5).ErrorS(err, failMsg, "dialID", random, "agentID", agentID, "connectionID", connectID)
+		klog.V(5).ErrorS(err, "Failed to send close to agent", "closeReason", reason, "dialID", random, "agentID", agentID, "connectionID", connectID)
+	}
+}
+
+func (s *ProxyServer) sendFrontendClose(stream client.ProxyService_ProxyServer, connectID int64, reason string) {
+	pkt := &client.Packet{
+		Type: client.PacketType_CLOSE_RSP,
+		Payload: &client.Packet_CloseResponse{
+			CloseResponse: &client.CloseResponse{
+				ConnectID: connectID,
+				Error:     reason,
+			},
+		},
+	}
+	const segment = commonmetrics.SegmentToClient
+	metrics.Metrics.ObservePacket(segment, pkt.Type)
+	if err := stream.Send(pkt); err != nil {
+		metrics.Metrics.ObserveStreamError(segment, err, pkt.Type)
+		klog.V(5).ErrorS(err, "Failed to send close to frontend", "closeReason", reason, "connectionID", connectID)
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -39,6 +39,7 @@ import (
 
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
+	metricstest "sigs.k8s.io/apiserver-network-proxy/pkg/testing/metrics"
 	agentmock "sigs.k8s.io/apiserver-network-proxy/proto/agent/mocks"
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
@@ -321,6 +322,10 @@ func TestServerProxyNoBackend(t *testing.T) {
 
 	}
 	baseServerProxyTestWithoutBackend(t, validate)
+
+	if err := metricstest.ExpectServerDialFailure(metrics.DialFailureNoAgent, 1); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestServerProxyNormalClose(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -354,16 +354,13 @@ func TestServerProxyNormalClose(t *testing.T) {
 		gomock.InOrder(
 			frontendConn.EXPECT().Recv().Return(dialReq, nil).Times(1),
 			frontendConn.EXPECT().Recv().Return(data, nil).Times(1),
-			frontendConn.EXPECT().Recv().Return(closePacket(connectID), nil).Times(1),
+			frontendConn.EXPECT().Recv().Return(closeReqPkt(connectID), nil).Times(1),
 			frontendConn.EXPECT().Recv().Return(nil, io.EOF).Times(1),
 		)
 		gomock.InOrder(
 			agentConn.EXPECT().Send(dialReq).Return(nil).Times(1),
 			agentConn.EXPECT().Send(data).Return(nil).Times(1),
-			agentConn.EXPECT().Send(closePacket(connectID)).Return(nil).Times(1),
-			// This extra close is unwanted and should be removed; see
-			// https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/307
-			agentConn.EXPECT().Send(closePacket(connectID)).Return(nil).Times(1),
+			agentConn.EXPECT().Send(closeReqPkt(connectID)).Return(nil).Times(1),
 		)
 	}
 	baseServerProxyTestWithBackend(t, validate)
@@ -440,7 +437,10 @@ func TestServerProxyRecvChanFull(t *testing.T) {
 				return data, nil
 			}),
 
-			frontendConn.EXPECT().Recv().Return(closePacket(1), nil),
+			frontendConn.EXPECT().Recv().Return(closeReqPkt(1), nil),
+			// Ensure that the go-routines don't deadlock if more packets are received before closing the connection.
+			// This is a bit contrived, but exercises a possible failure scenario.
+			frontendConn.EXPECT().Recv().Return(data, nil).Times(xfrChannelSize+1),
 			frontendConn.EXPECT().Recv().Return(nil, io.EOF),
 		)
 		gomock.InOrder(
@@ -455,21 +455,100 @@ func TestServerProxyRecvChanFull(t *testing.T) {
 				return nil
 			}),
 			agentConn.EXPECT().Send(data).Return(nil).Times(xfrChannelSize+1), // Expect the remaining packets to be sent.
-			agentConn.EXPECT().Send(closePacket(1)).Return(nil),
-			// This extra close is unwanted and should be removed; see
-			// https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/307
-			agentConn.EXPECT().Send(closePacket(1)).Return(nil),
+			agentConn.EXPECT().Send(closeReqPkt(1)).Return(nil),
 		)
 	}
 	baseServerProxyTestWithBackend(t, validate)
 }
 
-func closePacket(connectID int64) *client.Packet {
+func TestServerProxyNoDial(t *testing.T) {
+	baseServerProxyTestWithBackend(t, func(frontendConn, agentConn *agentmock.MockAgentService_ConnectServer) {
+		const connectID = 123456
+		data := &client.Packet{
+			Type: client.PacketType_DATA,
+			Payload: &client.Packet_Data{
+				Data: &client.Data{
+					ConnectID: connectID,
+				},
+			},
+		}
+
+		gomock.InOrder(
+			frontendConn.EXPECT().Recv().Return(data, nil),
+			frontendConn.EXPECT().Recv().Return(nil, io.EOF),
+		)
+		frontendConn.EXPECT().Send(closeRspPkt(connectID, "backend not initialized")).Return(nil)
+	})
+}
+
+func TestServerProxyConnectionMismatch(t *testing.T) {
+	baseServerProxyTestWithBackend(t, func(frontendConn, agentConn *agentmock.MockAgentService_ConnectServer) {
+		const firstConnectID = 123456
+		const secondConnectID = 654321
+		dialReq := &client.Packet{
+			Type: client.PacketType_DIAL_REQ,
+			Payload: &client.Packet_DialRequest{
+				DialRequest: &client.DialRequest{
+					Protocol: "tcp",
+					Address:  "127.0.0.1:8080",
+					Random:   111,
+				},
+			},
+		}
+		data := &client.Packet{
+			Type: client.PacketType_DATA,
+			Payload: &client.Packet_Data{
+				Data: &client.Data{
+					ConnectID: firstConnectID,
+					Data:      []byte("hello"),
+				},
+			},
+		}
+		mismatchedData := &client.Packet{
+			Type: client.PacketType_DATA,
+			Payload: &client.Packet_Data{
+				Data: &client.Data{
+					ConnectID: secondConnectID,
+					Data:      []byte("world"),
+				},
+			},
+		}
+
+		gomock.InOrder(
+			frontendConn.EXPECT().Recv().Return(dialReq, nil),
+			frontendConn.EXPECT().Recv().Return(data, nil),
+			frontendConn.EXPECT().Recv().Return(mismatchedData, nil),
+			frontendConn.EXPECT().Recv().Return(nil, io.EOF),
+		)
+		gomock.InOrder(
+			agentConn.EXPECT().Send(dialReq).Return(nil),
+			agentConn.EXPECT().Send(data).Return(nil),
+		)
+		agentConn.EXPECT().Send(closeReqPkt(secondConnectID)).Return(nil)
+		agentConn.EXPECT().Send(closeReqPkt(firstConnectID)).Return(nil)
+		frontendConn.EXPECT().Send(closeRspPkt(secondConnectID, "mismatched connection IDs")).Return(nil)
+		frontendConn.EXPECT().Send(closeRspPkt(firstConnectID, "mismatched connection IDs")).Return(nil)
+	})
+}
+
+func closeReqPkt(connectID int64) *client.Packet {
 	return &client.Packet{
 		Type: client.PacketType_CLOSE_REQ,
 		Payload: &client.Packet_CloseRequest{
 			CloseRequest: &client.CloseRequest{
 				ConnectID: connectID,
 			}},
+	}
+}
+
+func closeRspPkt(connectID int64, errMsg string) *client.Packet {
+	return &client.Packet{
+		Type: client.PacketType_CLOSE_RSP,
+		Payload: &client.Packet_CloseResponse{
+			CloseResponse: &client.CloseResponse{
+				ConnectID: connectID,
+				Error:     errMsg,
+			},
+		},
 	}
 }


### PR DESCRIPTION
Clean cherry-picks from 0.1.1 to `release-0.0` branch, to prepare comparable tag 0.0.36.

* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/448
* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/445
* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/450
* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/451
* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/417
* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/453

It is actually simpler to discuss the *differences* across branches. They are just:

* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/424 (unnecessary risk)
* https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/434 (not backportable prior to k/k 1.24)
