### PR TITLE
agent: smarter readiness check

### DIFF
--- a/pkg/agent/readiness.go
+++ b/pkg/agent/readiness.go
@@ -1,0 +1,30 @@
+/*
+copyright 2023 the kubernetes authors.
+
+licensed under the apache license, version 2.0 (the "license");
+you may not use this file except in compliance with the license.
+you may obtain a copy of the license at
+
+    http://www.apache.org/licenses/license-2.0
+
+unless required by applicable law or agreed to in writing, software
+distributed under the license is distributed on an "as is" basis,
+without warranties or conditions of any kind, either express or implied.
+see the license for the specific language governing permissions and
+limitations under the license.
+*/
+
+package agent
+
+// ReadinessManager supports checking if the agent is ready.
+type ReadinessManager interface {
+	// Ready returns true the proxy server is ready.
+	Ready() bool
+}
+
+var _ ReadinessManager = &ClientSet{}
+
+func (cs *ClientSet) Ready() bool {
+	// Returns true if the agent is connected to at least one server.
+	return cs.HealthyClientsCount() > 0
+}

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -969,6 +969,7 @@ func runAgentWithID(agentID, addr string, stopCh <-chan struct{}) *agent.ClientS
 		ProbeInterval: 100 * time.Millisecond,
 		DialOptions:   []grpc.DialOption{grpc.WithInsecure()},
 	}
+
 	client := cc.NewAgentClientSet(stopCh)
 	client.Serve()
 	return client

--- a/tests/readiness_test.go
+++ b/tests/readiness_test.go
@@ -16,11 +16,9 @@ limitations under the License.
 
 package tests
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestReadiness(t *testing.T) {
+func TestGRPCServerAndAgentReadiness(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
@@ -38,8 +36,45 @@ func TestReadiness(t *testing.T) {
 	clientset := runAgent(proxy.agent, stopCh)
 	waitForConnectedServerCount(t, 1, clientset)
 
+	// check the agent connected status
+	isAgentReady := clientset.Ready()
+	if !isAgentReady {
+		t.Fatalf("expected connection status 'true', got: %t", isAgentReady)
+	}
 	ready, _ = server.Readiness.Ready()
 	if !ready {
 		t.Fatalf("expected ready")
+	}
+}
+
+func TestHTTPConnServerAndAgentReadiness(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	proxy, cleanup, err := runHTTPConnProxyServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	clientset := runAgent(proxy.agent, stopCh)
+	waitForConnectedServerCount(t, 1, clientset)
+
+	// check the agent connected status
+	isAgentReady := clientset.Ready()
+	if !isAgentReady {
+		t.Fatalf("expected connection status 'true', got: %t", isAgentReady)
+	}
+}
+
+func TestAgentReadinessWithoutServer(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	clientset := runAgent("localhost:8080", stopCh)
+	// check the agent connected status
+	isAgentReady := clientset.Ready()
+	if isAgentReady {
+		t.Fatalf("expected connection status 'false', got: %t", isAgentReady)
 	}
 }


### PR DESCRIPTION
This commit introduces a smarter way for the readiness check.

Currently as soon as the agent is up, it signals itself as ready regardless of whether its actually connected to the server or not.

This commit introduces a callback function and a connected field in ClientSet struct to update the status of the agent -> proxy-server connection at regular intervals.


Concern: This makes the assumption that the client is connected to at least one proxy server and therefore the status is ready.

I've thought about updating the readiness of the agent only when all proxy-servers are connected but wasn't sure about the implications from the kubernetes side, ~~since this being a readiness check , kubernetes might treat the pod as not ready and not send any traffic.~~

EDIT: Since the agent pods are not behind a Kubernetes service, the readiness of the pod doesn't really matter. 

Please share your reviews,concerns to the approach I've taken.

/cc: @jveski @cheftako @jkh52 @tallclair 