### PR TITLE
Fix host:port joining

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -18,8 +18,10 @@ package options
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -81,7 +83,7 @@ type GrpcProxyAgentOptions struct {
 
 func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) *agent.ClientSetConfig {
 	return &agent.ClientSetConfig{
-		Address:                 fmt.Sprintf("%s:%d", o.ProxyServerHost, o.ProxyServerPort),
+		Address:                 net.JoinHostPort(o.ProxyServerHost, strconv.Itoa(o.ProxyServerPort)),
 		AgentID:                 o.AgentID,
 		AgentIdentifiers:        o.AgentIdentifiers,
 		SyncInterval:            o.SyncInterval,

--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -182,7 +182,9 @@ func (a *Agent) runAdminServer(o *options.GrpcProxyAgentOptions) error {
 		if err != nil {
 			host = r.Host
 		}
-		http.Redirect(w, r, fmt.Sprintf("%s:%d%s", host, o.HealthServerPort, r.URL.Path), http.StatusMovedPermanently)
+		dest := *r.URL
+		dest.Host = net.JoinHostPort(host, strconv.Itoa(o.HealthServerPort))
+		http.Redirect(w, r, dest.String(), http.StatusMovedPermanently)
 	}))
 	if o.EnableProfiling {
 		muxHandler.HandleFunc("/debug/pprof", util.RedirectTo("/debug/pprof/"))


### PR DESCRIPTION
The `Sprintf` version doesn't work properly for IPv6 addrs. E.g. 

```
	host := "::"
	port := 1234
	fmt.Println(fmt.Sprintf("%s:%d", host, port))
	fmt.Println(net.JoinHostPort(host, strconv.Itoa(port)))
```
outputs:
```
:::1234
[::]:1234
```

The first is not a valid address.