### PR TITLE
Updating baseimage to pick up assorted security fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 OUTPUT_TYPE ?= docker
 GO_TOOLCHAIN ?= golang
 GO_VERSION ?= 1.22.5
-BASEIMAGE ?= gcr.io/distroless/static-debian11:nonroot
+BASEIMAGE ?= gcr.io/distroless/static-debian12:nonroot
 
 ifeq ($(GOPATH),)
 export GOPATH := $(shell go env GOPATH)


### PR DESCRIPTION
git branch -f release-0.30 upstream/release-0.30
git checkout release-0.30
git cherry-pick 38daed44e6e8b38a3cf18c3b6e9cbe498c5b2d0d
---
Going from Debian11 to Debian12 base image.