### PR TITLE
golangci-lint refresh.

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -4,13 +4,14 @@ on:
     branches:
       - master
       - release-0.31
+      - release-0.32
   pull_request:
 
 permissions:
   contents: read
 
 env:
-  GO_VERSION: v1.23
+  GO_VERSION: v1.23.6
   GOLANGCI_LINT_VERSION: v1.60.1
 
 jobs:


### PR DESCRIPTION
- Adapt latest example from https://github.com/golangci/golangci-lint-action
- Prepare for release-0.32 branch