### PR TITLE
Remove deprecated golangci-lint flag.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,5 @@
 run:
   timeout: 5m
-  skip-dirs:
-  - vendor
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
After this change we still ignore vendor. Newer versions have --exclude-dirs-use-default which defaults to true.