### PR TITLE
fix: metric frontend_write_duration_seconds has wrong value

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -106,8 +106,7 @@ const (
 )
 
 func (c *ProxyClientConnection) send(pkt *client.Packet) error {
-	start := time.Now()
-	defer metrics.Metrics.ObserveFrontendWriteLatency(time.Since(start))
+	defer func(start time.Time) { metrics.Metrics.ObserveFrontendWriteLatency(time.Since(start)) }(time.Now())
 	if c.Mode == "grpc" {
 		return c.frontend.Send(pkt)
 	}


### PR DESCRIPTION
And maybe this issue is helpful: golang/go#60048