### PR TITLE
Update server and agent images to Go version 1.19.6

### DIFF
--- a/artifacts/images/agent-build.Dockerfile
+++ b/artifacts/images/agent-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-agent binary
-FROM golang:1.18.9 as builder
+FROM golang:1.19.6 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/server-build.Dockerfile
+++ b/artifacts/images/server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-server binary
-FROM golang:1.18.9 as builder
+FROM golang:1.19.6 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/apiserver-network-proxy
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION

Context: https://groups.google.com/g/golang-announce/c/2zqu2BOnpP8/m/3ECQJP56AwAJ

Reference similar for k/k: https://github.com/kubernetes/release/issues/2909