### PR TITLE
Bump golang from 1.19.6 to 1.19.9 (CVE fixes)

### DIFF
--- a/artifacts/images/agent-build.Dockerfile
+++ b/artifacts/images/agent-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-agent binary
-FROM golang:1.19.6 as builder
+FROM golang:1.19.9 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/server-build.Dockerfile
+++ b/artifacts/images/server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-server binary
-FROM golang:1.19.6 as builder
+FROM golang:1.19.9 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/test-client-build.Dockerfile
+++ b/artifacts/images/test-client-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the client binary
-FROM golang:1.19.6 as builder
+FROM golang:1.19.9 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/test-server-build.Dockerfile
+++ b/artifacts/images/test-server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the http test server binary
-FROM golang:1.19.6 as builder
+FROM golang:1.19.9 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy


### PR DESCRIPTION
Example: CVE-2023-24538