### PR TITLE
test: fix race condition

### DIFF
--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -130,9 +130,7 @@ func TestServeData_HTTP(t *testing.T) {
 	}
 
 	// Verify internal state is consistent
-	if _, ok := testClient.connManager.Get(connID); ok {
-		t.Error("client.endpointConn not released")
-	}
+	waitForConnectionDeletion(t, testClient, connID)
 }
 
 func TestClose_Client(t *testing.T) {


### PR DESCRIPTION
Fixes the race condition when running the test

```
client_test.go:134: client.endpointConn not released
E0330 19:34:12.841766   16710 client.go:489] "could not send DIAL_RSP" err="expected send error" dialID=111 connectionID=1 dialAddress="127.0.0.1:57901"
E0330 19:34:12.842510   16710 client.go:440] "close response failure" err="expected send error" ="(MISSING)"
E0330 19:34:16.834985   16710 client.go:388] "could not read stream" err="timeout recv" serverID="" agentID=""
E0330 19:34:16.838832   16710 client.go:388] "could not read stream" err="timeout recv" serverID="" agentID=""
E0330 19:34:16.839057   16710 client.go:388] "could not read stream" err="timeout recv" serverID="" agentID=""
E0330 19:34:17.842124   16710 client.go:388] "could not read stream" err="timeout recv" serverID="" agentID=""
FAIL
FAIL	sigs.k8s.io/apiserver-network-proxy/pkg/agent	8.111s
?   	sigs.k8s.io/apiserver-network-proxy/pkg/agent/metrics	[no test files]
FAIL
```