### PR TITLE
Add server "established_connections" metric.

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -306,6 +306,8 @@ func (s *ProxyServer) addFrontend(agentID string, connID int64, p *ProxyClientCo
 		s.frontends[agentID] = make(map[int64]*ProxyClientConnection)
 	}
 	s.frontends[agentID][connID] = p
+
+	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.frontends))
 }
 
 func (s *ProxyServer) removeFrontend(agentID string, connID int64) *ProxyClientConnection {
@@ -323,6 +325,7 @@ func (s *ProxyServer) removeFrontend(agentID string, connID int64) *ProxyClientC
 	if len(s.frontends[agentID]) == 0 {
 		delete(s.frontends, agentID)
 	}
+	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.frontends))
 	return ret
 }
 
@@ -354,7 +357,17 @@ func (s *ProxyServer) removeFrontendsForBackendConn(agentID string, backend Back
 			ret = append(ret, frontend)
 		}
 	}
+
+	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.frontends))
 	return ret, nil
+}
+
+func (s *ProxyServer) getCount(frontends map[string](map[int64]*ProxyClientConnection)) int {
+	count := 0
+	for _, frontend := range frontends {
+		count = count + len(frontend)
+	}
+	return count
 }
 
 // NewProxyServer creates a new ProxyServer instance

--- a/pkg/testing/metrics/metrics.go
+++ b/pkg/testing/metrics/metrics.go
@@ -32,6 +32,16 @@ const (
 # TYPE konnectivity_network_proxy_server_dial_failure_count counter`
 	serverDialFailureSample = `konnectivity_network_proxy_server_dial_failure_count{reason="%s"} %d`
 
+	serverPendingDialsHeader = `
+# HELP konnectivity_network_proxy_server_pending_backend_dials Current number of pending backend dial requests
+# TYPE konnectivity_network_proxy_server_pending_backend_dials gauge`
+	serverPendingDialsSample = `konnectivity_network_proxy_server_pending_backend_dials{} %d`
+
+	serverEstablishedConnsHeader = `
+# HELP konnectivity_network_proxy_server_established_connections Current number of established end-to-end connections (post-dial).
+# TYPE konnectivity_network_proxy_server_established_connections gauge`
+	serverEstablishedConnsSample = `konnectivity_network_proxy_server_established_connections{} %d`
+
 	agentDialFailureHeader = `
 # HELP konnectivity_network_proxy_agent_endpoint_dial_failure_total Number of failures dialing the remote endpoint, by reason (example: timeout).
 # TYPE konnectivity_network_proxy_agent_endpoint_dial_failure_total counter`
@@ -43,11 +53,23 @@ func ExpectServerDialFailures(expected map[server.DialFailureReason]int) error {
 	for r, v := range expected {
 		expect += fmt.Sprintf(serverDialFailureSample+"\n", r, v)
 	}
-	return ExpectMetric(server.Namespace, server.Subsystem, server.DialFailuresMetric, expect)
+	return ExpectMetric(server.Namespace, server.Subsystem, "dial_failure_count", expect)
 }
 
 func ExpectServerDialFailure(reason server.DialFailureReason, count int) error {
 	return ExpectServerDialFailures(map[server.DialFailureReason]int{reason: count})
+}
+
+func ExpectServerPendingDials(v int) error {
+	expect := serverPendingDialsHeader + "\n"
+	expect += fmt.Sprintf(serverPendingDialsSample+"\n", v)
+	return ExpectMetric(server.Namespace, server.Subsystem, "pending_backend_dials", expect)
+}
+
+func ExpectServerEstablishedConns(v int) error {
+	expect := serverEstablishedConnsHeader + "\n"
+	expect += fmt.Sprintf(serverEstablishedConnsSample+"\n", v)
+	return ExpectMetric(server.Namespace, server.Subsystem, "established_connections", expect)
 }
 
 func ExpectAgentDialFailures(expected map[agent.DialFailureReason]int) error {

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -849,7 +849,7 @@ func assertNoClientDialFailures(t testing.TB) {
 func assertNoServerDialFailures(t testing.TB) {
 	t.Helper()
 	if err := metricstest.ExpectServerDialFailures(nil); err != nil {
-		t.Errorf("Unexpected %s metric: %v", metricsserver.DialFailuresMetric, err)
+		t.Errorf("Unexpected %s metric: %v", "dial_failure_count", err)
 	}
 }
 


### PR DESCRIPTION
Comparing "grpc_connections" metric with this can help when debugging resource leaks.