### PR TITLE
Nit: go get -> go install in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For local builds these can be set to anything.
 For image builds these determine the location of your image.
 For GCE the registry should be gcr.io and PROJECT_ID should be the project you
 want to use the images in.
+Please ensure the go bin directory (usually `~/go/bin`) is in your `PATH`.
 
 ### Mockgen
 
@@ -70,11 +71,11 @@ Proto definitions are compiled with `protoc`. Please ensure you have protoc inst
 
 Currently, we are using protoc-gen-go@v1.27.1
 
-`go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1`
+`go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1`
 
 Currently, we are using protoc-gen-go-grpc@v1.2
 
-`go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2`
+`go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2`
 
 ### Local builds
 


### PR DESCRIPTION
`go get` has been deprecated for package installation since [1.16](https://tip.golang.org/doc/go1.16#modules):

> go install, with or without a version suffix (as described above), is now the recommended way to build and install packages in module mode. go get should be used with the -d flag to adjust the current module’s dependencies without building packages, and use of go get to build and install packages is deprecated. In a future release, the -d flag will always be enabled.

Using `go get` instead of `go install` resulted in some strange errors when trying to build. Changing to `go install` fixed the issue.

Also add mention of adding `~/go/bin` to the `PATH`.