### PR TITLE
Add auto update for github-actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     gomod-dependencies:
       patterns:
       - '*'
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    # Check for updates to GitHub Actions every week
+    interval: "weekly"


### PR DESCRIPTION
Let dependabot work for auto update github-actions to get rid of deprecated github actions.