### PR TITLE
Prevent docker build flakes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ PROXY_SERVER_IP ?= 127.0.0.1
 ## --------------------------------------
 ## Testing
 ## --------------------------------------
+.PHONY: mock_gen
 mock_gen:
 	mkdir -p proto/agent/mocks
 	mockgen sigs.k8s.io/apiserver-network-proxy/proto/agent AgentService_ConnectServer > proto/agent/mocks/agent_mock.go
@@ -103,14 +104,13 @@ mod-download:
 ## --------------------------------------
 
 .PHONY: gen
-gen: mod-download proto/agent/agent_grpc.pb.go proto/agent/agent.pb.go konnectivity-client/proto/client/client_grpc.pb.go konnectivity-client/proto/client/client.pb.go mock_gen
+gen: mod-download gen-proto mock_gen
 
-konnectivity-client/proto/client/client_grpc.pb.go konnectivity-client/proto/client/client.pb.go: konnectivity-client/proto/client/client.proto
+.PHONY: gen-proto
+gen-proto:
 	protoc -I . konnectivity-client/proto/client/client.proto --go_out=. --go_opt=paths=source_relative --go-grpc_out=require_unimplemented_servers=false:. --go-grpc_opt=paths=source_relative
 	cat hack/go-license-header.txt konnectivity-client/proto/client/client_grpc.pb.go > konnectivity-client/proto/client/client_grpc.licensed.go
 	mv konnectivity-client/proto/client/client_grpc.licensed.go konnectivity-client/proto/client/client_grpc.pb.go
-
-proto/agent/agent_grpc.pb.go proto/agent/agent.pb.go: proto/agent/agent.proto
 	protoc -I . proto/agent/agent.proto --go_out=. --go_opt=paths=source_relative --go-grpc_out=require_unimplemented_servers=false:. --go-grpc_opt=paths=source_relative
 	cat hack/go-license-header.txt proto/agent/agent_grpc.pb.go > proto/agent/agent_grpc.licensed.go
 	mv proto/agent/agent_grpc.licensed.go proto/agent/agent_grpc.pb.go


### PR DESCRIPTION
Tactical fix for build flake:

```
make ARCH=arm64 docker-build/proxy-agent
make[1]: Entering directory '/home/prow/go/src/sigs.k8s.io/apiserver-network-proxy'
protoc -I . proto/agent/agent.proto --go_out=. --go_opt=paths=source_relative --go-grpc_out=require_unimplemented_servers=false:. --go-grpc_opt=paths=source_relative
make[1]: protoc: No such file or directory
make[1]: *** [Makefile:[11](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_apiserver-network-proxy/473/pull-apiserver-network-proxy-docker-build-arm64/1633588688849997824#1:build-log.txt%3A11)4: proto/agent/agent.pb.go] Error [12](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_apiserver-network-proxy/473/pull-apiserver-network-proxy-docker-build-arm64/1633588688849997824#1:build-log.txt%3A12)7
make[1]: Leaving directory '/home/prow/go/src/sigs.k8s.io/apiserver-network-proxy'
make: *** [Makefile:253: docker-build/proxy-agent-arm64] Error 2
```

Note: there is a more ambitious request: https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/56
