### PR TITLE
chore: fix field comments on ClientSet

### DIFF
--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -38,42 +38,67 @@ const (
 
 // ClientSet consists of clients connected to each instance of an HA proxy server.
 type ClientSet struct {
-	mu      sync.Mutex         //protects the clients.
-	clients map[string]*Client // map between serverID and the client
-	// connects to this server.
+	// mu guards access to the clients map
+	mu sync.Mutex
 
-	agentID string // ID of this agent
-	address string // proxy server address. Assuming HA proxy server
+	// clients is a map between serverID and the client
+	// connected to this server.
+	clients map[string]*Client
 
-	leaseCounter            ServerCounter // counts number of proxy server leases
-	lastReceivedServerCount int           // last server count received from a proxy server
-	lastServerCount         int           // last server count value from either lease system or proxy server, former takes priority
+	// agentID is "our ID" - the ID of this agent.
+	agentID string
 
-	// unless it is an HA server. Initialized when the ClientSet creates
-	// the first client. When syncForever is set, it will be the most recently seen.
-	syncInterval time.Duration // The interval by which the agent
-	// periodically checks that it has connections to all instances of the
-	// proxy server.
-	probeInterval time.Duration // The interval by which the agent
+	// Address is the proxy server address.  Assuming HA proxy server
+	address string
+
+	// leaseCounter counts number of proxy server leases
+	leaseCounter ServerCounter
+
+	// lastReceivedServerCount is the last serverCount value received when connecting to a proxy server
+	lastReceivedServerCount int
+
+	// lastServerCount is the most-recently observed serverCount value from either lease system or proxy server,
+	// former takes priority unless it is an HA server.
+	// Initialized when the ClientSet creates the first client.
+	// When syncForever is set, it will be the most recently seen.
+	lastServerCount int
+
+	// syncInterval is the interval at which the agent periodically checks
+	// that it has connections to all instances of the proxy server.
+	syncInterval time.Duration
+
+	//  The maximum interval for the syncInterval to back off to when unable to connect to the proxy server
+	syncIntervalCap time.Duration
+
+	// 	syncForever is true if we should continue syncing (support dynamic server count).
+	syncForever bool
+
+	// probeInterval is the interval at which the agent
 	// periodically checks if its connections to the proxy server is ready.
-	syncIntervalCap time.Duration // The maximum interval
-	// for the syncInterval to back off to when unable to connect to the proxy server
+	probeInterval time.Duration
 
 	dialOptions []grpc.DialOption
-	// file path contains service account token
+
+	// serviceAccountTokenPath is the file path to our kubernetes service account token
 	serviceAccountTokenPath string
+
 	// channel to signal that the agent is pending termination.
 	drainCh <-chan struct{}
+
 	// channel to signal shutting down the client set. Primarily for test.
 	stopCh <-chan struct{}
 
-	agentIdentifiers string // The identifiers of the agent, which will be used
+	// agentIdentifiers is the identifiers of the agent, which will be used
 	// by the server when choosing agent
+	agentIdentifiers string
 
 	warnOnChannelLimit bool
 	xfrChannelSize     int
 
-	syncForever       bool // Continue syncing (support dynamic server count).
+	// serverCountSource controls how we compute the server count.
+	// The proxy server sends the serverCount header to each connecting agent,
+	// and the agent figures out from these observations how many
+	// agent-to-proxy-server connections it should maintain.
 	serverCountSource string
 }
 


### PR DESCRIPTION
Not following the go conventions here means the wrong comments
appear in IDEs.
