### PR TITLE
Allow admin port to be disabled

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -106,7 +106,7 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.StringSliceVar(&o.AlpnProtos, "alpn-proto", o.AlpnProtos, "Additional ALPN protocols to be presented when connecting to the server. Useful to distinguish between network proxy and apiserver connections that share the same destination address.")
 	flags.StringVar(&o.HealthServerHost, "health-server-host", o.HealthServerHost, "The host address to listen on, without port.")
 	flags.IntVar(&o.HealthServerPort, "health-server-port", o.HealthServerPort, "The port the health server is listening on.")
-	flags.IntVar(&o.AdminServerPort, "admin-server-port", o.AdminServerPort, "The port the admin server is listening on.")
+	flags.IntVar(&o.AdminServerPort, "admin-server-port", o.AdminServerPort, "The port the admin server is listening on. Setting to 0 disables the admin server.")
 	flags.StringVar(&o.AdminBindAddress, "admin-bind-address", o.AdminBindAddress, "Bind address for admin connections. If empty, we will bind to all interfaces.")
 	flags.BoolVar(&o.EnableProfiling, "enable-profiling", o.EnableProfiling, "enable pprof at host:admin-port/debug/pprof")
 	flags.BoolVar(&o.EnableContentionProfiling, "enable-contention-profiling", o.EnableContentionProfiling, "enable contention profiling at host:admin-port/debug/pprof/block. \"--enable-profiling\" must also be set.")
@@ -174,8 +174,8 @@ func (o *GrpcProxyAgentOptions) Validate() error {
 	if o.HealthServerPort <= 0 {
 		return fmt.Errorf("health server port %d must be greater than 0", o.HealthServerPort)
 	}
-	if o.AdminServerPort <= 0 {
-		return fmt.Errorf("admin server port %d must be greater than 0", o.AdminServerPort)
+	if o.AdminServerPort < 0 {
+		return fmt.Errorf("admin server port %d must not be negative", o.AdminServerPort)
 	}
 	if o.EnableContentionProfiling && !o.EnableProfiling {
 		return fmt.Errorf("if --enable-contention-profiling is set, --enable-profiling must also be set")

--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -18,10 +18,11 @@ package options
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 /*
@@ -116,11 +117,11 @@ func TestValidate(t *testing.T) {
 		},
 		"ZeroAdminServerPort": {
 			fieldMap: map[string]interface{}{"AdminServerPort": 0},
-			expected: fmt.Errorf("admin server port 0 must be greater than 0"),
+			expected: nil,
 		},
 		"NegativeAdminServerPort": {
 			fieldMap: map[string]interface{}{"AdminServerPort": -1},
-			expected: fmt.Errorf("admin server port -1 must be greater than 0"),
+			expected: fmt.Errorf("admin server port -1 must not be negative"),
 		},
 		"ReservedAdminServerPort": {
 			fieldMap: map[string]interface{}{"AdminServerPort": 1023},

--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -76,8 +76,10 @@ func (a *Agent) run(o *options.GrpcProxyAgentOptions) error {
 		return fmt.Errorf("failed to run health server with %v", err)
 	}
 
-	if err := a.runAdminServer(o); err != nil {
-		return fmt.Errorf("failed to run admin server with %v", err)
+	if o.AdminServerPort != 0 {
+		if err := a.runAdminServer(o); err != nil {
+			return fmt.Errorf("failed to run admin server with %v", err)
+		}
 	}
 
 	<-stopCh

--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -117,7 +117,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.BoolVar(&o.DeleteUDSFile, "delete-existing-uds-file", o.DeleteUDSFile, "If true and if file UdsName already exists, delete the file before listen on that UDS file. Default is true.")
 	flags.IntVar(&o.ServerPort, "server-port", o.ServerPort, "Port we listen for server connections on. Set to 0 for UDS.")
 	flags.StringVar(&o.ServerBindAddress, "server-bind-address", o.ServerBindAddress, "Bind address for server connections. If empty, we will bind to all interfaces.")
-	flags.IntVar(&o.AgentPort, "agent-port", o.AgentPort, "Port we listen for agent connections on.")
+	flags.IntVar(&o.AgentPort, "agent-port", o.AgentPort, "Port we listen for agent connections on. Setting to 0 disables the admin server.")
 	flags.StringVar(&o.AgentBindAddress, "agent-bind-address", o.AgentBindAddress, "Bind address for agent connections. If empty, we will bind to all interfaces.")
 	flags.IntVar(&o.AdminPort, "admin-port", o.AdminPort, "Port we listen for admin connections on.")
 	flags.StringVar(&o.AdminBindAddress, "admin-bind-address", o.AdminBindAddress, "Bind address for admin connections. If empty, we will bind to localhost.")
@@ -259,7 +259,7 @@ func (o *ProxyRunOptions) Validate() error {
 	if o.AgentPort < 1024 {
 		return fmt.Errorf("please do not try to use reserved port %d for the agent port", o.AgentPort)
 	}
-	if o.AdminPort < 1024 {
+	if o.AdminPort < 1024 && o.AdminPort != 0 {
 		return fmt.Errorf("please do not try to use reserved port %d for the admin port", o.AdminPort)
 	}
 	if o.HealthPort < 1024 {

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -138,10 +138,12 @@ func (p *Proxy) run(o *options.ProxyRunOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to run the agent server: %v", err)
 	}
-	klog.V(1).Infoln("Starting admin server for debug connections.")
-	err = p.runAdminServer(o, server)
-	if err != nil {
-		return fmt.Errorf("failed to run the admin server: %v", err)
+	if o.AdminPort != 0 {
+		klog.V(1).Infoln("Starting admin server for debug connections.")
+		err = p.runAdminServer(o, server)
+		if err != nil {
+			return fmt.Errorf("failed to run the admin server: %v", err)
+		}
 	}
 	klog.V(1).Infoln("Starting health server for healthchecks.")
 	err = p.runHealthServer(o, server)


### PR DESCRIPTION
Allow the agent & server "admin ports" to be disabled by setting them to 0. This is backwards compatible since the options validation previously forbid a value of 0.

My motivation is to have fewer ports to manage in integration tests, but this could also be useful for security reasons, especially since it's served over HTTP (no TLS)