### PR TITLE
fix: error propagation in http-connect mode

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,10 +17,12 @@ limitations under the License.
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	runpprof "runtime/pprof"
 	"strconv"
 	"strings"
@@ -119,6 +121,13 @@ func (c *ProxyClientConnection) send(pkt *client.Packet) error {
 			return err
 		} else if pkt.Type == client.PacketType_DIAL_RSP {
 			if pkt.GetDialResponse().Error != "" {
+				body := bytes.NewBufferString(pkt.GetDialResponse().Error)
+				t := http.Response{
+					StatusCode: 503,
+					Body:       io.NopCloser(body),
+				}
+
+				t.Write(c.HTTP)
 				return c.CloseHTTP()
 			}
 			return nil


### PR DESCRIPTION
If there is an error encountered by  the proxy-server, such as DNS lookup, this is currently not propagated currently back to the client in http-connect mode.

This PR adds a http response, conveying the error message to the client before closing the http connection.

I'm unsure about the Status Code, hence it is merely as a placeholder for now whether the status code should be in the 400 or 500 range.

fixes: #458