### PR TITLE
Quiet more error logs on stream canceled.

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -30,7 +30,9 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 
 	commonmetrics "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics"
@@ -332,7 +334,11 @@ func (a *Client) Serve() {
 				klog.V(2).InfoS("received EOF, exit", "serverID", a.serverID, "agentID", a.agentID)
 				return
 			}
-			klog.ErrorS(err, "could not read stream", "serverID", a.serverID, "agentID", a.agentID)
+			if status.Code(err) == codes.Canceled {
+				klog.V(2).InfoS("stream canceled",  "serverID", a.serverID, "agentID", a.agentID)
+			} else {
+				klog.ErrorS(err, "could not read stream", "serverID", a.serverID, "agentID", a.agentID)
+			}
 			return
 		}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -858,7 +858,11 @@ func (s *ProxyServer) readBackendToChannel(backend Backend, recvCh chan *client.
 			return
 		}
 		if err != nil {
-			klog.ErrorS(err, "Receive stream from agent read failure")
+			if status.Code(err) == codes.Canceled {
+				klog.V(2).InfoS("Stream read from agent cancelled", "agentID", agentID)
+			} else {
+				klog.ErrorS(err, "Receive stream from agent read failure", "agentID", agentID)
+			}
 			stopCh <- err
 			close(stopCh)
 			return


### PR DESCRIPTION
This mitigates log error spam noted at https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/358 (when agent uses --sync-forever, it frequently triggers stream canceled in server codepath).

In general, we already log at info level for stream EOF, and stream canceled seems comparable.
