### PR TITLE
Refactor integration tests to prepare for proxy-server & agent skew testing

### DIFF
--- a/tests/benchmarks_test.go
+++ b/tests/benchmarks_test.go
@@ -39,17 +39,14 @@ func BenchmarkLargeResponse_GRPC(b *testing.B) {
 	server := httptest.NewServer(newSizedServer(length, chunks))
 	defer server.Close()
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	proxy, cleanup, err := runGRPCProxyServer()
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer cleanup()
 
-	clientset := runAgent(proxy.agent, stopCh)
-	waitForConnectedServerCount(b, 1, clientset)
+	a := runAgent(b, proxy.agent)
+	waitForConnectedServerCount(b, 1, a)
 
 	req, err := http.NewRequest("GET", server.URL, nil)
 	if err != nil {
@@ -113,17 +110,14 @@ func BenchmarkLargeRequest_GRPC(b *testing.B) {
 	}))
 	defer server.Close()
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	proxy, cleanup, err := runGRPCProxyServer()
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer cleanup()
 
-	clientset := runAgent(proxy.agent, stopCh)
-	waitForConnectedServerCount(b, 1, clientset)
+	a := runAgent(b, proxy.agent)
+	waitForConnectedServerCount(b, 1, a)
 
 	bodyBytes := make([]byte, length)
 	body := bytes.NewReader(bodyBytes)

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -140,13 +140,13 @@ func TestConcurrentClientRequest(t *testing.T) {
 	defer cleanup()
 	ps.BackendManagers = []server.BackendManager{newSingleTimeGetter(server.NewDefaultBackendManager())}
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
 	// Run two agents
-	cs1 := runAgentWithID("a", proxy.agent, stopCh)
-	cs2 := runAgentWithID("b", proxy.agent, stopCh)
-	waitForConnectedServerCount(t, 1, cs1)
-	waitForConnectedServerCount(t, 1, cs2)
+	ai1 := runAgent(t, proxy.agent)
+	ai2 := runAgent(t, proxy.agent)
+	defer ai1.Stop()
+	defer ai2.Stop()
+	waitForConnectedServerCount(t, 1, ai1)
+	waitForConnectedServerCount(t, 1, ai2)
 
 	client1 := getTestClient(proxy.front, t)
 	client2 := getTestClient(proxy.front, t)

--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -19,39 +19,34 @@ package tests
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
-	"sigs.k8s.io/apiserver-network-proxy/pkg/server"
-	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
 type simpleServer struct {
-	receivedSecondReq chan struct{}
+	mu sync.Mutex
 }
 
-// ServeHTTP blocks the response to the request whose body is "1" until a
-// request whose body is "2" is handled.
 func (s *simpleServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	time.Sleep(time.Millisecond)
+
 	bytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		w.Write([]byte(err.Error()))
 	}
-	if string(bytes) == "2" {
-		close(s.receivedSecondReq)
-		w.Write([]byte("2"))
-	}
-	if string(bytes) == "1" {
-		<-s.receivedSecondReq
-		w.Write([]byte("1"))
-	}
+	w.Write(bytes)
 }
 
 // TODO: test http-connect as well.
@@ -70,119 +65,45 @@ func getTestClient(front string, t *testing.T) *http.Client {
 	}
 }
 
-// singleTimeManager makes sure that a backend only serves one request.
-type singleTimeManager struct {
-	mu       sync.Mutex
-	backends map[string]server.Backend
-	used     map[string]struct{}
-}
-
-func (s *singleTimeManager) AddBackend(agentID string, _ header.IdentifierType, backend server.Backend) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.backends[agentID] = backend
-}
-
-func (s *singleTimeManager) RemoveBackend(agentID string, _ header.IdentifierType, backend server.Backend) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	v, ok := s.backends[agentID]
-	if !ok {
-		panic(fmt.Errorf("no backends found for %s", agentID))
-	}
-	if v != backend {
-		panic(fmt.Errorf("recorded backend %v does not match %v", &v, backend))
-	}
-	delete(s.backends, agentID)
-}
-
-func (s *singleTimeManager) Backend(_ context.Context) (server.Backend, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for k, v := range s.backends {
-		if _, ok := s.used[k]; !ok {
-			s.used[k] = struct{}{}
-			return v, nil
-		}
-	}
-	return nil, fmt.Errorf("cannot find backend to a new agent")
-}
-
-func (s *singleTimeManager) GetBackend(agentID string) server.Backend {
-	return nil
-}
-
-func (s *singleTimeManager) NumBackends() int {
-	return 0
-}
-
-func newSingleTimeGetter(m *server.DefaultBackendManager) *singleTimeManager {
-	return &singleTimeManager{
-		used:     make(map[string]struct{}),
-		backends: make(map[string]server.Backend),
-	}
-}
-
-var _ server.BackendManager = &singleTimeManager{}
-
-func (s *singleTimeManager) Ready() (bool, string) {
-	return true, ""
-}
-
 func TestConcurrentClientRequest(t *testing.T) {
-	t.Skip() // FIXME: figure out how to run this without overriding the BackendManagers
-	s := httptest.NewServer(&simpleServer{receivedSecondReq: make(chan struct{})})
+	const numConcurrentRequests = 100
+	s := httptest.NewServer(&simpleServer{})
 	defer s.Close()
 
 	ps := runGRPCProxyServerWithServerCount(t, 1)
 	defer ps.Stop()
-	// ps.BackendManagers = []server.BackendManager{newSingleTimeGetter(server.NewDefaultBackendManager())} FIXME
 
 	// Run two agents
-	ai1 := runAgent(t, ps.AgentAddr())
-	ai2 := runAgent(t, ps.AgentAddr())
-	defer ai1.Stop()
-	defer ai2.Stop()
-	waitForConnectedServerCount(t, 1, ai1)
-	waitForConnectedServerCount(t, 1, ai2)
+	a1 := runAgent(t, ps.AgentAddr())
+	a2 := runAgent(t, ps.AgentAddr())
+	defer a1.Stop()
+	defer a2.Stop()
+	waitForConnectedServerCount(t, 1, a1)
+	waitForConnectedServerCount(t, 1, a2)
 
-	client1 := getTestClient(ps.FrontAddr(), t)
-	client2 := getTestClient(ps.FrontAddr(), t)
 	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		r, err := client1.Post(s.URL, "text/plain", bytes.NewBufferString("1"))
-		if err != nil {
-			t.Error(err)
-			return
-		}
-		data, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Error(err)
-		}
-		r.Body.Close()
+	wg.Add(numConcurrentRequests)
+	for i := 0; i < numConcurrentRequests; i++ {
+		id := i
+		go func() {
+			defer wg.Done()
+			client1 := getTestClient(ps.FrontAddr(), t)
 
-		if string(data) != "1" {
-			t.Errorf("expect %v; got %v", "1", string(data))
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		r, err := client2.Post(s.URL, "text/plain", bytes.NewBufferString("2"))
-		if err != nil {
-			t.Error(err)
-			return
-		}
-		data, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Error(err)
-		}
-		r.Body.Close()
+			r, err := client1.Post(s.URL, "text/plain", bytes.NewBufferString(strconv.Itoa(id)))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			data, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Error(err)
+			}
+			r.Body.Close()
 
-		if string(data) != "2" {
-			t.Errorf("expect %v; got %v", "2", string(data))
-		}
-	}()
+			if string(data) != strconv.Itoa(id) {
+				t.Errorf("expect %d; got %s", id, string(data))
+			}
+		}()
+	}
 	wg.Wait()
 }

--- a/tests/framework/agent.go
+++ b/tests/framework/agent.go
@@ -24,8 +24,8 @@ import (
 )
 
 type AgentOpts struct {
-	AgentID string
-	Addr    string
+	AgentID    string
+	ServerAddr string
 }
 
 type AgentRunner interface {
@@ -42,7 +42,7 @@ type InProcessAgentRunner struct{}
 
 func (*InProcessAgentRunner) Start(opts AgentOpts) (Agent, error) {
 	cc := agent.ClientSetConfig{
-		Address:       opts.Addr,
+		Address:       opts.ServerAddr,
 		AgentID:       opts.AgentID,
 		SyncInterval:  100 * time.Millisecond,
 		ProbeInterval: 100 * time.Millisecond,

--- a/tests/framework/agent.go
+++ b/tests/framework/agent.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"time"
+
+	"google.golang.org/grpc"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/agent"
+)
+
+type AgentOpts struct {
+	AgentID string
+	Addr    string
+}
+
+type AgentRunner interface {
+	Start(AgentOpts) (Agent, error)
+}
+
+type Agent interface {
+	GetConnectedServerCount() (int, error)
+	Ready() bool
+	Stop() error
+}
+
+type InProcessAgentRunner struct{}
+
+func (*InProcessAgentRunner) Start(opts AgentOpts) (Agent, error) {
+	cc := agent.ClientSetConfig{
+		Address:       opts.Addr,
+		AgentID:       opts.AgentID,
+		SyncInterval:  100 * time.Millisecond,
+		ProbeInterval: 100 * time.Millisecond,
+		DialOptions:   []grpc.DialOption{grpc.WithInsecure()},
+	}
+
+	stopCh := make(chan struct{})
+	client := cc.NewAgentClientSet(stopCh)
+	client.Serve()
+
+	return &inProcessAgent{
+		client: client,
+		stopCh: stopCh,
+	}, nil
+}
+
+type inProcessAgent struct {
+	client *agent.ClientSet
+	stopCh chan struct{}
+}
+
+func (a *inProcessAgent) Stop() error {
+	close(a.stopCh)
+	return nil
+}
+
+func (a *inProcessAgent) GetConnectedServerCount() (int, error) {
+	return a.client.HealthyClientsCount(), nil
+}
+
+func (a *inProcessAgent) Ready() bool {
+	return a.client.Ready()
+}

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+type Framework struct {
+	AgentRunner AgentRunner
+}

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -17,5 +17,6 @@ limitations under the License.
 package framework
 
 type Framework struct {
-	AgentRunner AgentRunner
+	AgentRunner       AgentRunner
+	ProxyServerRunner ProxyServerRunner
 }

--- a/tests/framework/proxy_server.go
+++ b/tests/framework/proxy_server.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	clientproto "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server"
+	agentproto "sigs.k8s.io/apiserver-network-proxy/proto/agent"
+)
+
+type ProxyServerOpts struct {
+	ServerCount int
+	Mode        string
+}
+
+type ProxyServerRunner interface {
+	Start(ProxyServerOpts) (ProxyServer, error)
+}
+
+type ProxyServer interface {
+	ConnectedBackends() int
+	FrontendConnectionCount() int
+	AgentAddr() string
+	FrontAddr() string
+	Ready() bool
+	Stop() error
+}
+
+type InProcessProxyServerRunner struct{}
+
+func (*InProcessProxyServerRunner) Start(opts ProxyServerOpts) (ProxyServer, error) {
+	switch opts.Mode {
+	case "http":
+		return startHTTP(opts)
+	case "grpc":
+		return startGRPC(opts)
+	default:
+		panic("must specify proxy server mode")
+	}
+}
+
+func startGRPC(opts ProxyServerOpts) (ProxyServer, error) {
+	var err error
+
+	commonServer, err := startInProcessCommonProxyServer(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	ps := &inProcessGRPCProxyServer{
+		inProcessCommonProxyServer: commonServer,
+		grpcServer:                 grpc.NewServer(),
+	}
+
+	clientproto.RegisterProxyServiceServer(ps.grpcServer, ps.proxyServer)
+	ps.grpcListener, err = net.Listen("tcp", "")
+	if err != nil {
+		return ps, err
+	}
+	go ps.grpcServer.Serve(ps.grpcListener)
+
+	return ps, nil
+}
+
+type inProcessGRPCProxyServer struct {
+	*inProcessCommonProxyServer
+
+	grpcServer   *grpc.Server
+	grpcListener net.Listener
+}
+
+func (ps *inProcessGRPCProxyServer) Stop() error {
+	ps.stopCommonProxyServer()
+
+	if ps.grpcListener != nil {
+		ps.grpcListener.Close()
+	}
+	ps.grpcServer.Stop()
+	return nil
+}
+
+func (ps *inProcessGRPCProxyServer) FrontAddr() string {
+	return ps.grpcListener.Addr().String()
+}
+
+func (ps *inProcessGRPCProxyServer) FrontendConnectionCount() int {
+	panic("unimplemented: inProcessGRPCProxyServer.FrontendConnectionCount") // FIXME: consider reading from metrics
+}
+
+func startHTTP(opts ProxyServerOpts) (ProxyServer, error) {
+	var err error
+
+	commonServer, err := startInProcessCommonProxyServer(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	ps := &inProcessHTTPProxyServer{
+		inProcessCommonProxyServer: commonServer,
+	}
+
+	// http-connect
+	handler := &server.Tunnel{
+		Server: ps.proxyServer,
+	}
+	ps.httpServer = &http.Server{
+		ReadHeaderTimeout: 60 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&ps.httpConnectionCount, 1)
+			defer atomic.AddInt32(&ps.httpConnectionCount, -1)
+			handler.ServeHTTP(w, r)
+		}),
+	}
+	ps.httpListener, err = net.Listen("tcp", "")
+	if err != nil {
+		return ps, err
+	}
+
+	go func() {
+		err := ps.httpServer.Serve(ps.httpListener)
+		if err != nil {
+			fmt.Println("http connect server error: ", err)
+		}
+	}()
+
+	return ps, nil
+}
+
+type inProcessHTTPProxyServer struct {
+	*inProcessCommonProxyServer
+
+	httpServer   *http.Server
+	httpListener net.Listener
+
+	httpConnectionCount int32 // atomic
+}
+
+func (ps *inProcessHTTPProxyServer) Stop() error {
+	ps.stopCommonProxyServer()
+
+	if ps.httpListener != nil {
+		ps.httpListener.Close()
+	}
+	ps.httpServer.Shutdown(context.Background())
+
+	return nil
+}
+
+func (ps *inProcessHTTPProxyServer) FrontAddr() string {
+	return ps.httpListener.Addr().String()
+}
+
+func (ps *inProcessHTTPProxyServer) FrontendConnectionCount() int {
+	return int(atomic.LoadInt32(&ps.httpConnectionCount))
+}
+
+// inProcessCommonProxyServer handles the common agent (backend) serving shared between the
+// inProccessGRPCProxyServer and inProcessHTTPProxyServer
+type inProcessCommonProxyServer struct {
+	proxyServer *server.ProxyServer
+
+	agentServer   *grpc.Server
+	agentListener net.Listener
+}
+
+func startInProcessCommonProxyServer(opts ProxyServerOpts) (*inProcessCommonProxyServer, error) {
+	s := server.NewProxyServer(uuid.New().String(), []server.ProxyStrategy{server.ProxyStrategyDefault}, opts.ServerCount, &server.AgentTokenAuthenticationOptions{})
+	ps := &inProcessCommonProxyServer{
+		proxyServer: s,
+		agentServer: grpc.NewServer(),
+	}
+	agentproto.RegisterAgentServiceServer(ps.agentServer, s)
+	var err error
+	ps.agentListener, err = net.Listen("tcp", "")
+	if err != nil {
+		return ps, err
+	}
+	go ps.agentServer.Serve(ps.agentListener)
+
+	return ps, nil
+}
+
+func (ps *inProcessCommonProxyServer) stopCommonProxyServer() {
+	if ps.agentListener != nil {
+		ps.agentListener.Close()
+	}
+	ps.agentServer.Stop()
+}
+
+func (ps *inProcessCommonProxyServer) AgentAddr() string {
+	return ps.agentListener.Addr().String()
+}
+
+func (ps *inProcessCommonProxyServer) ConnectedBackends() int {
+	numBackends := 0
+	for _, bm := range ps.proxyServer.BackendManagers {
+		numBackends += bm.NumBackends()
+	}
+	return numBackends
+}
+
+func (ps *inProcessCommonProxyServer) Ready() bool {
+	ready, _ := ps.proxyServer.Readiness.Ready()
+	return ready
+}

--- a/tests/ha_proxy_server_test.go
+++ b/tests/ha_proxy_server_test.go
@@ -30,6 +30,7 @@ import (
 
 	"google.golang.org/grpc"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
+	"sigs.k8s.io/apiserver-network-proxy/tests/framework"
 )
 
 type tcpLB struct {
@@ -111,22 +112,12 @@ func (lb *tcpLB) randomBackend() string {
 
 const haServerCount = 3
 
-func setupHAProxyServer(t *testing.T) ([]proxy, []func()) {
-	proxy1, _, cleanup1, err := runGRPCProxyServerWithServerCount(haServerCount)
-	if err != nil {
-		t.Fatal(err)
+func setupHAProxyServer(t *testing.T) []framework.ProxyServer {
+	ps := make([]framework.ProxyServer, haServerCount)
+	for i := 0; i < haServerCount; i++ {
+		ps[i] = runGRPCProxyServerWithServerCount(t, haServerCount)
 	}
-
-	proxy2, _, cleanup2, err := runGRPCProxyServerWithServerCount(haServerCount)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	proxy3, _, cleanup3, err := runGRPCProxyServerWithServerCount(haServerCount)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return []proxy{proxy1, proxy2, proxy3}, []func(){cleanup1, cleanup2, cleanup3}
+	return ps
 }
 
 func TestBasicHAProxyServer_GRPC(t *testing.T) {
@@ -136,54 +127,51 @@ func TestBasicHAProxyServer_GRPC(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	proxy, cleanups := setupHAProxyServer(t)
+	proxy := setupHAProxyServer(t)
 
 	lb := tcpLB{
 		backends: []string{
-			proxy[0].agent,
-			proxy[1].agent,
-			proxy[2].agent,
+			proxy[0].AgentAddr(),
+			proxy[1].AgentAddr(),
+			proxy[2].AgentAddr(),
 		},
 		t: t,
 	}
 	lbAddr := lb.serve(stopCh)
 
-	ai := runAgent(t, lbAddr)
-	defer ai.Stop()
-	waitForConnectedServerCount(t, 3, ai)
+	a := runAgent(t, lbAddr)
+	defer a.Stop()
+	waitForConnectedServerCount(t, 3, a)
 
 	// run test client
-	testProxyServer(t, proxy[0].front, server.URL)
-	testProxyServer(t, proxy[1].front, server.URL)
-	testProxyServer(t, proxy[2].front, server.URL)
+	testProxyServer(t, proxy[0].FrontAddr(), server.URL)
+	testProxyServer(t, proxy[1].FrontAddr(), server.URL)
+	testProxyServer(t, proxy[2].FrontAddr(), server.URL)
 
 	t.Logf("basic HA proxy server test passed")
 
 	// interrupt the HA server
-	lb.removeBackend(proxy[0].agent)
-	cleanups[0]()
+	lb.removeBackend(proxy[0].AgentAddr())
+	proxy[0].Stop()
 
 	// give the agent some time to detect the disconnection
-	waitForConnectedServerCount(t, 2, ai)
+	waitForConnectedServerCount(t, 2, a)
 
-	proxy4, _, cleanup4, err := runGRPCProxyServerWithServerCount(haServerCount)
-	if err != nil {
-		t.Fatal(err)
-	}
-	lb.addBackend(proxy4.agent)
+	proxy4 := runGRPCProxyServerWithServerCount(t, haServerCount)
+	lb.addBackend(proxy4.AgentAddr())
 	defer func() {
-		cleanups[1]()
-		cleanups[2]()
-		cleanup4()
+		proxy[1].Stop()
+		proxy[2].Stop()
+		proxy4.Stop()
 	}()
 
 	// wait for the new server to be connected.
-	waitForConnectedServerCount(t, 3, ai)
+	waitForConnectedServerCount(t, 3, a)
 
 	// run test client
-	testProxyServer(t, proxy[1].front, server.URL)
-	testProxyServer(t, proxy[2].front, server.URL)
-	testProxyServer(t, proxy4.front, server.URL)
+	testProxyServer(t, proxy[1].FrontAddr(), server.URL)
+	testProxyServer(t, proxy[2].FrontAddr(), server.URL)
+	testProxyServer(t, proxy4.FrontAddr(), server.URL)
 }
 
 func testProxyServer(t *testing.T, front string, target string) {

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -24,7 +24,12 @@ import (
 	"k8s.io/klog/v2"
 
 	metricsclient "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics"
+	"sigs.k8s.io/apiserver-network-proxy/tests/framework"
 )
+
+var Framework = framework.Framework{
+	AgentRunner: &framework.InProcessAgentRunner{},
+}
 
 func TestMain(m *testing.M) {
 	fs := flag.NewFlagSet("mock-flags", flag.PanicOnError)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 var Framework = framework.Framework{
-	AgentRunner: &framework.InProcessAgentRunner{},
+	AgentRunner:       &framework.InProcessAgentRunner{},
+	ProxyServerRunner: &framework.InProcessProxyServerRunner{},
 }
 
 func TestMain(m *testing.M) {

--- a/tests/reconnect_test.go
+++ b/tests/reconnect_test.go
@@ -54,8 +54,8 @@ func TestClientReconnects(t *testing.T) {
 		}
 	}()
 
-	ai := runAgentWithID(t, "test-id", lis.Addr().String())
-	defer ai.Stop()
+	a := runAgentWithID(t, "test-id", lis.Addr().String())
+	defer a.Stop()
 
 	select {
 	case <-connections:

--- a/tests/reconnect_test.go
+++ b/tests/reconnect_test.go
@@ -54,9 +54,8 @@ func TestClientReconnects(t *testing.T) {
 		}
 	}()
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	runAgentWithID("test-id", lis.Addr().String(), stopCh)
+	ai := runAgentWithID(t, "test-id", lis.Addr().String())
+	defer ai.Stop()
 
 	select {
 	case <-connections:

--- a/tests/tcp_server_test.go
+++ b/tests/tcp_server_test.go
@@ -62,18 +62,15 @@ func TestEchoServer(t *testing.T) {
 		}
 	}()
 
-	proxy, cleanup, err := runGRPCProxyServer()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanup()
+	ps := runGRPCProxyServer(t)
+	defer ps.Stop()
 
-	ai := runAgent(t, proxy.agent)
-	defer ai.Stop()
-	waitForConnectedServerCount(t, 1, ai)
+	a := runAgent(t, ps.AgentAddr())
+	defer a.Stop()
+	waitForConnectedServerCount(t, 1, a)
 
 	// run test client
-	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())
+	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, ps.FrontAddr(), grpc.WithInsecure())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/tcp_server_test.go
+++ b/tests/tcp_server_test.go
@@ -62,17 +62,15 @@ func TestEchoServer(t *testing.T) {
 		}
 	}()
 
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
 	proxy, cleanup, err := runGRPCProxyServer()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cleanup()
 
-	clientset := runAgent(proxy.agent, stopCh)
-	waitForConnectedServerCount(t, 1, clientset)
+	ai := runAgent(t, proxy.agent)
+	defer ai.Stop()
+	waitForConnectedServerCount(t, 1, ai)
 
 	// run test client
 	tunnel, err := client.CreateSingleUseGrpcTunnel(ctx, proxy.front, grpc.WithInsecure())


### PR DESCRIPTION
This PR refactors the running of the test proxy-server & agent to prepare for running them as separate binaries, which will enable [version skew testing](https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/519).

This PR makes it so the server & agent are run with a `RunnerInterface` accessed through a global `Framework`. The runner interfaces returns a respective interface for accessing the testable surface of the server & agent.

The `TestConcurrentClientRequest` test needed to be rewritten, since it relied on internal implementation details. The new test is less deterministic, but should still reliably hit the same case being tested (and others).

First step towards https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/519

Next steps:
1. Implement `External{ProxyServer,Agent}Runner`, which takes an external binary to run for the server/agent, and accesses the measurements through prometheus metrics. Expose test flags to select a binary (or the in-tree version).
2. Implement a `version_skew_test` script that handles fetching target tagged versions, compiling, and running the tests.
3. Set up CI jobs for skew testing
4. Refactor client operations to enable external client testing via the `test-client` binary.
5. Implement `ExternalClient`, update version_skew_test to run tests with the external client

/assign @jkh52 

I recommend reviewing this 1 commit at a time.