### PR TITLE
Switching to a longer test timeout.

### DIFF
--- a/tests/concurrent_client_request_test.go
+++ b/tests/concurrent_client_request_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/apiserver-network-proxy/tests/framework"
 )
 
 type simpleServer struct {
@@ -59,7 +59,7 @@ func getTestClient(front string, t *testing.T) *http.Client {
 		Transport: &http.Transport{
 			DialContext: tunnel.DialContext,
 		},
-		Timeout: wait.ForeverTestTimeout,
+		Timeout: framework.ForeverTestTimeout,
 	}
 }
 

--- a/tests/framework/agent.go
+++ b/tests/framework/agent.go
@@ -78,7 +78,7 @@ func (*InProcessAgentRunner) Start(t testing.TB, opts AgentOpts) (Agent, error) 
 	}()
 
 	healthAddr := net.JoinHostPort(o.HealthServerHost, strconv.Itoa(o.HealthServerPort))
-	if err := wait.PollImmediateWithContext(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, func(context.Context) (bool, error) {
+	if err := wait.PollImmediateWithContext(ctx, 100*time.Millisecond, ForeverTestTimeout, func(context.Context) (bool, error) {
 		return checkLiveness(healthAddr), nil
 	}); err != nil {
 		close(stopCh)
@@ -215,7 +215,7 @@ func (a *externalAgent) Metrics() metricstest.AgentTester {
 }
 
 func (a *externalAgent) waitForLiveness() error {
-	err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	err := wait.PollImmediate(100*time.Millisecond, ForeverTestTimeout, func() (bool, error) {
 		resp, err := http.Get(fmt.Sprintf("http://%s/healthz", a.healthAddr))
 		if err != nil {
 			return false, nil

--- a/tests/framework/proxy_server.go
+++ b/tests/framework/proxy_server.go
@@ -73,7 +73,7 @@ func (*InProcessProxyServerRunner) Start(t testing.TB, opts ProxyServerOpts) (Pr
 	}()
 
 	healthAddr := net.JoinHostPort(o.HealthBindAddress, strconv.Itoa(o.HealthPort))
-	if err := wait.PollImmediateWithContext(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, func(context.Context) (bool, error) {
+	if err := wait.PollImmediateWithContext(ctx, 100*time.Millisecond, ForeverTestTimeout, func(context.Context) (bool, error) {
 		return checkLiveness(healthAddr), nil
 	}); err != nil {
 		close(stopCh)

--- a/tests/framework/util.go
+++ b/tests/framework/util.go
@@ -21,7 +21,10 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"time"
 )
+
+var ForeverTestTimeout = time.Minute
 
 func checkReadiness(addr string) bool {
 	resp, err := http.Get(fmt.Sprintf("http://%s/readyz", addr))

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -293,7 +293,7 @@ func TestProxyHandle_RequestDeadlineExceeded_GRPC(t *testing.T) {
 		select {
 		case <-tunnel.Done():
 			t.Log("Tunnel closed successfully")
-		case <-time.After(wait.ForeverTestTimeout):
+		case <-time.After(framework.ForeverTestTimeout):
 			t.Errorf("Timed out waiting for tunnel to close")
 		}
 	}()
@@ -343,7 +343,7 @@ func TestProxyDial_RequestCancelled_GRPC(t *testing.T) {
 
 		select {
 		case <-tunnel.Done():
-		case <-time.After(wait.ForeverTestTimeout):
+		case <-time.After(framework.ForeverTestTimeout):
 			t.Errorf("Timed out waiting for tunnel to close")
 		}
 	}()
@@ -405,7 +405,7 @@ func TestProxyDial_RequestCancelled_Concurrent_GRPC(t *testing.T) {
 
 		select {
 		case <-tunnel.Done():
-		case <-time.After(wait.ForeverTestTimeout):
+		case <-time.After(framework.ForeverTestTimeout):
 			t.Errorf("Timed out waiting for tunnel to close")
 		}
 	}
@@ -427,7 +427,7 @@ func TestProxyDial_RequestCancelled_Concurrent_GRPC(t *testing.T) {
 
 	// Wait for the closed connections to propogate
 	var endpointConnsErr, goLeaksErr error
-	wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (done bool, err error) {
+	wait.PollImmediate(time.Second, framework.ForeverTestTimeout, func() (done bool, err error) {
 		endpointConnsErr = a.Metrics().ExpectAgentEndpointConnections(0)
 		goLeaksErr = goleak.Find(ignoredGoRoutines...)
 		return endpointConnsErr == nil && goLeaksErr == nil, nil
@@ -489,7 +489,7 @@ func TestProxyDial_AgentTimeout_GRPC(t *testing.T) {
 
 		select {
 		case <-tunnel.Done():
-		case <-time.After(wait.ForeverTestTimeout):
+		case <-time.After(framework.ForeverTestTimeout):
 			t.Errorf("Timed out waiting for tunnel to close")
 		}
 	}()
@@ -965,7 +965,7 @@ func waitForConnectedServerCount(t testing.TB, expectedServerCount int, a framew
 // agents (backends). This assumes the ProxyServer is using a single ProxyStrategy.
 func waitForConnectedAgentCount(t testing.TB, expectedAgentCount int, ps framework.ProxyServer) {
 	t.Helper()
-	err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	err := wait.PollImmediate(100*time.Millisecond, framework.ForeverTestTimeout, func() (bool, error) {
 		count, err := ps.ConnectedBackends()
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Github actions seem significantly under resourced. As a result we get a high level of flakes where CPU starved goroutines are not completing inside of 30 seconds.