### PR TITLE
Update golangci-lint.yaml, need 1.60.1 linter to work with golang 1.23

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: v1.22
-  GOLANGCI_LINT_VERSION: v1.56
+  GO_VERSION: v1.23
+  GOLANGCI_LINT_VERSION: v1.60.1
 
 jobs:
   golangci:


### PR DESCRIPTION
Update golangci-lint.yaml, need 1.60.1 linter to work with golang 1.23