### PR TITLE
konnectivity-server: synchronization cleanup.

### DIFF
--- a/konnectivity-client/pkg/client/client.go
+++ b/konnectivity-client/pkg/client/client.go
@@ -526,11 +526,11 @@ func (t *grpcTunnel) Recv() (*client.Packet, error) {
 
 	const segment = commonmetrics.SegmentToClient
 	pkt, err := t.stream.Recv()
-	if err != nil && err != io.EOF {
-		metrics.Metrics.ObserveStreamErrorNoPacket(segment, err)
-	}
 	if err != nil {
-		return pkt, err
+		if err != io.EOF {
+			metrics.Metrics.ObserveStreamErrorNoPacket(segment, err)
+		}
+		return nil, err
 	}
 	metrics.Metrics.ObservePacket(segment, pkt.Type)
 	return pkt, nil

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -295,11 +295,11 @@ func (a *Client) Recv() (*client.Packet, error) {
 
 	const segment = commonmetrics.SegmentToAgent
 	pkt, err := a.stream.Recv()
-	if err != nil && err != io.EOF {
-		metrics.Metrics.ObserveServerFailureDeprecated(metrics.DirectionFromServer)
-		metrics.Metrics.ObserveStreamErrorNoPacket(segment, err)
-	}
 	if err != nil {
+		if err != io.EOF {
+			metrics.Metrics.ObserveServerFailureDeprecated(metrics.DirectionFromServer)
+			metrics.Metrics.ObserveStreamErrorNoPacket(segment, err)
+		}
 		return nil, err
 	}
 	metrics.Metrics.ObservePacket(segment, pkt.Type)

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -72,6 +72,7 @@ func GenProxyStrategiesFromStr(proxyStrategies string) ([]ProxyStrategy, error) 
 
 type Backend interface {
 	Send(p *client.Packet) error
+	Recv() (*client.Packet, error)
 	Context() context.Context
 }
 
@@ -81,13 +82,15 @@ var _ Backend = agent.AgentService_ConnectServer(nil)
 type backend struct {
 	// TODO: this is a multi-writer single-reader pattern, it's tricky to
 	// write it using channel. Let's worry about performance later.
-	mu   sync.Mutex // mu protects conn
-	conn agent.AgentService_ConnectServer
+	sendLock sync.Mutex
+	recvLock sync.Mutex
+	conn     agent.AgentService_ConnectServer
 }
 
 func (b *backend) Send(p *client.Packet) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.sendLock.Lock()
+	defer b.sendLock.Unlock()
+
 	const segment = commonmetrics.SegmentToAgent
 	metrics.Metrics.ObservePacket(segment, p.Type)
 	err := b.conn.Send(p)
@@ -95,6 +98,22 @@ func (b *backend) Send(p *client.Packet) error {
 		metrics.Metrics.ObserveStreamError(segment, err, p.Type)
 	}
 	return err
+}
+
+func (b *backend) Recv() (*client.Packet, error) {
+	b.recvLock.Lock()
+	defer b.recvLock.Unlock()
+
+	const segment = commonmetrics.SegmentFromAgent
+	pkt, err := b.conn.Recv()
+	if err != nil {
+		if err != io.EOF {
+			metrics.Metrics.ObserveStreamErrorNoPacket(segment, err)
+		}
+		return nil, err
+	}
+	metrics.Metrics.ObservePacket(segment, pkt.Type)
+	return pkt, nil
 }
 
 func (b *backend) Context() context.Context {


### PR DESCRIPTION
Guard frontend gRPC stream send with mutex, since both serveRecvFrontend and serveRecvBackend use it. Guard receive just for consistency.

Always use Backend interface to send to and receive from agent. This allows some metrics duplication cleanup.