### PR TITLE
Concurrent cancelled requests test

### DIFF
--- a/pkg/testing/metrics/metrics.go
+++ b/pkg/testing/metrics/metrics.go
@@ -36,6 +36,11 @@ const (
 # HELP konnectivity_network_proxy_agent_endpoint_dial_failure_total Number of failures dialing the remote endpoint, by reason (example: timeout).
 # TYPE konnectivity_network_proxy_agent_endpoint_dial_failure_total counter`
 	agentDialFailureSample = `konnectivity_network_proxy_agent_endpoint_dial_failure_total{reason="%s"} %d`
+
+	agentEndpointConnections = `
+# HELP konnectivity_network_proxy_agent_open_endpoint_connections Current number of open endpoint connections.
+# TYPE konnectivity_network_proxy_agent_open_endpoint_connections gauge
+konnectivity_network_proxy_agent_open_endpoint_connections %d`
 )
 
 func ExpectServerDialFailures(expected map[server.DialFailureReason]int) error {
@@ -60,6 +65,11 @@ func ExpectAgentDialFailures(expected map[agent.DialFailureReason]int) error {
 
 func ExpectAgentDialFailure(reason agent.DialFailureReason, count int) error {
 	return ExpectAgentDialFailures(map[agent.DialFailureReason]int{reason: count})
+}
+
+func ExpectAgentEndpointConnections(count int) error {
+	expect := fmt.Sprintf(agentEndpointConnections+"\n", count)
+	return ExpectMetric(agent.Namespace, agent.Subsystem, "open_endpoint_connections", expect)
 }
 
 func ExpectMetric(namespace, subsystem, name, expected string) error {

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -21,11 +21,13 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -94,6 +96,26 @@ func newWaitingServer() *waitingServer {
 func (s *waitingServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	close(s.requestReceivedCh)
 	<-s.respondCh // Wait for permission to respond.
+	w.Write([]byte("hello"))
+}
+
+type delayedServer struct {
+	minWait time.Duration
+	maxWait time.Duration
+}
+
+func newDelayedServer() *delayedServer {
+	return &delayedServer{
+		minWait: 500 * time.Millisecond,
+		maxWait: 2 * time.Second,
+	}
+}
+
+var _ = newDelayedServer() // Suppress unused lint error.
+
+func (s *delayedServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	delay := time.Duration(rand.Int63n(int64(s.maxWait-s.minWait))) + s.minWait /* #nosec G404 */
+	time.Sleep(delay)
 	w.Write([]byte("hello"))
 }
 
@@ -344,6 +366,93 @@ func TestProxyDial_RequestCancelled_GRPC(t *testing.T) {
 	if err := metricstest.ExpectServerDialFailure(metricsserver.DialFailureFrontendClose, 1); err != nil {
 		t.Error(err)
 	}
+	resetAllMetrics() // For clean shutdown.
+}
+
+func TestProxyDial_RequestCancelled_Concurrent_GRPC(t *testing.T) {
+	// TODO: remove this skip once the underlying leaks are addressed.
+	t.Skip("Test fails due to leaks")
+
+	expectCleanShutdown(t)
+
+	slowServer := newDelayedServer()
+	server := httptest.NewServer(slowServer)
+	defer server.Close()
+
+	proxy, cleanup, err := runGRPCProxyServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	clientset := runAgent(proxy.agent, stopCh)
+	waitForConnectedServerCount(t, 1, clientset)
+
+	wg := sync.WaitGroup{}
+	dialFn := func(id int, cancelDelay time.Duration) {
+		defer wg.Done()
+
+		// run test client
+		tunnel, err := client.CreateSingleUseGrpcTunnel(context.Background(), proxy.front, grpc.WithInsecure())
+		if err != nil {
+			t.Error(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			time.Sleep(cancelDelay)
+			cancel() // Cancel the request (client-side)
+		}()
+
+		c := &http.Client{
+			Transport: &http.Transport{
+				DialContext: tunnel.DialContext,
+			},
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
+		if err != nil {
+			t.Error(err)
+		}
+
+		c.Do(req) // Errors are expected.
+
+		select {
+		case <-tunnel.Done():
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Errorf("Timed out waiting for tunnel to close")
+		}
+	}
+
+	// Ensure that tunnels aren't leaked with long-running servers.
+	ignoredGoRoutines := goleak.IgnoreCurrent()
+
+	const concurrentConns = 100
+	wg.Add(concurrentConns)
+	for i := 0; i < concurrentConns; i++ {
+		cancelDelayMs := rand.Int63n(1000) + 5 /* #nosec G404 */
+		go dialFn(i, time.Duration(cancelDelayMs)*time.Millisecond)
+	}
+	wg.Wait()
+
+	// Wait for the closed connections to propogate
+	var endpointConnsErr, goLeaksErr error
+	wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (done bool, err error) {
+		endpointConnsErr = metricstest.ExpectAgentEndpointConnections(0)
+		goLeaksErr = goleak.Find(ignoredGoRoutines)
+		return endpointConnsErr == nil && goLeaksErr == nil, nil
+	})
+
+	if endpointConnsErr != nil {
+		t.Errorf("Agent connections leaked: %v", endpointConnsErr)
+	}
+	if goLeaksErr != nil {
+		t.Error(goLeaksErr)
+	}
+
 	resetAllMetrics() // For clean shutdown.
 }
 


### PR DESCRIPTION
This test sometime leaks an agent connection. On my machine, the leak repros on approximately every fourth run. If I up the `parallel` request count to 1000, it reproduces every time but leaks multiple connections which makes the stack trace harder to sift through.


```
--- FAIL: TestProxyDial_RequestCancelled_Concurrent_GRPC (37.15s)
    proxy_test.go:441: 
        metric output does not match expectation; want:
        
        # HELP konnectivity_network_proxy_agent_open_endpoint_connections Current number of open endpoint connections.
        # TYPE konnectivity_network_proxy_agent_open_endpoint_connections gauge
        konnectivity_network_proxy_agent_open_endpoint_connections 0
        
        got:
        
        # HELP konnectivity_network_proxy_agent_open_endpoint_connections Current number of open endpoint connections.
        # TYPE konnectivity_network_proxy_agent_open_endpoint_connections gauge
        konnectivity_network_proxy_agent_open_endpoint_connections 1
        
    proxy_test.go:443: found unexpected goroutines:
        [Goroutine 1899 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        goroutine 1899 [IO wait]:
        internal/poll.runtime_pollWait(0x7f0cb0271900, 0x72)
        	/home/stclair/sdk/go1.19/src/runtime/netpoll.go:305 +0x89
        internal/poll.(*pollDesc).wait(0xc001ee8680?, 0xc002b22000?, 0x0)
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_poll_runtime.go:84 +0x32
        internal/poll.(*pollDesc).waitRead(...)
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Read(0xc001ee8680, {0xc002b22000, 0x1000, 0x1000})
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_unix.go:167 +0x25a
        net.(*netFD).Read(0xc001ee8680, {0xc002b22000?, 0xc0028c56c0?, 0x76aca5?})
        	/home/stclair/sdk/go1.19/src/net/fd_posix.go:55 +0x29
        net.(*conn).Read(0xc0006165b8, {0xc002b22000?, 0x0?, 0x0?})
        	/home/stclair/sdk/go1.19/src/net/net.go:183 +0x45
        net/http.(*connReader).Read(0xc0028ce390, {0xc002b22000, 0x1000, 0x1000})
        	/home/stclair/sdk/go1.19/src/net/http/server.go:786 +0x171
        bufio.(*Reader).fill(0xc0028e2c60)
        	/home/stclair/sdk/go1.19/src/bufio/bufio.go:106 +0xff
        bufio.(*Reader).ReadSlice(0xc0028e2c60, 0x0?)
        	/home/stclair/sdk/go1.19/src/bufio/bufio.go:372 +0x2f
        bufio.(*Reader).ReadLine(0xc0028e2c60)
        	/home/stclair/sdk/go1.19/src/bufio/bufio.go:401 +0x27
        net/textproto.(*Reader).readLineSlice(0xc0028ce3c0)
        	/home/stclair/sdk/go1.19/src/net/textproto/reader.go:56 +0x99
        net/textproto.(*Reader).ReadLine(...)
        	/home/stclair/sdk/go1.19/src/net/textproto/reader.go:37
        net/http.readRequest(0xc0006165b8?)
        	/home/stclair/sdk/go1.19/src/net/http/request.go:1036 +0x79
        net/http.(*conn).readRequest(0xc0028ac280, {0x1953750, 0xc002b02bc0})
        	/home/stclair/sdk/go1.19/src/net/http/server.go:994 +0x24a
        net/http.(*conn).serve(0xc0028ac280, {0x19537f8, 0xc0000be0c0})
        	/home/stclair/sdk/go1.19/src/net/http/server.go:1916 +0x345
        created by net/http.(*Server).Serve
        	/home/stclair/sdk/go1.19/src/net/http/server.go:3102 +0x4db
        
         Goroutine 1897 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        goroutine 1897 [IO wait]:
        internal/poll.runtime_pollWait(0x7f0cb0337690, 0x72)
        	/home/stclair/sdk/go1.19/src/runtime/netpoll.go:305 +0x89
        internal/poll.(*pollDesc).wait(0xc001c7f580?, 0xc0028c9000?, 0x0)
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_poll_runtime.go:84 +0x32
        internal/poll.(*pollDesc).waitRead(...)
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Read(0xc001c7f580, {0xc0028c9000, 0x1000, 0x1000})
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_unix.go:167 +0x25a
        net.(*netFD).Read(0xc001c7f580, {0xc0028c9000?, 0xc0029c2de0?, 0x40fb07?})
        	/home/stclair/sdk/go1.19/src/net/fd_posix.go:55 +0x29
        net.(*conn).Read(0xc0006165a8, {0xc0028c9000?, 0x50cc06?, 0x1661960?})
        	/home/stclair/sdk/go1.19/src/net/net.go:183 +0x45
        sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).remoteToProxy(0xc00020e6c0, 0x35, 0xc002847980)
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:571 +0x104
        sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).Serve.func3.2({0x19537f8, 0xc0028ce330})
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:497 +0x25
        runtime/pprof.Do({0x1953788?, 0xc000130000?}, {{0xc00020f140?, 0x0?, 0x0?}}, 0xc000649c80)
        	/home/stclair/sdk/go1.19/src/runtime/pprof/runtime.go:40 +0xa3
        created by sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).Serve.func3
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:497 +0xfc5
        
         Goroutine 1898 in state chan receive, with sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).proxyToRemote on top of the stack:
        goroutine 1898 [chan receive]:
        sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).proxyToRemote(0xc00020e6c0, 0x35, 0xc002847980)
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:624 +0x108
        sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).Serve.func3.3({0x19537f8, 0xc0025694a0})
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:498 +0x25
        runtime/pprof.Do({0x1953788?, 0xc000130000?}, {{0xc00020f140?, 0x0?, 0xc0025db8c0?}}, 0xc000649ca0)
        	/home/stclair/sdk/go1.19/src/runtime/pprof/runtime.go:40 +0xa3
        created by sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).Serve.func3
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:498 +0x10fb
        ]
    proxy_test.go:443: Leaks found; Retrying after 30s
    proxy_test.go:443: found unexpected goroutines:
        [Goroutine 1899 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        goroutine 1899 [IO wait]:
        internal/poll.runtime_pollWait(0x7f0cb0271900, 0x72)
        	/home/stclair/sdk/go1.19/src/runtime/netpoll.go:305 +0x89
        internal/poll.(*pollDesc).wait(0xc001ee8680?, 0xc002b22000?, 0x0)
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_poll_runtime.go:84 +0x32
        internal/poll.(*pollDesc).waitRead(...)
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Read(0xc001ee8680, {0xc002b22000, 0x1000, 0x1000})
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_unix.go:167 +0x25a
        net.(*netFD).Read(0xc001ee8680, {0xc002b22000?, 0xc0028c56c0?, 0x76aca5?})
        	/home/stclair/sdk/go1.19/src/net/fd_posix.go:55 +0x29
        net.(*conn).Read(0xc0006165b8, {0xc002b22000?, 0x0?, 0x0?})
        	/home/stclair/sdk/go1.19/src/net/net.go:183 +0x45
        net/http.(*connReader).Read(0xc0028ce390, {0xc002b22000, 0x1000, 0x1000})
        	/home/stclair/sdk/go1.19/src/net/http/server.go:786 +0x171
        bufio.(*Reader).fill(0xc0028e2c60)
        	/home/stclair/sdk/go1.19/src/bufio/bufio.go:106 +0xff
        bufio.(*Reader).ReadSlice(0xc0028e2c60, 0x0?)
        	/home/stclair/sdk/go1.19/src/bufio/bufio.go:372 +0x2f
        bufio.(*Reader).ReadLine(0xc0028e2c60)
        	/home/stclair/sdk/go1.19/src/bufio/bufio.go:401 +0x27
        net/textproto.(*Reader).readLineSlice(0xc0028ce3c0)
        	/home/stclair/sdk/go1.19/src/net/textproto/reader.go:56 +0x99
        net/textproto.(*Reader).ReadLine(...)
        	/home/stclair/sdk/go1.19/src/net/textproto/reader.go:37
        net/http.readRequest(0xc0006165b8?)
        	/home/stclair/sdk/go1.19/src/net/http/request.go:1036 +0x79
        net/http.(*conn).readRequest(0xc0028ac280, {0x1953750, 0xc002b02bc0})
        	/home/stclair/sdk/go1.19/src/net/http/server.go:994 +0x24a
        net/http.(*conn).serve(0xc0028ac280, {0x19537f8, 0xc0000be0c0})
        	/home/stclair/sdk/go1.19/src/net/http/server.go:1916 +0x345
        created by net/http.(*Server).Serve
        	/home/stclair/sdk/go1.19/src/net/http/server.go:3102 +0x4db
        
         Goroutine 1897 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        goroutine 1897 [IO wait]:
        internal/poll.runtime_pollWait(0x7f0cb0337690, 0x72)
        	/home/stclair/sdk/go1.19/src/runtime/netpoll.go:305 +0x89
        internal/poll.(*pollDesc).wait(0xc001c7f580?, 0xc0028c9000?, 0x0)
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_poll_runtime.go:84 +0x32
        internal/poll.(*pollDesc).waitRead(...)
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Read(0xc001c7f580, {0xc0028c9000, 0x1000, 0x1000})
        	/home/stclair/sdk/go1.19/src/internal/poll/fd_unix.go:167 +0x25a
        net.(*netFD).Read(0xc001c7f580, {0xc0028c9000?, 0xc0029c2de0?, 0x40fb07?})
        	/home/stclair/sdk/go1.19/src/net/fd_posix.go:55 +0x29
        net.(*conn).Read(0xc0006165a8, {0xc0028c9000?, 0x50cc06?, 0x1661960?})
        	/home/stclair/sdk/go1.19/src/net/net.go:183 +0x45
        sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).remoteToProxy(0xc00020e6c0, 0x35, 0xc002847980)
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:571 +0x104
        sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).Serve.func3.2({0x19537f8, 0xc0028ce330})
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:497 +0x25
        runtime/pprof.Do({0x1953788?, 0xc000130000?}, {{0xc00020f140?, 0x0?, 0x0?}}, 0xc000649c80)
        	/home/stclair/sdk/go1.19/src/runtime/pprof/runtime.go:40 +0xa3
        created by sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).Serve.func3
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:497 +0xfc5
        
         Goroutine 1898 in state chan receive, with sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).proxyToRemote on top of the stack:
        goroutine 1898 [chan receive]:
        sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).proxyToRemote(0xc00020e6c0, 0x35, 0xc002847980)
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:624 +0x108
        sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).Serve.func3.3({0x19537f8, 0xc0025694a0})
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:498 +0x25
        runtime/pprof.Do({0x1953788?, 0xc000130000?}, {{0xc00020f140?, 0x0?, 0xc0025db8c0?}}, 0xc000649ca0)
        	/home/stclair/sdk/go1.19/src/runtime/pprof/runtime.go:40 +0xa3
        created by sigs.k8s.io/apiserver-network-proxy/pkg/agent.(*Client).Serve.func3
        	/home/stclair/src/github.com/kubernetes-sigs/apiserver-network-proxy/pkg/agent/client.go:498 +0x10fb
        ]
    proxy_test.go:447: Connections still leaked after 30.924014462s
    proxy_test.go:448: 
        metric output does not match expectation; want:
        
        # HELP konnectivity_network_proxy_agent_open_endpoint_connections Current number of open endpoint connections.
        # TYPE konnectivity_network_proxy_agent_open_endpoint_connections gauge
        konnectivity_network_proxy_agent_open_endpoint_connections 0
        
        got:
        
        # HELP konnectivity_network_proxy_agent_open_endpoint_connections Current number of open endpoint connections.
        # TYPE konnectivity_network_proxy_agent_open_endpoint_connections gauge
        konnectivity_network_proxy_agent_open_endpoint_connections 1
        
FAIL
FAIL	sigs.k8s.io/apiserver-network-proxy/tests	37.183s
FAIL
```