### PR TITLE
delete stale socket file, if it exists

### DIFF
--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -188,6 +188,7 @@ func getUDSListener(ctx context.Context, udsName string) (net.Listener, error) {
 	defer udsListenerLock.Unlock()
 	oldUmask := syscall.Umask(0007)
 	defer syscall.Umask(oldUmask)
+	os.Remove(udsName) // delete stale socket file, if it exists
 	var lc net.ListenConfig
 	lis, err := lc.Listen(ctx, "unix", udsName)
 	if err != nil {


### PR DESCRIPTION
we had issues were the server could not start because an old socket file was still around:

 [main.go:49] error: failed to run the frontend server: failed to get uds listener: failed to listen(unix) name /etc/kubernetes/konnectivity-server/konnectivity-server.socket: listen unix /etc/kubernetes/konnectivity-server/konnectivity-server.socket: bind: address already in use