### PR TITLE
Updated golang version to 1.23.6

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -4,13 +4,14 @@ on:
     branches:
       - master
       - release-0.31
+      - release-0.32
   pull_request:
 
 permissions:
   contents: read
 
 env:
-  GO_VERSION: v1.23
+  GO_VERSION: v1.23.6
   GOLANGCI_LINT_VERSION: v1.60.1
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 # The output type could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
 GO_TOOLCHAIN ?= golang
-GO_VERSION ?= 1.23.0
+GO_VERSION ?= 1.23.6
 BASEIMAGE ?= gcr.io/distroless/static-debian12:nonroot
 
 ifeq ($(GOPATH),)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/apiserver-network-proxy
 
-go 1.23.0
+go 1.23.6
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
Build the server and agent binaries with 1.23.6.

Refresh golangci-lint.yaml.