### PR TITLE
[release-0.30] Fix lint: upgrade to first version that supports go1.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 INSTALL_LOCATION:=$(shell go env GOPATH)/bin
-GOLANGCI_LINT_VERSION ?= 1.51.2
+GOLANGCI_LINT_VERSION ?= 1.54.0
 GOSEC_VERSION ?= 2.13.1
 
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -393,7 +393,7 @@ func (p *Proxy) runAgentServer(o *options.ProxyRunOptions, server *server.ProxyS
 	return nil
 }
 
-func (p *Proxy) runAdminServer(o *options.ProxyRunOptions, server *server.ProxyServer) error {
+func (p *Proxy) runAdminServer(o *options.ProxyRunOptions, _ *server.ProxyServer) error {
 	muxHandler := http.NewServeMux()
 	muxHandler.Handle("/metrics", promhttp.Handler())
 	if o.EnableProfiling {

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -143,15 +143,15 @@ func SetupSignalHandler() (stopCh <-chan struct{}) {
 	return stop
 }
 
-func returnSuccess(w http.ResponseWriter, req *http.Request) {
+func returnSuccess(w http.ResponseWriter, _ *http.Request) {
 	fmt.Fprintf(w, "<!DOCTYPE html>\n<html>\n    <head>\n        <title>Success</title>\n    </head>\n    <body>\n        <p>The success test page!</p>\n    </body>\n</html>")
 }
 
-func returnError(w http.ResponseWriter, req *http.Request) {
+func returnError(w http.ResponseWriter, _ *http.Request) {
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 }
 
-func closeNoResponse(w http.ResponseWriter, req *http.Request) {
+func closeNoResponse(w http.ResponseWriter, _ *http.Request) {
 	hj, ok := w.(http.Hijacker)
 	if !ok {
 		http.Error(w, "webserver doesn't support hijacking", http.StatusInternalServerError)

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -259,12 +260,7 @@ func NewDefaultBackendStorage(idTypes []header.IdentifierType) *DefaultBackendSt
 }
 
 func containIDType(idTypes []header.IdentifierType, idType header.IdentifierType) bool {
-	for _, it := range idTypes {
-		if it == idType {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(idTypes, idType)
 }
 
 // AddBackend adds a backend.

--- a/pkg/server/default_route_backend_manager.go
+++ b/pkg/server/default_route_backend_manager.go
@@ -36,7 +36,7 @@ func NewDefaultRouteBackendManager() *DefaultRouteBackendManager {
 }
 
 // Backend tries to get a backend associating to the request destination host.
-func (dibm *DefaultRouteBackendManager) Backend(ctx context.Context) (Backend, error) {
+func (dibm *DefaultRouteBackendManager) Backend(_ context.Context) (Backend, error) {
 	dibm.mu.RLock()
 	defer dibm.mu.RUnlock()
 	if len(dibm.backends) == 0 {

--- a/tests/agent_disconnect_test.go
+++ b/tests/agent_disconnect_test.go
@@ -173,7 +173,7 @@ func clientRequest(c *http.Client, addr string) ([]byte, error) {
 	return data, nil
 }
 
-func createGrpcTunnelClient(ctx context.Context, proxyAddr, addr string) (*http.Client, error) {
+func createGrpcTunnelClient(ctx context.Context, proxyAddr, _ string) (*http.Client, error) {
 	tunnel, err := createSingleUseGrpcTunnel(ctx, proxyAddr)
 	if err != nil {
 		return nil, err
@@ -189,7 +189,7 @@ func createGrpcTunnelClient(ctx context.Context, proxyAddr, addr string) (*http.
 	return c, nil
 }
 
-func createHTTPConnectClient(ctx context.Context, proxyAddr, addr string) (*http.Client, error) {
+func createHTTPConnectClient(_ context.Context, proxyAddr, addr string) (*http.Client, error) {
 	conn, err := net.Dial("unix", proxyAddr)
 	if err != nil {
 		return nil, err

--- a/tests/framework/agent.go
+++ b/tests/framework/agent.go
@@ -208,6 +208,7 @@ func (a *externalAgent) waitForLiveness() error {
 }
 
 func agentOptions(t testing.TB, opts AgentOpts) (*agentopts.GrpcProxyAgentOptions, error) {
+	t.Helper()
 	o := agentopts.NewGrpcProxyAgentOptions()
 
 	host, port, err := net.SplitHostPort(opts.ServerAddr)

--- a/tests/framework/proxy_server.go
+++ b/tests/framework/proxy_server.go
@@ -136,6 +136,7 @@ func (ps *inProcessProxyServer) Metrics() metricstest.ServerTester {
 }
 
 func serverOptions(t testing.TB, opts ProxyServerOpts) (*serveropts.ProxyRunOptions, error) {
+	t.Helper()
 	o := serveropts.NewProxyRunOptions()
 
 	o.ServerCount = uint(opts.ServerCount)

--- a/tests/ha_proxy_server_test.go
+++ b/tests/ha_proxy_server_test.go
@@ -37,7 +37,7 @@ type tcpLB struct {
 	backends []string
 }
 
-func copy(wc io.WriteCloser, r io.Reader) {
+func ioCopy(wc io.WriteCloser, r io.Reader) {
 	defer wc.Close()
 	io.Copy(wc, r)
 }
@@ -48,8 +48,8 @@ func (lb *tcpLB) handleConnection(in net.Conn, backend string) {
 		lb.t.Log(err)
 		return
 	}
-	go copy(out, in)
-	go copy(in, out)
+	go ioCopy(out, in)
+	go ioCopy(in, out)
 }
 
 func (lb *tcpLB) serve(stopCh chan struct{}) string {

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -76,7 +76,7 @@ func newSizedServer(length, chunks int) *testServer {
 	}
 }
 
-func (s *testServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (s *testServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	for i := 0; i < s.chunks; i++ {
 		w.Write(s.echo)
 	}
@@ -94,7 +94,7 @@ func newWaitingServer() *waitingServer {
 	}
 }
 
-func (s *waitingServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s *waitingServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	close(s.requestReceivedCh)
 	<-s.respondCh // Wait for permission to respond.
 	w.Write([]byte("hello"))
@@ -114,7 +114,7 @@ func newDelayedServer() *delayedServer {
 
 var _ = newDelayedServer() // Suppress unused lint error.
 
-func (s *delayedServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (s *delayedServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	delay := time.Duration(rand.Int63n(int64(s.maxWait-s.minWait))) + s.minWait /* #nosec G404 */
 	time.Sleep(delay)
 	w.Write([]byte("hello"))


### PR DESCRIPTION
Cherry-pick https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/605 to `release-0.30` which also uses go 1.21.

Hoping to fix https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/614 broken lint check.