### PR TITLE
ci: github workflow for k8s 1.30 and fix kind-e2e.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -56,13 +56,13 @@ jobs:
     - build
     env:
       REGISTRY: gcr.io/k8s-staging-kas-network-proxy
-      KIND_IMAGE: kindest/node${{ matrix.k8s }}
+      KIND_IMAGE: kindest/node:${{ matrix.k8s }}
       TAG: master
       CONNECTION_MODE: ${{ matrix.connection-mode }}
     strategy:
       fail-fast: false
       matrix:
-        k8s: [ v1.27.11, v1.28.7, v1.29.2 ]
+        k8s: [ v1.28.7, v1.29.2, v1.30.4 ]
         connection-mode: [ grpc, http-connect ]
     steps:
     - name: Install kind
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         ipFamily: ["ipv4", "ipv6", "dual"]
-        k8s: [ v1.27.11, v1.28.7, v1.29.2 ]
+        k8s: [ v1.28.7, v1.29.2, v1.30.4 ]
     env:
       JOB_NAME: "kindnetd-e2e-${{ matrix.ipFamily }}"
       IP_FAMILY: ${{ matrix.ipFamily }}


### PR DESCRIPTION
kind-e2e was introduced in https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/643 and never seems to have been run.