### PR TITLE
Use nonroot distroless image for agent and server

### DIFF
--- a/artifacts/images/agent-build.Dockerfile
+++ b/artifacts/images/agent-build.Dockerfile
@@ -25,7 +25,7 @@ ARG ARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -mod=vendor -v -a -ldflags '-extldflags "-static"' -o proxy-agent sigs.k8s.io/apiserver-network-proxy/cmd/agent
 
 # Copy the loader into a thin image
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian11:nonroot
 WORKDIR /
 COPY --from=builder /go/src/sigs.k8s.io/apiserver-network-proxy/proxy-agent .
 ENTRYPOINT ["/proxy-agent"]

--- a/artifacts/images/server-build.Dockerfile
+++ b/artifacts/images/server-build.Dockerfile
@@ -24,7 +24,7 @@ ARG ARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -mod=vendor -v -a -ldflags '-extldflags "-static"' -o proxy-server sigs.k8s.io/apiserver-network-proxy/cmd/server
 
 # Copy the loader into a thin image
-FROM gcr.io/distroless/static-debian11
+FROM gcr.io/distroless/static-debian11:nonroot
 WORKDIR /
 COPY --from=builder /go/src/sigs.k8s.io/apiserver-network-proxy/proxy-server .
 ENTRYPOINT ["/proxy-server"]


### PR DESCRIPTION
This change helps to avoid reports like this:
```
[
  {
    "corrective_action": "Add a non-root user when building the container image",
    "description": "It is a good practice to run the container as a non-root user, if possible.",
    "scan_engines": {
      "scan_engines": [
        "prisma_cloud"
      ]
    },
    "type": "system_configuration:users.root-user"
  }
]
```
