### PR TITLE
Move shared definitions from pkg/agent to proto/header.

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -29,6 +29,7 @@ import (
 
 	"sigs.k8s.io/apiserver-network-proxy/pkg/agent"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
+	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
 type GrpcProxyAgentOptions struct {
@@ -197,12 +198,12 @@ func validateAgentIdentifiers(agentIdentifiers string) error {
 		return err
 	}
 	for idType := range decoded {
-		switch agent.IdentifierType(idType) {
-		case agent.IPv4:
-		case agent.IPv6:
-		case agent.CIDR:
-		case agent.Host:
-		case agent.DefaultRoute:
+		switch header.IdentifierType(idType) {
+		case header.IPv4:
+		case header.IPv6:
+		case header.CIDR:
+		case header.Host:
+		case header.DefaultRoute:
 		default:
 			return fmt.Errorf("unknown address type: %s", idType)
 		}

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
-	"net/url"
 	runpprof "runtime/pprof"
 	"strconv"
 	"sync"
@@ -116,58 +115,6 @@ func newConnectionManager() *connectionManager {
 	return &connectionManager{
 		connections: make(map[int64]*endpointConn),
 	}
-}
-
-// Identifiers stores agent identifiers that will be used by the server when
-// choosing agents
-type Identifiers struct {
-	IPv4         []string
-	IPv6         []string
-	Host         []string
-	CIDR         []string
-	DefaultRoute bool
-}
-
-type IdentifierType string
-
-const (
-	IPv4         IdentifierType = "ipv4"
-	IPv6         IdentifierType = "ipv6"
-	Host         IdentifierType = "host"
-	CIDR         IdentifierType = "cidr"
-	UID          IdentifierType = "uid"
-	DefaultRoute IdentifierType = "default-route"
-)
-
-// GenAgentIdentifiers generates an Identifiers based on the input string, the
-// input string should be a comma-seprated list with each item in the format
-// of <IdentifierType>=<address>
-func GenAgentIdentifiers(addrs string) (Identifiers, error) {
-	var agentIDs Identifiers
-	decoded, err := url.ParseQuery(addrs)
-	if err != nil {
-		return agentIDs, fmt.Errorf("fail to parse url encoded string: %v", err)
-	}
-	for idType, ids := range decoded {
-		switch IdentifierType(idType) {
-		case IPv4:
-			agentIDs.IPv4 = append(agentIDs.IPv4, ids...)
-		case IPv6:
-			agentIDs.IPv6 = append(agentIDs.IPv6, ids...)
-		case Host:
-			agentIDs.Host = append(agentIDs.Host, ids...)
-		case CIDR:
-			agentIDs.CIDR = append(agentIDs.CIDR, ids...)
-		case DefaultRoute:
-			defaultRouteIdentifier, err := strconv.ParseBool(ids[0])
-			if err == nil && defaultRouteIdentifier {
-				agentIDs.DefaultRoute = true
-			}
-		default:
-			return agentIDs, fmt.Errorf("Unknown address type: %s", idType)
-		}
-	}
-	return agentIDs, nil
 }
 
 // Client runs on the node network side. It connects to proxy server and establishes

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -29,9 +29,9 @@ import (
 
 	commonmetrics "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics"
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
-	pkgagent "sigs.k8s.io/apiserver-network-proxy/pkg/agent"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
 	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
 type ProxyStrategy string
@@ -129,9 +129,9 @@ func newBackend(conn agent.AgentService_ConnectServer) *backend {
 // connections, i.e., get, add and remove
 type BackendStorage interface {
 	// AddBackend adds a backend.
-	AddBackend(identifier string, idType pkgagent.IdentifierType, conn agent.AgentService_ConnectServer) Backend
+	AddBackend(identifier string, idType header.IdentifierType, conn agent.AgentService_ConnectServer) Backend
 	// RemoveBackend removes a backend.
-	RemoveBackend(identifier string, idType pkgagent.IdentifierType, conn agent.AgentService_ConnectServer)
+	RemoveBackend(identifier string, idType header.IdentifierType, conn agent.AgentService_ConnectServer)
 	// NumBackends returns the number of backends.
 	NumBackends() int
 }
@@ -182,18 +182,18 @@ type DefaultBackendStorage struct {
 	// types of identifiers when associating to a specific BackendManager,
 	// e.g., when associating to the DestHostBackendManager, it can only use the
 	// identifiers of types, IPv4, IPv6 and Host.
-	idTypes []pkgagent.IdentifierType
+	idTypes []header.IdentifierType
 }
 
 // NewDefaultBackendManager returns a DefaultBackendManager.
 func NewDefaultBackendManager() *DefaultBackendManager {
 	return &DefaultBackendManager{
 		DefaultBackendStorage: NewDefaultBackendStorage(
-			[]pkgagent.IdentifierType{pkgagent.UID})}
+			[]header.IdentifierType{header.UID})}
 }
 
 // NewDefaultBackendStorage returns a DefaultBackendStorage
-func NewDefaultBackendStorage(idTypes []pkgagent.IdentifierType) *DefaultBackendStorage {
+func NewDefaultBackendStorage(idTypes []header.IdentifierType) *DefaultBackendStorage {
 	// Set an explicit value, so that the metric is emitted even when
 	// no agent ever successfully connects.
 	metrics.Metrics.SetBackendCount(0)
@@ -204,7 +204,7 @@ func NewDefaultBackendStorage(idTypes []pkgagent.IdentifierType) *DefaultBackend
 	} /* #nosec G404 */
 }
 
-func containIDType(idTypes []pkgagent.IdentifierType, idType pkgagent.IdentifierType) bool {
+func containIDType(idTypes []header.IdentifierType, idType header.IdentifierType) bool {
 	for _, it := range idTypes {
 		if it == idType {
 			return true
@@ -214,7 +214,7 @@ func containIDType(idTypes []pkgagent.IdentifierType, idType pkgagent.Identifier
 }
 
 // AddBackend adds a backend.
-func (s *DefaultBackendStorage) AddBackend(identifier string, idType pkgagent.IdentifierType, conn agent.AgentService_ConnectServer) Backend {
+func (s *DefaultBackendStorage) AddBackend(identifier string, idType header.IdentifierType, conn agent.AgentService_ConnectServer) Backend {
 	if !containIDType(s.idTypes, idType) {
 		klog.V(4).InfoS("fail to add backend", "backend", identifier, "error", &ErrWrongIDType{idType, s.idTypes})
 		return nil
@@ -237,14 +237,14 @@ func (s *DefaultBackendStorage) AddBackend(identifier string, idType pkgagent.Id
 	s.backends[identifier] = []*backend{addedBackend}
 	metrics.Metrics.SetBackendCount(len(s.backends))
 	s.agentIDs = append(s.agentIDs, identifier)
-	if idType == pkgagent.DefaultRoute {
+	if idType == header.DefaultRoute {
 		s.defaultRouteAgentIDs = append(s.defaultRouteAgentIDs, identifier)
 	}
 	return addedBackend
 }
 
 // RemoveBackend removes a backend.
-func (s *DefaultBackendStorage) RemoveBackend(identifier string, idType pkgagent.IdentifierType, conn agent.AgentService_ConnectServer) {
+func (s *DefaultBackendStorage) RemoveBackend(identifier string, idType header.IdentifierType, conn agent.AgentService_ConnectServer) {
 	if !containIDType(s.idTypes, idType) {
 		klog.ErrorS(&ErrWrongIDType{idType, s.idTypes}, "fail to remove backend")
 		return
@@ -276,7 +276,7 @@ func (s *DefaultBackendStorage) RemoveBackend(identifier string, idType pkgagent
 				break
 			}
 		}
-		if idType == pkgagent.DefaultRoute {
+		if idType == header.DefaultRoute {
 			for i := range s.defaultRouteAgentIDs {
 				if s.defaultRouteAgentIDs[i] == identifier {
 					s.defaultRouteAgentIDs = append(s.defaultRouteAgentIDs[:i], s.defaultRouteAgentIDs[i+1:]...)
@@ -307,8 +307,8 @@ func (e *ErrNotFound) Error() string {
 }
 
 type ErrWrongIDType struct {
-	got    pkgagent.IdentifierType
-	expect []pkgagent.IdentifierType
+	got    header.IdentifierType
+	expect []header.IdentifierType
 }
 
 func (e *ErrWrongIDType) Error() string {

--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -20,8 +20,8 @@ import (
 	"reflect"
 	"testing"
 
-	pkgagent "sigs.k8s.io/apiserver-network-proxy/pkg/agent"
 	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
 type fakeAgentServiceConnectServer struct {
@@ -37,8 +37,8 @@ func TestAddRemoveBackends(t *testing.T) {
 
 	p := NewDefaultBackendManager()
 
-	p.AddBackend("agent1", pkgagent.UID, conn1)
-	p.RemoveBackend("agent1", pkgagent.UID, conn1)
+	p.AddBackend("agent1", header.UID, conn1)
+	p.RemoveBackend("agent1", header.UID, conn1)
 	expectedBackends := make(map[string][]*backend)
 	expectedAgentIDs := []string{}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
@@ -49,18 +49,18 @@ func TestAddRemoveBackends(t *testing.T) {
 	}
 
 	p = NewDefaultBackendManager()
-	p.AddBackend("agent1", pkgagent.UID, conn1)
-	p.AddBackend("agent1", pkgagent.UID, conn12)
+	p.AddBackend("agent1", header.UID, conn1)
+	p.AddBackend("agent1", header.UID, conn12)
 	// Adding the same connection again should be a no-op.
-	p.AddBackend("agent1", pkgagent.UID, conn12)
-	p.AddBackend("agent2", pkgagent.UID, conn2)
-	p.AddBackend("agent2", pkgagent.UID, conn22)
-	p.AddBackend("agent3", pkgagent.UID, conn3)
-	p.RemoveBackend("agent2", pkgagent.UID, conn22)
-	p.RemoveBackend("agent2", pkgagent.UID, conn2)
-	p.RemoveBackend("agent1", pkgagent.UID, conn1)
+	p.AddBackend("agent1", header.UID, conn12)
+	p.AddBackend("agent2", header.UID, conn2)
+	p.AddBackend("agent2", header.UID, conn22)
+	p.AddBackend("agent3", header.UID, conn3)
+	p.RemoveBackend("agent2", header.UID, conn22)
+	p.RemoveBackend("agent2", header.UID, conn2)
+	p.RemoveBackend("agent1", header.UID, conn1)
 	// This is invalid. agent1 doesn't have conn3. This should be a no-op.
-	p.RemoveBackend("agent1", pkgagent.UID, conn3)
+	p.RemoveBackend("agent1", header.UID, conn3)
 	expectedBackends = map[string][]*backend{
 		"agent1": {newBackend(conn12)},
 		"agent3": {newBackend(conn3)},
@@ -83,8 +83,8 @@ func TestAddRemoveBackendsWithDefaultRoute(t *testing.T) {
 
 	p := NewDefaultRouteBackendManager()
 
-	p.AddBackend("agent1", pkgagent.DefaultRoute, conn1)
-	p.RemoveBackend("agent1", pkgagent.DefaultRoute, conn1)
+	p.AddBackend("agent1", header.DefaultRoute, conn1)
+	p.RemoveBackend("agent1", header.DefaultRoute, conn1)
 	expectedBackends := make(map[string][]*backend)
 	expectedAgentIDs := []string{}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
@@ -98,18 +98,18 @@ func TestAddRemoveBackendsWithDefaultRoute(t *testing.T) {
 	}
 
 	p = NewDefaultRouteBackendManager()
-	p.AddBackend("agent1", pkgagent.DefaultRoute, conn1)
-	p.AddBackend("agent1", pkgagent.DefaultRoute, conn12)
+	p.AddBackend("agent1", header.DefaultRoute, conn1)
+	p.AddBackend("agent1", header.DefaultRoute, conn12)
 	// Adding the same connection again should be a no-op.
-	p.AddBackend("agent1", pkgagent.DefaultRoute, conn12)
-	p.AddBackend("agent2", pkgagent.DefaultRoute, conn2)
-	p.AddBackend("agent2", pkgagent.DefaultRoute, conn22)
-	p.AddBackend("agent3", pkgagent.DefaultRoute, conn3)
-	p.RemoveBackend("agent2", pkgagent.DefaultRoute, conn22)
-	p.RemoveBackend("agent2", pkgagent.DefaultRoute, conn2)
-	p.RemoveBackend("agent1", pkgagent.DefaultRoute, conn1)
+	p.AddBackend("agent1", header.DefaultRoute, conn12)
+	p.AddBackend("agent2", header.DefaultRoute, conn2)
+	p.AddBackend("agent2", header.DefaultRoute, conn22)
+	p.AddBackend("agent3", header.DefaultRoute, conn3)
+	p.RemoveBackend("agent2", header.DefaultRoute, conn22)
+	p.RemoveBackend("agent2", header.DefaultRoute, conn2)
+	p.RemoveBackend("agent1", header.DefaultRoute, conn1)
 	// This is invalid. agent1 doesn't have conn3. This should be a no-op.
-	p.RemoveBackend("agent1", pkgagent.DefaultRoute, conn3)
+	p.RemoveBackend("agent1", header.DefaultRoute, conn3)
 
 	expectedBackends = map[string][]*backend{
 		"agent1": {newBackend(conn12)},

--- a/pkg/server/default_route_backend_manager.go
+++ b/pkg/server/default_route_backend_manager.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/apiserver-network-proxy/pkg/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
 type DefaultRouteBackendManager struct {
@@ -32,7 +32,7 @@ var _ BackendManager = &DefaultRouteBackendManager{}
 func NewDefaultRouteBackendManager() *DefaultRouteBackendManager {
 	return &DefaultRouteBackendManager{
 		DefaultBackendStorage: NewDefaultBackendStorage(
-			[]agent.IdentifierType{agent.DefaultRoute})}
+			[]header.IdentifierType{header.DefaultRoute})}
 }
 
 // Backend tries to get a backend associating to the request destination host.

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/apiserver-network-proxy/pkg/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
 type DestHostBackendManager struct {
@@ -32,7 +32,7 @@ var _ BackendManager = &DestHostBackendManager{}
 func NewDestHostBackendManager() *DestHostBackendManager {
 	return &DestHostBackendManager{
 		DefaultBackendStorage: NewDefaultBackendStorage(
-			[]agent.IdentifierType{agent.IPv4, agent.IPv6, agent.Host})}
+			[]header.IdentifierType{header.IPv4, header.IPv6, header.Host})}
 }
 
 // Backend tries to get a backend associating to the request destination host.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,7 +40,7 @@ import (
 
 	commonmetrics "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
-	pkgagent "sigs.k8s.io/apiserver-network-proxy/pkg/agent"
+
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
 	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
@@ -267,15 +267,15 @@ func (s *ProxyServer) addBackend(agentID string, conn agent.AgentService_Connect
 			}
 			for _, ipv4 := range agentIdentifiers.IPv4 {
 				klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", ipv4)
-				s.BackendManagers[i].AddBackend(ipv4, pkgagent.IPv4, conn)
+				s.BackendManagers[i].AddBackend(ipv4, header.IPv4, conn)
 			}
 			for _, ipv6 := range agentIdentifiers.IPv6 {
 				klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", ipv6)
-				s.BackendManagers[i].AddBackend(ipv6, pkgagent.IPv6, conn)
+				s.BackendManagers[i].AddBackend(ipv6, header.IPv6, conn)
 			}
 			for _, host := range agentIdentifiers.Host {
 				klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", host)
-				s.BackendManagers[i].AddBackend(host, pkgagent.Host, conn)
+				s.BackendManagers[i].AddBackend(host, header.Host, conn)
 			}
 		case *DefaultRouteBackendManager:
 			agentIdentifiers, err := getAgentIdentifiers(conn)
@@ -285,11 +285,11 @@ func (s *ProxyServer) addBackend(agentID string, conn agent.AgentService_Connect
 			}
 			if agentIdentifiers.DefaultRoute {
 				klog.V(5).InfoS("Add the agent to DefaultRouteBackendManager", "agentID", agentID)
-				backend = s.BackendManagers[i].AddBackend(agentID, pkgagent.DefaultRoute, conn)
+				backend = s.BackendManagers[i].AddBackend(agentID, header.DefaultRoute, conn)
 			}
 		default:
 			klog.V(5).InfoS("Add the agent to DefaultBackendManager", "agentID", agentID)
-			backend = s.BackendManagers[i].AddBackend(agentID, pkgagent.UID, conn)
+			backend = s.BackendManagers[i].AddBackend(agentID, header.UID, conn)
 		}
 	}
 	return
@@ -306,15 +306,15 @@ func (s *ProxyServer) removeBackend(agentID string, conn agent.AgentService_Conn
 			}
 			for _, ipv4 := range agentIdentifiers.IPv4 {
 				klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", ipv4)
-				bm.RemoveBackend(ipv4, pkgagent.IPv4, conn)
+				bm.RemoveBackend(ipv4, header.IPv4, conn)
 			}
 			for _, ipv6 := range agentIdentifiers.IPv6 {
 				klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", ipv6)
-				bm.RemoveBackend(ipv6, pkgagent.IPv6, conn)
+				bm.RemoveBackend(ipv6, header.IPv6, conn)
 			}
 			for _, host := range agentIdentifiers.Host {
 				klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", host)
-				bm.RemoveBackend(host, pkgagent.Host, conn)
+				bm.RemoveBackend(host, header.Host, conn)
 			}
 		case *DefaultRouteBackendManager:
 			agentIdentifiers, err := getAgentIdentifiers(conn)
@@ -324,11 +324,11 @@ func (s *ProxyServer) removeBackend(agentID string, conn agent.AgentService_Conn
 			}
 			if agentIdentifiers.DefaultRoute {
 				klog.V(5).InfoS("Remove the agent from the DefaultRouteBackendManager", "agentID", agentID)
-				bm.RemoveBackend(agentID, pkgagent.DefaultRoute, conn)
+				bm.RemoveBackend(agentID, header.DefaultRoute, conn)
 			}
 		default:
 			klog.V(5).InfoS("Remove the agent from the DefaultBackendManager", "agentID", agentID)
-			bm.RemoveBackend(agentID, pkgagent.UID, conn)
+			bm.RemoveBackend(agentID, header.UID, conn)
 		}
 	}
 }
@@ -707,8 +707,8 @@ func agentID(stream agent.AgentService_ConnectServer) (string, error) {
 	return agentIDs[0], nil
 }
 
-func getAgentIdentifiers(stream agent.AgentService_ConnectServer) (pkgagent.Identifiers, error) {
-	var agentIdentifiers pkgagent.Identifiers
+func getAgentIdentifiers(stream agent.AgentService_ConnectServer) (header.Identifiers, error) {
+	var agentIdentifiers header.Identifiers
 	md, ok := metadata.FromIncomingContext(stream.Context())
 	if !ok {
 		return agentIdentifiers, fmt.Errorf("failed to get context")
@@ -721,7 +721,7 @@ func getAgentIdentifiers(stream agent.AgentService_ConnectServer) (pkgagent.Iden
 		return agentIdentifiers, nil
 	}
 
-	agentIdentifiers, err := pkgagent.GenAgentIdentifiers(agentIDs[0])
+	agentIdentifiers, err := header.GenAgentIdentifiers(agentIDs[0])
 	if err != nil {
 		return agentIdentifiers, err
 	}

--- a/proto/header/header.go
+++ b/proto/header/header.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package header
 
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
 const (
 	ServerCount      = "serverCount"
 	ServerID         = "serverID"
@@ -32,3 +38,55 @@ const (
 	// UserAgent is used to provide the client information in a proxy request
 	UserAgent = "user-agent"
 )
+
+// Identifiers stores agent identifiers that will be used by the server when
+// choosing agents
+type Identifiers struct {
+	IPv4         []string
+	IPv6         []string
+	Host         []string
+	CIDR         []string
+	DefaultRoute bool
+}
+
+type IdentifierType string
+
+const (
+	IPv4         IdentifierType = "ipv4"
+	IPv6         IdentifierType = "ipv6"
+	Host         IdentifierType = "host"
+	CIDR         IdentifierType = "cidr"
+	UID          IdentifierType = "uid"
+	DefaultRoute IdentifierType = "default-route"
+)
+
+// GenAgentIdentifiers generates an Identifiers based on the input string, the
+// input string should be a comma-seprated list with each item in the format
+// of <IdentifierType>=<address>
+func GenAgentIdentifiers(addrs string) (Identifiers, error) {
+	var agentIDs Identifiers
+	decoded, err := url.ParseQuery(addrs)
+	if err != nil {
+		return agentIDs, fmt.Errorf("fail to parse url encoded string: %v", err)
+	}
+	for idType, ids := range decoded {
+		switch IdentifierType(idType) {
+		case IPv4:
+			agentIDs.IPv4 = append(agentIDs.IPv4, ids...)
+		case IPv6:
+			agentIDs.IPv6 = append(agentIDs.IPv6, ids...)
+		case Host:
+			agentIDs.Host = append(agentIDs.Host, ids...)
+		case CIDR:
+			agentIDs.CIDR = append(agentIDs.CIDR, ids...)
+		case DefaultRoute:
+			defaultRouteIdentifier, err := strconv.ParseBool(ids[0])
+			if err == nil && defaultRouteIdentifier {
+				agentIDs.DefaultRoute = true
+			}
+		default:
+			return agentIDs, fmt.Errorf("Unknown address type: %s", idType)
+		}
+	}
+	return agentIDs, nil
+}

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -29,9 +29,9 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
-	pkgagent "sigs.k8s.io/apiserver-network-proxy/pkg/agent"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server"
 	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
+	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
 type simpleServer struct {
@@ -78,14 +78,14 @@ type singleTimeManager struct {
 	used     map[string]struct{}
 }
 
-func (s *singleTimeManager) AddBackend(agentID string, _ pkgagent.IdentifierType, conn agent.AgentService_ConnectServer) server.Backend {
+func (s *singleTimeManager) AddBackend(agentID string, _ header.IdentifierType, conn agent.AgentService_ConnectServer) server.Backend {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.backends[agentID] = conn
 	return conn
 }
 
-func (s *singleTimeManager) RemoveBackend(agentID string, _ pkgagent.IdentifierType, conn agent.AgentService_ConnectServer) {
+func (s *singleTimeManager) RemoveBackend(agentID string, _ header.IdentifierType, conn agent.AgentService_ConnectServer) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	v, ok := s.backends[agentID]


### PR DESCRIPTION
This allows pkg/server to avoid importing pkg/agent, which is a slight dependency cleanup.
