### PR TITLE
Configure Dependabot for automatic Docker and Gomod updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: /artifacts/images
+  schedule:
+    interval: weekly
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  groups:
+    gomod-dependencies:
+      patterns:
+      - '*'
+- package-ecosystem: gomod
+  directory: /konnectivity-client
+  schedule:
+    interval: weekly
+  groups:
+    gomod-dependencies:
+      patterns:
+      - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,3 @@ updates:
     gomod-dependencies:
       patterns:
       - '*'
-- package-ecosystem: gomod
-  directory: /konnectivity-client
-  schedule:
-    interval: weekly
-  groups:
-    gomod-dependencies:
-      patterns:
-      - '*'


### PR DESCRIPTION
Enable Dependabot for Dockerfile and go.mod updates.
This will update images in Dockerfile `FROM` statements, and go modules.

The purpose is to drastically reduce number of vulnerabilities that affect this repo, 
by keeping dependencies up-to-date. 

This PR is created by a script. Please let me know if we should modify any values.