### PR TITLE
[release-0.1] Backport CVEs from release-0.28

### DIFF
--- a/artifacts/images/agent-build.Dockerfile
+++ b/artifacts/images/agent-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-agent binary
-FROM golang:1.19.13 as builder
+FROM golang:1.20.10 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/server-build.Dockerfile
+++ b/artifacts/images/server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the proxy-server binary
-FROM golang:1.19.13 as builder
+FROM golang:1.20.10 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/test-client-build.Dockerfile
+++ b/artifacts/images/test-client-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the client binary
-FROM golang:1.19.13 as builder
+FROM golang:1.20.10 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy

--- a/artifacts/images/test-server-build.Dockerfile
+++ b/artifacts/images/test-server-build.Dockerfile
@@ -1,5 +1,5 @@
 # Build the http test server binary
-FROM golang:1.19.13 as builder
+FROM golang:1.20.10 as builder
 
 # Copy in the go src
 WORKDIR /go/src/sigs.k8s.io/apiserver-network-proxy


### PR DESCRIPTION
Backport CVE fixes to release-0.1, since Kubernetes 1.26 and 1.27 are still in the supported range.

Clean cherry pick of https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/539.

CVE-2023-39318 (https://pkg.go.dev/vuln/GO-2023-2041)
CVE-2023-39319 (https://pkg.go.dev/vuln/GO-2023-2043)
CVE-2023-39323 (https://pkg.go.dev/vuln/GO-2023-2095)
CVE-2023-44487 (https://pkg.go.dev/vuln/GO-2023-2102)