### PR TITLE
Cosmetic: restore konnectivity-client v0.0.0 to avoid confusion.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	k8s.io/component-helpers v0.31.1
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
-	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.0
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/e2e-framework v0.4.0
 )


### PR DESCRIPTION
We have a replace directive so the version isn't meaningful.