### PR TITLE
Fix 'kind' example manifests.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,9 +36,11 @@ jobs:
         mkdir _output
 
         make docker-build/proxy-agent-amd64 REGISTRY=gcr.io/k8s-staging-kas-network-proxy TAG=local BASEIMAGE=${{ env.BASEIMAGE }}
-        docker save gcr.io/k8s-staging-kas-network-proxy/proxy-agent-amd64:local > _output/konnectivity-agent.tar
+        docker tag gcr.io/k8s-staging-kas-network-proxy/proxy-agent-amd64:local gcr.io/k8s-staging-kas-network-proxy/proxy-agent:master
+        docker save gcr.io/k8s-staging-kas-network-proxy/proxy-agent:master > _output/konnectivity-agent.tar
         make docker-build/proxy-server-amd64 REGISTRY=gcr.io/k8s-staging-kas-network-proxy TAG=local BASEIMAGE=${{ env.BASEIMAGE }}
-        docker save gcr.io/k8s-staging-kas-network-proxy/proxy-server-amd64:local > _output/konnectivity-server.tar
+        docker tag gcr.io/k8s-staging-kas-network-proxy/proxy-server-amd64:local gcr.io/k8s-staging-kas-network-proxy/proxy-server:master
+        docker save gcr.io/k8s-staging-kas-network-proxy/proxy-server:master > _output/konnectivity-server.tar
 
     - uses: actions/upload-artifact@v4
       with:
@@ -153,8 +155,8 @@ jobs:
         # preload konnectivity images
         docker load --input konnectivity-server.tar
         docker load --input konnectivity-agent.tar
-        /usr/local/bin/kind load docker-image gcr.io/k8s-staging-kas-network-proxy/proxy-server-amd64:local --name ${{ env.KIND_CLUSTER_NAME}}
-        /usr/local/bin/kind load docker-image gcr.io/k8s-staging-kas-network-proxy/proxy-agent-amd64:local --name ${{ env.KIND_CLUSTER_NAME}}
+        /usr/local/bin/kind load docker-image gcr.io/k8s-staging-kas-network-proxy/proxy-server:master --name ${{ env.KIND_CLUSTER_NAME}}
+        /usr/local/bin/kind load docker-image gcr.io/k8s-staging-kas-network-proxy/proxy-agent:master --name ${{ env.KIND_CLUSTER_NAME}}
         kubectl apply -f examples/kind/konnectivity-server.yaml
         kubectl apply -f examples/kind/konnectivity-agent-ds.yaml
 

--- a/examples/kind/README.md
+++ b/examples/kind/README.md
@@ -35,7 +35,7 @@ $ kubectl apply -f konnectivity-agent-ds.yaml
 serviceaccount/konnectivity-agent created
 ```
 
-To validate that it works, run a custom image and try to exec into the pod (it goes through the konnectivity proxy):
+To validate that it works, run a custom image and get pod logs (it goes through the konnectivity proxy):
 ```sh
 $ kubectl run test --image httpd:2
 pod/test created
@@ -45,7 +45,7 @@ test   0/1     ContainerCreating   0          4s
 $ kubectl get pods
 NAME   READY   STATUS    RESTARTS   AGE
 test   1/1     Running   0          6s
-$ kubectl exec -it test bash
-kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
+$ kubectl logs test
+...
+[Tue Apr 09 20:58:36.756720 2024] [mpm_event:notice] [pid 1:tid 139788897408896] AH00489: Apache/2.4.59 (Unix) configured -- resuming normal operations
 ```
-

--- a/examples/kind/konnectivity-agent-ds.yaml
+++ b/examples/kind/konnectivity-agent-ds.yaml
@@ -36,8 +36,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: konnectivity-agent-container
-        image: gcr.io/k8s-staging-kas-network-proxy/proxy-agent-amd64:local
-        imagePullPolicy: Never
+        image: gcr.io/k8s-staging-kas-network-proxy/proxy-agent:master
         resources:
           requests:
             cpu: 50m

--- a/examples/kind/konnectivity-server.yaml
+++ b/examples/kind/konnectivity-server.yaml
@@ -55,17 +55,20 @@ spec:
       hostNetwork: true
       containers:
       - name: konnectivity-server-container
-        image: gcr.io/k8s-staging-kas-network-proxy/proxy-server-amd64:local
-        imagePullPolicy: Never
+        image: gcr.io/k8s-staging-kas-network-proxy/proxy-server:master
         resources:
           requests:
             cpu: 1m
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
         command: [ "/proxy-server"]
         args: [
           "--log-file=/var/log/konnectivity-server.log",
           "--logtostderr=true",
           "--log-file-max-size=0",
           "--uds-name=/etc/kubernetes/konnectivity-server/konnectivity-server.socket",
+          "--delete-existing-uds-file",
           "--cluster-cert=/etc/kubernetes/pki/apiserver.crt",
           "--cluster-key=/etc/kubernetes/pki/apiserver.key",
           "--server-port=0",


### PR DESCRIPTION
I tried the instructions at https://github.com/kubernetes-sigs/apiserver-network-proxy/tree/master/examples/kind, but they have regressed and needed fixing.

For the image name change, it's clear that https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/579 inadvertently broke the [examples/kind/README.md](https://github.com/kubernetes-sigs/apiserver-network-proxy/tree/master/examples/kind) workflow.

For the `runAsUser: 0` server change, it's a bit mysterious, but I get crashlooping without it. It is possible that https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/564 explains the regression, but I haven't verified carefully.