### PR TITLE
🐛 Respect log level from the command-line arguments

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -36,9 +36,11 @@ func main() {
 	flags.AddFlagSet(o.Flags())
 	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(local)
-	err := local.Set("v", "4")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error setting klog flags: %v", err)
+	if local.Lookup("v") == nil {
+		err := local.Set("v", "4")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error setting klog flags: %v", err)
+		}
 	}
 	local.VisitAll(func(fl *flag.Flag) {
 		fl.Name = util.Normalize(fl.Name)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -36,9 +36,11 @@ func main() {
 	flags.AddFlagSet(o.Flags())
 	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(local)
-	err := local.Set("v", "4")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error setting klog flags: %v", err)
+	if local.Lookup("v") == nil {
+		err := local.Set("v", "4")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error setting klog flags: %v", err)
+		}
 	}
 	local.VisitAll(func(fl *flag.Flag) {
 		fl.Name = util.Normalize(fl.Name)


### PR DESCRIPTION
Currently, the log level is hardcoded and konnectivity is usually quite noisy