### PR TITLE
Replace Backend interface with a struct.

### DIFF
--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -119,7 +119,7 @@ func TestDefaultBackendManager_AddRemoveBackends(t *testing.T) {
 
 	p.AddBackend(backend1)
 	p.RemoveBackend(backend1)
-	expectedBackends := make(map[string][]Backend)
+	expectedBackends := make(map[string][]*Backend)
 	expectedAgentIDs := []string{}
 	expectedDefaultRouteAgentIDs := []string(nil)
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
@@ -143,7 +143,7 @@ func TestDefaultBackendManager_AddRemoveBackends(t *testing.T) {
 	p.RemoveBackend(backend22)
 	p.RemoveBackend(backend2)
 	p.RemoveBackend(backend1)
-	expectedBackends = map[string][]Backend{
+	expectedBackends = map[string][]*Backend{
 		"agent1": {backend12},
 		"agent3": {backend3},
 	}
@@ -174,7 +174,7 @@ func TestDefaultRouteBackendManager_AddRemoveBackends(t *testing.T) {
 
 	p.AddBackend(backend1)
 	p.RemoveBackend(backend1)
-	expectedBackends := make(map[string][]Backend)
+	expectedBackends := make(map[string][]*Backend)
 	expectedAgentIDs := []string{}
 	expectedDefaultRouteAgentIDs := []string{}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
@@ -199,7 +199,7 @@ func TestDefaultRouteBackendManager_AddRemoveBackends(t *testing.T) {
 	p.RemoveBackend(backend2)
 	p.RemoveBackend(backend1)
 
-	expectedBackends = map[string][]Backend{
+	expectedBackends = map[string][]*Backend{
 		"agent1": {backend12},
 		"agent3": {backend3},
 	}
@@ -231,7 +231,7 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 
 	p.AddBackend(backend1)
 	p.RemoveBackend(backend1)
-	expectedBackends := make(map[string][]Backend)
+	expectedBackends := make(map[string][]*Backend)
 	expectedAgentIDs := []string{}
 	expectedDefaultRouteAgentIDs := []string(nil)
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
@@ -247,7 +247,7 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 	p = NewDestHostBackendManager()
 	p.AddBackend(backend1)
 
-	expectedBackends = map[string][]Backend{
+	expectedBackends = map[string][]*Backend{
 		"localhost":                 {backend1},
 		"1.2.3.4":                   {backend1},
 		"9878::7675:1292:9183:7562": {backend1},
@@ -273,7 +273,7 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 	p.AddBackend(backend2)
 	p.AddBackend(backend3)
 
-	expectedBackends = map[string][]Backend{
+	expectedBackends = map[string][]*Backend{
 		"localhost":                 {backend1},
 		"node1.mydomain.com":        {backend1},
 		"node2.mydomain.com":        {backend3},
@@ -306,7 +306,7 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 	p.RemoveBackend(backend2)
 	p.RemoveBackend(backend1)
 
-	expectedBackends = map[string][]Backend{
+	expectedBackends = map[string][]*Backend{
 		"node2.mydomain.com": {backend3},
 		"5.6.7.8":            {backend3},
 		"::":                 {backend3},
@@ -328,7 +328,7 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 	}
 
 	p.RemoveBackend(backend3)
-	expectedBackends = map[string][]Backend{}
+	expectedBackends = map[string][]*Backend{}
 	expectedAgentIDs = []string{}
 
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
@@ -356,7 +356,7 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 	p.AddBackend(backend2)
 	p.AddBackend(backend3)
 
-	expectedBackends := map[string][]Backend{
+	expectedBackends := map[string][]*Backend{
 		"localhost":                 {backend1, backend2, backend3},
 		"1.2.3.4":                   {backend1, backend2},
 		"5.6.7.8":                   {backend3},
@@ -389,7 +389,7 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 	p.RemoveBackend(backend1)
 	p.RemoveBackend(backend3)
 
-	expectedBackends = map[string][]Backend{
+	expectedBackends = map[string][]*Backend{
 		"localhost":                 {backend2},
 		"1.2.3.4":                   {backend2},
 		"9878::7675:1292:9183:7562": {backend2},
@@ -413,7 +413,7 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 	}
 
 	p.RemoveBackend(backend2)
-	expectedBackends = map[string][]Backend{}
+	expectedBackends = map[string][]*Backend{}
 	expectedAgentIDs = []string{}
 
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {

--- a/pkg/server/default_route_backend_manager.go
+++ b/pkg/server/default_route_backend_manager.go
@@ -36,11 +36,11 @@ func NewDefaultRouteBackendManager() *DefaultRouteBackendManager {
 }
 
 // Backend tries to get a backend that advertises default route, with random selection.
-func (dibm *DefaultRouteBackendManager) Backend(_ context.Context) (Backend, error) {
+func (dibm *DefaultRouteBackendManager) Backend(_ context.Context) (*Backend, error) {
 	return dibm.GetRandomBackend()
 }
 
-func (dibm *DefaultRouteBackendManager) AddBackend(backend Backend) {
+func (dibm *DefaultRouteBackendManager) AddBackend(backend *Backend) {
 	agentID := backend.GetAgentID()
 	agentIdentifiers := backend.GetAgentIdentifiers()
 	if agentIdentifiers.DefaultRoute {
@@ -49,7 +49,7 @@ func (dibm *DefaultRouteBackendManager) AddBackend(backend Backend) {
 	}
 }
 
-func (dibm *DefaultRouteBackendManager) RemoveBackend(backend Backend) {
+func (dibm *DefaultRouteBackendManager) RemoveBackend(backend *Backend) {
 	agentID := backend.GetAgentID()
 	agentIdentifiers := backend.GetAgentIdentifiers()
 	if agentIdentifiers.DefaultRoute {

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -35,7 +35,7 @@ func NewDestHostBackendManager() *DestHostBackendManager {
 			[]header.IdentifierType{header.IPv4, header.IPv6, header.Host})}
 }
 
-func (dibm *DestHostBackendManager) AddBackend(backend Backend) {
+func (dibm *DestHostBackendManager) AddBackend(backend *Backend) {
 	agentIdentifiers := backend.GetAgentIdentifiers()
 	for _, ipv4 := range agentIdentifiers.IPv4 {
 		klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", ipv4)
@@ -51,7 +51,7 @@ func (dibm *DestHostBackendManager) AddBackend(backend Backend) {
 	}
 }
 
-func (dibm *DestHostBackendManager) RemoveBackend(backend Backend) {
+func (dibm *DestHostBackendManager) RemoveBackend(backend *Backend) {
 	agentIdentifiers := backend.GetAgentIdentifiers()
 	for _, ipv4 := range agentIdentifiers.IPv4 {
 		klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", ipv4)
@@ -68,7 +68,7 @@ func (dibm *DestHostBackendManager) RemoveBackend(backend Backend) {
 }
 
 // Backend tries to get a backend associating to the request destination host.
-func (dibm *DestHostBackendManager) Backend(ctx context.Context) (Backend, error) {
+func (dibm *DestHostBackendManager) Backend(ctx context.Context) (*Backend, error) {
 	dibm.mu.RLock()
 	defer dibm.mu.RUnlock()
 	if len(dibm.backends) == 0 {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -540,9 +540,9 @@ func TestEstablishedConnsMetric(t *testing.T) {
 }
 
 func TestRemoveEstablishedForBackendConn(t *testing.T) {
-	backend1 := &backend{}
-	backend2 := &backend{}
-	backend3 := &backend{}
+	backend1 := &Backend{}
+	backend2 := &Backend{}
+	backend3 := &Backend{}
 	agent1ConnID1 := &ProxyClientConnection{backend: backend1}
 	agent1ConnID2 := &ProxyClientConnection{backend: backend1}
 	agent2ConnID1 := &ProxyClientConnection{backend: backend2}
@@ -571,9 +571,9 @@ func TestRemoveEstablishedForBackendConn(t *testing.T) {
 
 func TestRemoveEstablishedForStream(t *testing.T) {
 	streamUID := "target-uuid"
-	backend1 := &backend{}
-	backend2 := &backend{}
-	backend3 := &backend{}
+	backend1 := &Backend{}
+	backend2 := &Backend{}
+	backend3 := &Backend{}
 	agent1ConnID1 := &ProxyClientConnection{backend: backend1, frontend: &GrpcFrontend{streamUID: streamUID}}
 	agent1ConnID2 := &ProxyClientConnection{backend: backend1}
 	agent2ConnID1 := &ProxyClientConnection{backend: backend2, frontend: &GrpcFrontend{streamUID: streamUID}}
@@ -613,7 +613,7 @@ func prepareFrontendConn(ctrl *gomock.Controller) *agentmock.MockAgentService_Co
 	return frontendConn
 }
 
-func prepareAgentConnMD(t testing.TB, ctrl *gomock.Controller, proxyServer *ProxyServer) (*agentmock.MockAgentService_ConnectServer, Backend) {
+func prepareAgentConnMD(t testing.TB, ctrl *gomock.Controller, proxyServer *ProxyServer) (*agentmock.MockAgentService_ConnectServer, *Backend) {
 	t.Helper()
 	// prepare the the connection to agent of proxy-server
 	agentConn := agentmock.NewMockAgentService_ConnectServer(ctrl)


### PR DESCRIPTION
Comparisons (like [those in DefaultBackendStorage](https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/0416f5e62fdbbf5acfd1656c1131705facfb02c9/pkg/server/backend_manager.go#L297)) should be by pointer value.

This also increases consistency (with pkg/server `ProxyClientConnection` and `GrpcFrontend` handling).