### PR TITLE
Fix e2e test for rootless image.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -114,19 +114,19 @@ jobs:
               kind: ClusterConfiguration
               apiServer:
                 extraArgs:
-                  "egress-selector-config-file": "/etc/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
+                  "egress-selector-config-file": "/etc/srv/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
                 extraVolumes:
                 - name: egress-selector-config-file
-                  hostPath: "/etc/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
-                  mountPath: "/etc/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
+                  hostPath: "/etc/srv/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
+                  mountPath: "/etc/srv/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
                   readOnly: true
                 - name: konnectivity-server
-                  hostPath: "/etc/kubernetes/konnectivity-server"
-                  mountPath: "/etc/kubernetes/konnectivity-server"
+                  hostPath: "/etc/srv/kubernetes/konnectivity-server"
+                  mountPath: "/etc/srv/kubernetes/konnectivity-server"
                   readOnly: true
             extraMounts:
             - hostPath: ./examples/kind/egress_selector_configuration.yaml
-              containerPath: /etc/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml
+              containerPath: /etc/srv/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml
           - role: worker
           - role: worker
         EOF
@@ -149,6 +149,13 @@ jobs:
         docker load --input konnectivity-agent.tar
         /usr/local/bin/kind load docker-image gcr.io/k8s-staging-kas-network-proxy/proxy-server:master --name ${{ env.KIND_CLUSTER_NAME}}
         /usr/local/bin/kind load docker-image gcr.io/k8s-staging-kas-network-proxy/proxy-agent:master --name ${{ env.KIND_CLUSTER_NAME}}
+
+        docker exec kind-control-plane mkdir -p /etc/srv/kubernetes/{konnectivity-server,pki}
+        docker exec kind-control-plane cp -f /etc/kubernetes/pki/apiserver.crt /etc/srv/kubernetes/pki/apiserver.crt
+        docker exec kind-control-plane cp -f /etc/kubernetes/pki/apiserver.key /etc/srv/kubernetes/pki/apiserver.key
+        docker exec kind-control-plane cp -f /etc/kubernetes/admin.conf /etc/srv/kubernetes/admin.conf
+        docker exec kind-control-plane chown -R 1002:1000 /etc/srv/kubernetes
+
         kubectl apply -f examples/kind/konnectivity-server.yaml
         kubectl apply -f examples/kind/konnectivity-agent-ds.yaml
 

--- a/examples/kind/README.md
+++ b/examples/kind/README.md
@@ -27,6 +27,17 @@ Have a nice day! 👋
 Once the cluster is ready install the `apiserver-network-proxy` components:
 
 ```sh
+
+$ docker exec kind-control-plane mkdir -p /etc/srv/kubernetes/{konnectivity-server,pki}
+
+$ docker exec kind-control-plane cp -f /etc/kubernetes/pki/apiserver.crt /etc/srv/kubernetes/pki/apiserver.crt
+
+$ docker exec kind-control-plane cp -f /etc/kubernetes/pki/apiserver.key /etc/srv/kubernetes/pki/apiserver.key
+
+$ docker exec kind-control-plane cp -f /etc/kubernetes/admin.conf /etc/srv/kubernetes/admin.conf
+
+$ docker exec kind-control-plane chown -R 1002:1000 /etc/srv/kubernetes
+
 $ kubectl apply -f konnectivity-server.yaml
 clusterrolebinding.rbac.authorization.k8s.io/system:konnectivity-server created
 daemonset.apps/konnectivity-server created

--- a/examples/kind/egress_selector_configuration.yaml
+++ b/examples/kind/egress_selector_configuration.yaml
@@ -6,7 +6,7 @@ egressSelections:
     proxyProtocol: GRPC
     transport:
       uds:
-        udsName: /etc/kubernetes/konnectivity-server/konnectivity-server.socket
+        udsName: /etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket
 - name: master
   connection:
     proxyProtocol: Direct

--- a/examples/kind/kind.config
+++ b/examples/kind/kind.config
@@ -18,15 +18,15 @@ nodes:
         "egress-selector-config-file": "/etc/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
       extraVolumes:
       - name: egress-selector-config-file
-        hostPath: "/etc/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
-        mountPath: "/etc/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
+        hostPath: "/etc/srv/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
+        mountPath: "/etc/srv/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml"
         readOnly: true
       - name: konnectivity-server
-        hostPath: "/etc/kubernetes/konnectivity-server"
-        mountPath: "/etc/kubernetes/konnectivity-server"
+        hostPath: "/etc/srv/kubernetes/konnectivity-server"
+        mountPath: "/etc/srv/kubernetes/konnectivity-server"
         readOnly: true
   extraMounts:
   - hostPath: ./egress_selector_configuration.yaml
-    containerPath: /etc/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml
+    containerPath: /etc/srv/kubernetes/konnectivity-server-config/egress_selector_configuration.yaml
 - role: worker
 - role: worker

--- a/examples/kind/konnectivity-server.yaml
+++ b/examples/kind/konnectivity-server.yaml
@@ -53,6 +53,9 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       hostNetwork: true
+      securityContext:
+        runAsUser: 1002
+        runAsGroup: 1000
       containers:
       - name: konnectivity-server-container
         image: gcr.io/k8s-staging-kas-network-proxy/proxy-server:master
@@ -64,9 +67,9 @@ spec:
           "--log-file=/var/log/konnectivity-server.log",
           "--logtostderr=true",
           "--log-file-max-size=0",
-          "--uds-name=/etc/kubernetes/konnectivity-server/konnectivity-server.socket",
-          "--cluster-cert=/etc/kubernetes/pki/apiserver.crt",
-          "--cluster-key=/etc/kubernetes/pki/apiserver.key",
+          "--uds-name=/etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket",
+          "--cluster-cert=/etc/srv/kubernetes/pki/apiserver.crt",
+          "--cluster-key=/etc/srv/kubernetes/pki/apiserver.key",
           "--server-port=0",
           "--agent-port=8091",
           "--health-port=8092",
@@ -75,7 +78,7 @@ spec:
           "--mode=grpc",
           "--agent-namespace=kube-system",
           "--agent-service-account=konnectivity-agent",
-          "--kubeconfig=/etc/kubernetes/admin.conf",
+          "--kubeconfig=/etc/srv/kubernetes/admin.conf",
           "--authentication-audience=system:konnectivity-server",
           ]
         livenessProbe:
@@ -103,20 +106,28 @@ spec:
         - name: varlogkonnectivityserver
           mountPath: /var/log/konnectivity-server.log
           readOnly: false
-        - name: kubernetes
-          mountPath: /etc/kubernetes
-          readOnly: true
         - name: konnectivity-home
-          mountPath: /etc/kubernetes/konnectivity-server
+          mountPath: /etc/srv/kubernetes/konnectivity-server
+        - name: pki
+          mountPath: /etc/srv/kubernetes/pki
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/srv/kubernetes/admin.conf
+          readOnly: true
       volumes:
       - name: varlogkonnectivityserver
         hostPath:
           path: /var/log/konnectivity-server.log
           type: FileOrCreate
-      - name: kubernetes
+      - name: pki
         hostPath:
-          path: /etc/kubernetes
+          path: /etc/srv/kubernetes/pki
+          type: DirectoryOrCreate
+      - name: kubeconfig
+        hostPath:
+          path: /etc/srv/kubernetes/admin.conf
+          type: FileOrCreate
       - name: konnectivity-home
         hostPath:
-          path: /etc/kubernetes/konnectivity-server
+          path: /etc/srv/kubernetes/konnectivity-server
           type: DirectoryOrCreate


### PR DESCRIPTION
e2e CI is broken (https://github.com/kubernetes-sigs/apiserver-network-proxy/actions/runs/7935785136) after merge https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/564, the reason is permission denied when reading `/etc/kubernetes` with rootless image. This PR adds an initContainer to change the `/etc/kubernetes` directory permissions to fix this issue.

Another option is run root as user for ANP server pod,But this will not testing rootless container images.

```shell
...
      securityContext:
        runAsUser: 0
...
```

The error logs:
```shell
...
2024-02-16T20:20:47.774302668Z stderr F 
2024-02-16T20:20:47.774304462Z stderr F E0216 20:20:47.774123       1 main.go:48] error: failed to load kubernetes client config: error loading config file "/etc/kubernetes/admin.conf": open /etc/kubernetes/admin.conf: permission denied
```

/cc @jkh52 @cheftako @ipochi
