### PR TITLE
Update golang to 1.22.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 # The output type could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
 GO_TOOLCHAIN ?= golang
-GO_VERSION ?= 1.22.5
+GO_VERSION ?= 1.22.7
 BASEIMAGE ?= gcr.io/distroless/static-debian11:nonroot
 
 ifeq ($(GOPATH),)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/apiserver-network-proxy
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Pending dependency changes require golang 1.22.7.
Upgrading to allow those dependencies to go through.