### PR TITLE
proxy-server: change --delete-existing-uds-file default to true.

### DIFF
--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -114,7 +114,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.ClusterCaCert, "cluster-ca-cert", o.ClusterCaCert, "If non-empty the CA we use to validate Agent clients.")
 	flags.StringVar(&o.Mode, "mode", o.Mode, "mode can be either 'grpc' or 'http-connect'.")
 	flags.StringVar(&o.UdsName, "uds-name", o.UdsName, "uds-name should be empty for TCP traffic. For UDS set to its name.")
-	flags.BoolVar(&o.DeleteUDSFile, "delete-existing-uds-file", o.DeleteUDSFile, "If true and if file UdsName already exists, delete the file before listen on that UDS file")
+	flags.BoolVar(&o.DeleteUDSFile, "delete-existing-uds-file", o.DeleteUDSFile, "If true and if file UdsName already exists, delete the file before listen on that UDS file. Default is true.")
 	flags.IntVar(&o.ServerPort, "server-port", o.ServerPort, "Port we listen for server connections on. Set to 0 for UDS.")
 	flags.StringVar(&o.ServerBindAddress, "server-bind-address", o.ServerBindAddress, "Bind address for server connections. If empty, we will bind to all interfaces.")
 	flags.IntVar(&o.AgentPort, "agent-port", o.AgentPort, "Port we listen for agent connections on.")
@@ -330,7 +330,7 @@ func NewProxyRunOptions() *ProxyRunOptions {
 		ClusterCaCert:             "",
 		Mode:                      "grpc",
 		UdsName:                   "",
-		DeleteUDSFile:             false,
+		DeleteUDSFile:             true,
 		ServerPort:                8090,
 		ServerBindAddress:         "",
 		AgentPort:                 8091,

--- a/cmd/server/app/options/options_test.go
+++ b/cmd/server/app/options/options_test.go
@@ -38,7 +38,7 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "ClusterCaCert", defaultServerOptions.ClusterCaCert, "")
 	assertDefaultValue(t, "Mode", defaultServerOptions.Mode, "grpc")
 	assertDefaultValue(t, "UdsName", defaultServerOptions.UdsName, "")
-	assertDefaultValue(t, "DeleteUDSFile", defaultServerOptions.DeleteUDSFile, false)
+	assertDefaultValue(t, "DeleteUDSFile", defaultServerOptions.DeleteUDSFile, true)
 	assertDefaultValue(t, "ServerPort", defaultServerOptions.ServerPort, 8090)
 	assertDefaultValue(t, "ServerBindAddress", defaultServerOptions.ServerBindAddress, "")
 	assertDefaultValue(t, "AgentPort", defaultServerOptions.AgentPort, 8091)


### PR DESCRIPTION
This is followup from discusssion at https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/476