### PR TITLE
Allow configuration of transport channel size in agent and server

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -79,7 +79,7 @@ type GrpcProxyAgentOptions struct {
 	WarnOnChannelLimit bool
 
 	SyncForever    bool
-	XfrChannelSize uint
+	XfrChannelSize int
 }
 
 func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) *agent.ClientSetConfig {
@@ -121,7 +121,7 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.AgentIdentifiers, "agent-identifiers", o.AgentIdentifiers, "Identifiers of the agent that will be used by the server when choosing agent. N.B. the list of identifiers must be in URL encoded format. e.g.,host=localhost&host=node1.mydomain.com&cidr=127.0.0.1/16&ipv4=1.2.3.4&ipv4=5.6.7.8&ipv6=:::::&default-route=true")
 	flags.BoolVar(&o.WarnOnChannelLimit, "warn-on-channel-limit", o.WarnOnChannelLimit, "Turns on a warning if the system is going to push to a full channel. The check involves an unsafe read.")
 	flags.BoolVar(&o.SyncForever, "sync-forever", o.SyncForever, "If true, the agent continues syncing, in order to support server count changes.")
-	flags.UintVar(&o.XfrChannelSize, "xfr-channel-size", 150, "Set the size of the channel")
+	flags.IntVar(&o.XfrChannelSize, "xfr-channel-size", 150, "Set the size of the channel for transferring data between the agent and the proxy server.")
 	return flags
 }
 

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -78,7 +78,8 @@ type GrpcProxyAgentOptions struct {
 	// The check is an "unlocked" read but is still use at your own peril.
 	WarnOnChannelLimit bool
 
-	SyncForever bool
+	SyncForever    bool
+	XrfChannelSize int
 }
 
 func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) *agent.ClientSetConfig {
@@ -93,6 +94,7 @@ func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) 
 		ServiceAccountTokenPath: o.ServiceAccountTokenPath,
 		WarnOnChannelLimit:      o.WarnOnChannelLimit,
 		SyncForever:             o.SyncForever,
+		XrfChannelSize:          o.XrfChannelSize,
 	}
 }
 
@@ -119,6 +121,7 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.AgentIdentifiers, "agent-identifiers", o.AgentIdentifiers, "Identifiers of the agent that will be used by the server when choosing agent. N.B. the list of identifiers must be in URL encoded format. e.g.,host=localhost&host=node1.mydomain.com&cidr=127.0.0.1/16&ipv4=1.2.3.4&ipv4=5.6.7.8&ipv6=:::::&default-route=true")
 	flags.BoolVar(&o.WarnOnChannelLimit, "warn-on-channel-limit", o.WarnOnChannelLimit, "Turns on a warning if the system is going to push to a full channel. The check involves an unsafe read.")
 	flags.BoolVar(&o.SyncForever, "sync-forever", o.SyncForever, "If true, the agent continues syncing, in order to support server count changes.")
+	flags.IntVar(&o.XrfChannelSize, "channel-size", 150, "Set the size of the channel")
 	return flags
 }
 
@@ -144,6 +147,7 @@ func (o *GrpcProxyAgentOptions) Print() {
 	klog.V(1).Infof("AgentIdentifiers set to %s.\n", util.PrettyPrintURL(o.AgentIdentifiers))
 	klog.V(1).Infof("WarnOnChannelLimit set to %t.\n", o.WarnOnChannelLimit)
 	klog.V(1).Infof("SyncForever set to %v.\n", o.SyncForever)
+	klog.V(1).Infof("ChannelSize set to %d.\n", o.XrfChannelSize)
 }
 
 func (o *GrpcProxyAgentOptions) Validate() error {
@@ -176,6 +180,9 @@ func (o *GrpcProxyAgentOptions) Validate() error {
 	}
 	if o.AdminServerPort <= 0 {
 		return fmt.Errorf("admin server port %d must be greater than 0", o.AdminServerPort)
+	}
+	if o.XrfChannelSize <= 0 {
+		return fmt.Errorf("channel size %d must be greater than 0", o.XrfChannelSize)
 	}
 	if o.EnableContentionProfiling && !o.EnableProfiling {
 		return fmt.Errorf("if --enable-contention-profiling is set, --enable-profiling must also be set")
@@ -235,6 +242,7 @@ func NewGrpcProxyAgentOptions() *GrpcProxyAgentOptions {
 		ServiceAccountTokenPath:   "",
 		WarnOnChannelLimit:        false,
 		SyncForever:               false,
+		XrfChannelSize:            150,
 	}
 	return &o
 }

--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -79,7 +79,7 @@ type GrpcProxyAgentOptions struct {
 	WarnOnChannelLimit bool
 
 	SyncForever    bool
-	XrfChannelSize int
+	XfrChannelSize uint
 }
 
 func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) *agent.ClientSetConfig {
@@ -94,7 +94,7 @@ func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) 
 		ServiceAccountTokenPath: o.ServiceAccountTokenPath,
 		WarnOnChannelLimit:      o.WarnOnChannelLimit,
 		SyncForever:             o.SyncForever,
-		XrfChannelSize:          o.XrfChannelSize,
+		XfrChannelSize:          o.XfrChannelSize,
 	}
 }
 
@@ -121,7 +121,7 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.AgentIdentifiers, "agent-identifiers", o.AgentIdentifiers, "Identifiers of the agent that will be used by the server when choosing agent. N.B. the list of identifiers must be in URL encoded format. e.g.,host=localhost&host=node1.mydomain.com&cidr=127.0.0.1/16&ipv4=1.2.3.4&ipv4=5.6.7.8&ipv6=:::::&default-route=true")
 	flags.BoolVar(&o.WarnOnChannelLimit, "warn-on-channel-limit", o.WarnOnChannelLimit, "Turns on a warning if the system is going to push to a full channel. The check involves an unsafe read.")
 	flags.BoolVar(&o.SyncForever, "sync-forever", o.SyncForever, "If true, the agent continues syncing, in order to support server count changes.")
-	flags.IntVar(&o.XrfChannelSize, "channel-size", 150, "Set the size of the channel")
+	flags.UintVar(&o.XfrChannelSize, "xfr-channel-size", 150, "Set the size of the channel")
 	return flags
 }
 
@@ -147,7 +147,7 @@ func (o *GrpcProxyAgentOptions) Print() {
 	klog.V(1).Infof("AgentIdentifiers set to %s.\n", util.PrettyPrintURL(o.AgentIdentifiers))
 	klog.V(1).Infof("WarnOnChannelLimit set to %t.\n", o.WarnOnChannelLimit)
 	klog.V(1).Infof("SyncForever set to %v.\n", o.SyncForever)
-	klog.V(1).Infof("ChannelSize set to %d.\n", o.XrfChannelSize)
+	klog.V(1).Infof("ChannelSize set to %d.\n", o.XfrChannelSize)
 }
 
 func (o *GrpcProxyAgentOptions) Validate() error {
@@ -181,8 +181,8 @@ func (o *GrpcProxyAgentOptions) Validate() error {
 	if o.AdminServerPort <= 0 {
 		return fmt.Errorf("admin server port %d must be greater than 0", o.AdminServerPort)
 	}
-	if o.XrfChannelSize <= 0 {
-		return fmt.Errorf("channel size %d must be greater than 0", o.XrfChannelSize)
+	if o.XfrChannelSize <= 0 {
+		return fmt.Errorf("channel size %d must be greater than 0", o.XfrChannelSize)
 	}
 	if o.EnableContentionProfiling && !o.EnableProfiling {
 		return fmt.Errorf("if --enable-contention-profiling is set, --enable-profiling must also be set")
@@ -242,7 +242,7 @@ func NewGrpcProxyAgentOptions() *GrpcProxyAgentOptions {
 		ServiceAccountTokenPath:   "",
 		WarnOnChannelLimit:        false,
 		SyncForever:               false,
-		XrfChannelSize:            150,
+		XfrChannelSize:            150,
 	}
 	return &o
 }

--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -50,7 +50,7 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "ServiceAccountTokenPath", defaultAgentOptions.ServiceAccountTokenPath, "")
 	assertDefaultValue(t, "WarnOnChannelLimit", defaultAgentOptions.WarnOnChannelLimit, false)
 	assertDefaultValue(t, "SyncForever", defaultAgentOptions.SyncForever, false)
-	assertDefaultValue(t, "XfrChannelSize", defaultAgentOptions.XfrChannelSize, uint(150))
+	assertDefaultValue(t, "XfrChannelSize", defaultAgentOptions.XfrChannelSize, 150)
 }
 
 func assertDefaultValue(t *testing.T, fieldName string, actual, expected interface{}) {
@@ -148,8 +148,12 @@ func TestValidate(t *testing.T) {
 			expected: fmt.Errorf("if --enable-contention-profiling is set, --enable-profiling must also be set"),
 		},
 		"ZeroXfrChannelSize": {
-			fieldMap: map[string]interface{}{"XfrChannelSize": uint(0)},
+			fieldMap: map[string]interface{}{"XfrChannelSize": 0},
 			expected: fmt.Errorf("channel size 0 must be greater than 0"),
+		},
+		"NegativeXfrChannelSize": {
+			fieldMap: map[string]interface{}{"XfrChannelSize": -10},
+			expected: fmt.Errorf("channel size -10 must be greater than 0"),
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
@@ -168,9 +172,6 @@ func TestValidate(t *testing.T) {
 				case reflect.Bool:
 					bvalue := value.(bool)
 					fv.SetBool(bvalue)
-				case reflect.Uint:
-					uvalue := value.(uint)
-					fv.SetUint(uint64(uvalue))
 				}
 			}
 			actual := testAgentOptions.Validate()

--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -18,10 +18,11 @@ package options
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 /*
@@ -49,6 +50,7 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "ServiceAccountTokenPath", defaultAgentOptions.ServiceAccountTokenPath, "")
 	assertDefaultValue(t, "WarnOnChannelLimit", defaultAgentOptions.WarnOnChannelLimit, false)
 	assertDefaultValue(t, "SyncForever", defaultAgentOptions.SyncForever, false)
+	assertDefaultValue(t, "XfrChannelSize", defaultAgentOptions.XfrChannelSize, uint(150))
 }
 
 func assertDefaultValue(t *testing.T, fieldName string, actual, expected interface{}) {
@@ -145,6 +147,10 @@ func TestValidate(t *testing.T) {
 			},
 			expected: fmt.Errorf("if --enable-contention-profiling is set, --enable-profiling must also be set"),
 		},
+		"ZeroXfrChannelSize": {
+			fieldMap: map[string]interface{}{"XfrChannelSize": uint(0)},
+			expected: fmt.Errorf("channel size 0 must be greater than 0"),
+		},
 	} {
 		t.Run(desc, func(t *testing.T) {
 			testAgentOptions := NewGrpcProxyAgentOptions()
@@ -162,6 +168,9 @@ func TestValidate(t *testing.T) {
 				case reflect.Bool:
 					bvalue := value.(bool)
 					fv.SetBool(bvalue)
+				case reflect.Uint:
+					uvalue := value.(uint)
+					fv.SetUint(uint64(uvalue))
 				}
 			}
 			actual := testAgentOptions.Validate()

--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -137,7 +137,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.AuthenticationAudience, "authentication-audience", o.AuthenticationAudience, "Expected agent's token authentication audience (used with agent-namespace, agent-service-account, kubeconfig).")
 	flags.StringVar(&o.ProxyStrategies, "proxy-strategies", o.ProxyStrategies, "The list of proxy strategies used by the server to pick an agent/tunnel, available strategies are: default, destHost, defaultRoute.")
 	flags.StringSliceVar(&o.CipherSuites, "cipher-suites", o.CipherSuites, "The comma separated list of allowed cipher suites. Has no effect on TLS1.3. Empty means allow default list.")
-	flags.IntVar(&o.XfrChannelSize, "xfr-channel-size", o.XfrChannelSize, "The size of the channel for transferring data between the proxy server and the agent.")
+	flags.IntVar(&o.XfrChannelSize, "xfr-channel-size", o.XfrChannelSize, "The size of the two KNP server channels used in server for transferring data. One channel is for data coming from the Kubernetes API Server, and the other one is for data coming from the KNP agent.")
 
 	flags.Bool("warn-on-channel-limit", true, "This behavior is now thread safe and always on. This flag will be removed in a future release.")
 	flags.MarkDeprecated("warn-on-channel-limit", "This behavior is now thread safe and always on. This flag will be removed in a future release.")

--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -101,7 +101,7 @@ type ProxyRunOptions struct {
 	// NOTE that cipher suites are not configurable for TLS1.3,
 	// see: https://pkg.go.dev/crypto/tls#Config, so in that case, this option won't have any effect.
 	CipherSuites   []string
-	XrfChannelSize int
+	XfrChannelSize uint
 }
 
 func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
@@ -137,7 +137,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.AuthenticationAudience, "authentication-audience", o.AuthenticationAudience, "Expected agent's token authentication audience (used with agent-namespace, agent-service-account, kubeconfig).")
 	flags.StringVar(&o.ProxyStrategies, "proxy-strategies", o.ProxyStrategies, "The list of proxy strategies used by the server to pick an agent/tunnel, available strategies are: default, destHost, defaultRoute.")
 	flags.StringSliceVar(&o.CipherSuites, "cipher-suites", o.CipherSuites, "The comma separated list of allowed cipher suites. Has no effect on TLS1.3. Empty means allow default list.")
-	flags.IntVar(&o.XrfChannelSize, "xfr-channel-size", o.XrfChannelSize, "The size of the channel for transferring data between the proxy server and the agent.")
+	flags.UintVar(&o.XfrChannelSize, "xfr-channel-size", o.XfrChannelSize, "The size of the channel for transferring data between the proxy server and the agent.")
 
 	flags.Bool("warn-on-channel-limit", true, "This behavior is now thread safe and always on. This flag will be removed in a future release.")
 	flags.MarkDeprecated("warn-on-channel-limit", "This behavior is now thread safe and always on. This flag will be removed in a future release.")
@@ -177,7 +177,7 @@ func (o *ProxyRunOptions) Print() {
 	klog.V(1).Infof("KubeconfigBurst set to %d.\n", o.KubeconfigBurst)
 	klog.V(1).Infof("ProxyStrategies set to %q.\n", o.ProxyStrategies)
 	klog.V(1).Infof("CipherSuites set to %q.\n", o.CipherSuites)
-	klog.V(1).Infof("XrfChannelSize set to %d.\n", o.XrfChannelSize)
+	klog.V(1).Infof("XfrChannelSize set to %d.\n", o.XfrChannelSize)
 }
 
 func (o *ProxyRunOptions) Validate() error {
@@ -300,8 +300,8 @@ func (o *ProxyRunOptions) Validate() error {
 	if _, err := server.ParseProxyStrategies(o.ProxyStrategies); err != nil {
 		return fmt.Errorf("invalid proxy strategies: %v", err)
 	}
-	if o.XrfChannelSize <= 0 {
-		return fmt.Errorf("channel size %d must be greater than 0", o.XrfChannelSize)
+	if o.XfrChannelSize <= 0 {
+		return fmt.Errorf("channel size %d must be greater than 0", o.XfrChannelSize)
 	}
 	// validate the cipher suites
 	if len(o.CipherSuites) != 0 {
@@ -350,7 +350,7 @@ func NewProxyRunOptions() *ProxyRunOptions {
 		AuthenticationAudience:    "",
 		ProxyStrategies:           "default",
 		CipherSuites:              make([]string, 0),
-		XrfChannelSize:            10,
+		XfrChannelSize:            10,
 	}
 	return &o
 }

--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -101,7 +101,7 @@ type ProxyRunOptions struct {
 	// NOTE that cipher suites are not configurable for TLS1.3,
 	// see: https://pkg.go.dev/crypto/tls#Config, so in that case, this option won't have any effect.
 	CipherSuites   []string
-	XfrChannelSize uint
+	XfrChannelSize int
 }
 
 func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
@@ -137,7 +137,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.AuthenticationAudience, "authentication-audience", o.AuthenticationAudience, "Expected agent's token authentication audience (used with agent-namespace, agent-service-account, kubeconfig).")
 	flags.StringVar(&o.ProxyStrategies, "proxy-strategies", o.ProxyStrategies, "The list of proxy strategies used by the server to pick an agent/tunnel, available strategies are: default, destHost, defaultRoute.")
 	flags.StringSliceVar(&o.CipherSuites, "cipher-suites", o.CipherSuites, "The comma separated list of allowed cipher suites. Has no effect on TLS1.3. Empty means allow default list.")
-	flags.UintVar(&o.XfrChannelSize, "xfr-channel-size", o.XfrChannelSize, "The size of the channel for transferring data between the proxy server and the agent.")
+	flags.IntVar(&o.XfrChannelSize, "xfr-channel-size", o.XfrChannelSize, "The size of the channel for transferring data between the proxy server and the agent.")
 
 	flags.Bool("warn-on-channel-limit", true, "This behavior is now thread safe and always on. This flag will be removed in a future release.")
 	flags.MarkDeprecated("warn-on-channel-limit", "This behavior is now thread safe and always on. This flag will be removed in a future release.")

--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -100,7 +100,8 @@ type ProxyRunOptions struct {
 	// also checks if given comma separated list contains cipher from tls.InsecureCipherSuites().
 	// NOTE that cipher suites are not configurable for TLS1.3,
 	// see: https://pkg.go.dev/crypto/tls#Config, so in that case, this option won't have any effect.
-	CipherSuites []string
+	CipherSuites   []string
+	XrfChannelSize int
 }
 
 func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
@@ -136,6 +137,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.AuthenticationAudience, "authentication-audience", o.AuthenticationAudience, "Expected agent's token authentication audience (used with agent-namespace, agent-service-account, kubeconfig).")
 	flags.StringVar(&o.ProxyStrategies, "proxy-strategies", o.ProxyStrategies, "The list of proxy strategies used by the server to pick an agent/tunnel, available strategies are: default, destHost, defaultRoute.")
 	flags.StringSliceVar(&o.CipherSuites, "cipher-suites", o.CipherSuites, "The comma separated list of allowed cipher suites. Has no effect on TLS1.3. Empty means allow default list.")
+	flags.IntVar(&o.XrfChannelSize, "xfr-channel-size", o.XrfChannelSize, "The size of the channel for transferring data between the proxy server and the agent.")
 
 	flags.Bool("warn-on-channel-limit", true, "This behavior is now thread safe and always on. This flag will be removed in a future release.")
 	flags.MarkDeprecated("warn-on-channel-limit", "This behavior is now thread safe and always on. This flag will be removed in a future release.")
@@ -175,6 +177,7 @@ func (o *ProxyRunOptions) Print() {
 	klog.V(1).Infof("KubeconfigBurst set to %d.\n", o.KubeconfigBurst)
 	klog.V(1).Infof("ProxyStrategies set to %q.\n", o.ProxyStrategies)
 	klog.V(1).Infof("CipherSuites set to %q.\n", o.CipherSuites)
+	klog.V(1).Infof("XrfChannelSize set to %d.\n", o.XrfChannelSize)
 }
 
 func (o *ProxyRunOptions) Validate() error {
@@ -297,7 +300,9 @@ func (o *ProxyRunOptions) Validate() error {
 	if _, err := server.ParseProxyStrategies(o.ProxyStrategies); err != nil {
 		return fmt.Errorf("invalid proxy strategies: %v", err)
 	}
-
+	if o.XrfChannelSize <= 0 {
+		return fmt.Errorf("channel size %d must be greater than 0", o.XrfChannelSize)
+	}
 	// validate the cipher suites
 	if len(o.CipherSuites) != 0 {
 		acceptedCiphers := util.GetAcceptedCiphers()
@@ -345,6 +350,7 @@ func NewProxyRunOptions() *ProxyRunOptions {
 		AuthenticationAudience:    "",
 		ProxyStrategies:           "default",
 		CipherSuites:              make([]string, 0),
+		XrfChannelSize:            10,
 	}
 	return &o
 }

--- a/cmd/server/app/options/options_test.go
+++ b/cmd/server/app/options/options_test.go
@@ -61,7 +61,7 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "AuthenticationAudience", defaultServerOptions.AuthenticationAudience, "")
 	assertDefaultValue(t, "ProxyStrategies", defaultServerOptions.ProxyStrategies, "default")
 	assertDefaultValue(t, "CipherSuites", defaultServerOptions.CipherSuites, make([]string, 0))
-	assertDefaultValue(t, "XfrChannelSize", defaultServerOptions.XfrChannelSize, uint(10))
+	assertDefaultValue(t, "XfrChannelSize", defaultServerOptions.XfrChannelSize, 10)
 
 }
 
@@ -159,8 +159,13 @@ func TestValidate(t *testing.T) {
 		},
 		"ZeroXfrChannelSize": {
 			field:    "XfrChannelSize",
-			value:    uint(0),
+			value:    0,
 			expected: fmt.Errorf("channel size 0 must be greater than 0"),
+		},
+		"NegativeXfrChannelSize": {
+			field:    "XfrChannelSize",
+			value:    -10,
+			expected: fmt.Errorf("channel size -10 must be greater than 0"),
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
@@ -178,9 +183,6 @@ func TestValidate(t *testing.T) {
 				case reflect.Int:
 					ivalue := tc.value.(int)
 					fv.SetInt(int64(ivalue))
-				case reflect.Uint:
-					uvalue := tc.value.(uint)
-					fv.SetUint(uint64(uvalue))
 				}
 			}
 			actual := testServerOptions.Validate()

--- a/cmd/server/app/options/options_test.go
+++ b/cmd/server/app/options/options_test.go
@@ -61,6 +61,8 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "AuthenticationAudience", defaultServerOptions.AuthenticationAudience, "")
 	assertDefaultValue(t, "ProxyStrategies", defaultServerOptions.ProxyStrategies, "default")
 	assertDefaultValue(t, "CipherSuites", defaultServerOptions.CipherSuites, make([]string, 0))
+	assertDefaultValue(t, "XfrChannelSize", defaultServerOptions.XfrChannelSize, uint(10))
+
 }
 
 func assertDefaultValue(t *testing.T, fieldName string, actual, expected interface{}) {
@@ -155,6 +157,11 @@ func TestValidate(t *testing.T) {
 			value:    "invalid",
 			expected: fmt.Errorf("invalid proxy strategies: unknown proxy strategy: invalid"),
 		},
+		"ZeroXfrChannelSize": {
+			field:    "XfrChannelSize",
+			value:    uint(0),
+			expected: fmt.Errorf("channel size 0 must be greater than 0"),
+		},
 	} {
 		t.Run(desc, func(t *testing.T) {
 			testServerOptions := NewProxyRunOptions()
@@ -171,6 +178,9 @@ func TestValidate(t *testing.T) {
 				case reflect.Int:
 					ivalue := tc.value.(int)
 					fv.SetInt(int64(ivalue))
+				case reflect.Uint:
+					uvalue := tc.value.(uint)
+					fv.SetUint(uint64(uvalue))
 				}
 			}
 			actual := testServerOptions.Validate()

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -132,7 +132,7 @@ func (p *Proxy) Run(o *options.ProxyRunOptions, stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	p.server = server.NewProxyServer(o.ServerID, ps, int(o.ServerCount), authOpt, o.XrfChannelSize)
+	p.server = server.NewProxyServer(o.ServerID, ps, int(o.ServerCount), authOpt, o.XfrChannelSize)
 
 	frontendStop, err := p.runFrontendServer(ctx, o, p.server)
 	if err != nil {

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -132,7 +132,7 @@ func (p *Proxy) Run(o *options.ProxyRunOptions, stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	p.server = server.NewProxyServer(o.ServerID, ps, int(o.ServerCount), authOpt)
+	p.server = server.NewProxyServer(o.ServerID, ps, int(o.ServerCount), authOpt, o.XrfChannelSize)
 
 	frontendStop, err := p.runFrontendServer(ctx, o, p.server)
 	if err != nil {

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -43,7 +43,8 @@ import (
 )
 
 const dialTimeout = 5 * time.Second
-const xfrChannelSize = 150
+
+//const xfrChannelSize = 150
 
 // endpointConn tracks a connection from agent to node network.
 type endpointConn struct {
@@ -68,7 +69,7 @@ func (e *endpointConn) send(msg []byte) {
 			klog.InfoS("Recovered from attempt to write to closed channel")
 		}
 	}()
-	if e.warnChLim && len(e.dataCh) >= xfrChannelSize {
+	if e.warnChLim && len(e.dataCh) >= cap(e.dataCh) {
 		klog.V(2).InfoS("Data channel on agent is full", "connectionID", e.connID)
 	}
 
@@ -377,7 +378,7 @@ func (a *Client) Serve() {
 			dialResp.GetDialResponse().Random = dialReq.Random
 
 			connID := atomic.AddInt64(&a.nextConnID, 1)
-			dataCh := make(chan []byte, xfrChannelSize)
+			dataCh := make(chan []byte, a.cs.xfrChannelSize)
 			dialDone := make(chan struct{})
 			eConn := &endpointConn{
 				dataCh:    dataCh,

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -44,8 +44,6 @@ import (
 
 const dialTimeout = 5 * time.Second
 
-//const xfrChannelSize = 150
-
 // endpointConn tracks a connection from agent to node network.
 type endpointConn struct {
 	conn      net.Conn

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -61,7 +61,7 @@ type ClientSet struct {
 	// by the server when choosing agent
 
 	warnOnChannelLimit bool
-	xfrChannelSize     int
+	xfrChannelSize     uint
 
 	syncForever bool // Continue syncing (support dynamic server count).
 }
@@ -142,7 +142,7 @@ type ClientSetConfig struct {
 	ServiceAccountTokenPath string
 	WarnOnChannelLimit      bool
 	SyncForever             bool
-	XrfChannelSize          int
+	XfrChannelSize          uint
 }
 
 func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *ClientSet {
@@ -160,6 +160,7 @@ func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *C
 		syncForever:             cc.SyncForever,
 		drainCh:                 drainCh,
 		xfrChannelSize:          cc.XrfChannelSize,
+		xfrChannelSize:          cc.XfrChannelSize,
 		stopCh:                  stopCh,
 	}
 }

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -159,7 +159,6 @@ func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *C
 		warnOnChannelLimit:      cc.WarnOnChannelLimit,
 		syncForever:             cc.SyncForever,
 		drainCh:                 drainCh,
-		xfrChannelSize:          cc.XrfChannelSize,
 		xfrChannelSize:          cc.XfrChannelSize,
 		stopCh:                  stopCh,
 	}

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -61,7 +61,7 @@ type ClientSet struct {
 	// by the server when choosing agent
 
 	warnOnChannelLimit bool
-	xfrChannelSize     uint
+	xfrChannelSize     int
 
 	syncForever bool // Continue syncing (support dynamic server count).
 }
@@ -142,7 +142,7 @@ type ClientSetConfig struct {
 	ServiceAccountTokenPath string
 	WarnOnChannelLimit      bool
 	SyncForever             bool
-	XfrChannelSize          uint
+	XfrChannelSize          int
 }
 
 func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *ClientSet {

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -61,6 +61,7 @@ type ClientSet struct {
 	// by the server when choosing agent
 
 	warnOnChannelLimit bool
+	xfrChannelSize     int
 
 	syncForever bool // Continue syncing (support dynamic server count).
 }
@@ -141,6 +142,7 @@ type ClientSetConfig struct {
 	ServiceAccountTokenPath string
 	WarnOnChannelLimit      bool
 	SyncForever             bool
+	XrfChannelSize          int
 }
 
 func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *ClientSet {
@@ -157,6 +159,7 @@ func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *C
 		warnOnChannelLimit:      cc.WarnOnChannelLimit,
 		syncForever:             cc.SyncForever,
 		drainCh:                 drainCh,
+		xfrChannelSize:          cc.XrfChannelSize,
 		stopCh:                  stopCh,
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -216,7 +216,7 @@ type ProxyServer struct {
 
 	// TODO: move strategies into BackendStorage
 	proxyStrategies []ProxyStrategy
-	xfrChannelSize  uint
+	xfrChannelSize  int
 }
 
 // AgentTokenAuthenticationOptions contains list of parameters required for agent token based authentication
@@ -375,7 +375,7 @@ func (s *ProxyServer) removeEstablishedForStream(streamUID string) []*ProxyClien
 }
 
 // NewProxyServer creates a new ProxyServer instance
-func NewProxyServer(serverID string, proxyStrategies []ProxyStrategy, serverCount int, agentAuthenticationOptions *AgentTokenAuthenticationOptions, channelSize uint) *ProxyServer {
+func NewProxyServer(serverID string, proxyStrategies []ProxyStrategy, serverCount int, agentAuthenticationOptions *AgentTokenAuthenticationOptions, channelSize int) *ProxyServer {
 	var bms []BackendManager
 	for _, ps := range proxyStrategies {
 		switch ps {
@@ -417,7 +417,7 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 	streamUID := uuid.New().String()
 	klog.V(5).InfoS("Proxy request from client", "userAgent", userAgent, "serverID", s.serverID, "streamUID", streamUID)
 
-	recvCh := make(chan *client.Packet, int(s.xfrChannelSize))
+	recvCh := make(chan *client.Packet, s.xfrChannelSize)
 	stopCh := make(chan error, 1)
 
 	frontend := GrpcFrontend{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -216,7 +216,7 @@ type ProxyServer struct {
 
 	// TODO: move strategies into BackendStorage
 	proxyStrategies []ProxyStrategy
-	xfrChannelSize  int
+	xfrChannelSize  uint
 }
 
 // AgentTokenAuthenticationOptions contains list of parameters required for agent token based authentication
@@ -375,7 +375,7 @@ func (s *ProxyServer) removeEstablishedForStream(streamUID string) []*ProxyClien
 }
 
 // NewProxyServer creates a new ProxyServer instance
-func NewProxyServer(serverID string, proxyStrategies []ProxyStrategy, serverCount int, agentAuthenticationOptions *AgentTokenAuthenticationOptions, channelSize int) *ProxyServer {
+func NewProxyServer(serverID string, proxyStrategies []ProxyStrategy, serverCount int, agentAuthenticationOptions *AgentTokenAuthenticationOptions, channelSize uint) *ProxyServer {
 	var bms []BackendManager
 	for _, ps := range proxyStrategies {
 		switch ps {
@@ -417,7 +417,7 @@ func (s *ProxyServer) Proxy(stream client.ProxyService_ProxyServer) error {
 	streamUID := uuid.New().String()
 	klog.V(5).InfoS("Proxy request from client", "userAgent", userAgent, "serverID", s.serverID, "streamUID", streamUID)
 
-	recvCh := make(chan *client.Packet, s.xfrChannelSize)
+	recvCh := make(chan *client.Packet, int(s.xfrChannelSize))
 	stopCh := make(chan error, 1)
 
 	frontend := GrpcFrontend{


### PR DESCRIPTION
See also:
https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/586