### PR TITLE
Cherrypick to 0.30: Updating baseimage to pick up assorted security fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ RELEASE_ARCH_LIST = amd64 arm64
 OUTPUT_TYPE ?= docker
 GO_TOOLCHAIN ?= golang
 GO_VERSION ?= 1.21.9
-BASEIMAGE ?= gcr.io/distroless/static-debian11:nonroot
+BASEIMAGE ?= gcr.io/distroless/static-debian12:nonroot
 
 ifeq ($(GOPATH),)
 export GOPATH := $(shell go env GOPATH)


### PR DESCRIPTION
git cherry-pick 38daed44e6e8b38a3cf18c3b6e9cbe498c5b2d0d
---
Going from Debian11 to Debian12 base image.