### PR TITLE
Release v0.31 Cherry picked back missing v0.31.1 PR - KNP agent should pick the larger of the two server count

### DIFF
--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -156,6 +156,10 @@ func TestValidate(t *testing.T) {
 			fieldMap: map[string]interface{}{"XfrChannelSize": -10},
 			expected: fmt.Errorf("channel size -10 must be greater than 0"),
 		},
+		"ServerCountSource": {
+			fieldMap: map[string]interface{}{"ServerCountSource": "foobar"},
+			expected: fmt.Errorf("--server-count-source must be one of '', 'default', 'max', got foobar"),
+		},
 	} {
 		t.Run(desc, func(t *testing.T) {
 			testAgentOptions := NewGrpcProxyAgentOptions()

--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -53,7 +53,6 @@ import (
 
 const (
 	ReadHeaderTimeout   = 60 * time.Second
-	LeaseNamespace      = "kube-system"
 	LeaseInformerResync = time.Second * 10
 )
 
@@ -163,11 +162,11 @@ func (a *Agent) runProxyConnection(o *options.GrpcProxyAgentOptions, drainCh, st
 		if err != nil {
 			return nil, fmt.Errorf("failed to create kubernetes clientset: %v", err)
 		}
-		leaseInformer := agent.NewLeaseInformerWithMetrics(k8sClient, LeaseNamespace, LeaseInformerResync)
+		leaseInformer := agent.NewLeaseInformerWithMetrics(k8sClient, o.LeaseNamespace, LeaseInformerResync)
 		go leaseInformer.Run(stopCh)
 		cache.WaitForCacheSync(stopCh, leaseInformer.HasSynced)
 		leaseLister := coordinationv1lister.NewLeaseLister(leaseInformer.GetIndexer())
-		serverLeaseSelector, _ := labels.Parse("k8s-app=konnectivity-server")
+		serverLeaseSelector, _ := labels.Parse(o.LeaseLabel)
 		serverLeaseCounter := agent.NewServerLeaseCounter(
 			clock.RealClock{},
 			leaseLister,

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -30,6 +30,12 @@ import (
 	"sigs.k8s.io/apiserver-network-proxy/pkg/agent/metrics"
 )
 
+const (
+	fromResponses = "KNP server response headers"
+	fromLeases = "KNP lease count"
+	fromFallback = "fallback to 1"
+)
+
 // ClientSet consists of clients connected to each instance of an HA proxy server.
 type ClientSet struct {
 	mu      sync.Mutex         //protects the clients.
@@ -68,6 +74,7 @@ type ClientSet struct {
 	xfrChannelSize     int
 
 	syncForever bool // Continue syncing (support dynamic server count).
+	serverCountSource string
 }
 
 func (cs *ClientSet) ClientsCount() int {
@@ -148,6 +155,7 @@ type ClientSetConfig struct {
 	SyncForever             bool
 	XfrChannelSize          int
 	ServerLeaseCounter      ServerCounter
+	ServerCountSource       string
 }
 
 func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *ClientSet {
@@ -167,6 +175,7 @@ func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *C
 		xfrChannelSize:          cc.XfrChannelSize,
 		stopCh:                  stopCh,
 		leaseCounter:            cc.ServerLeaseCounter,
+		serverCountSource:       cc.ServerCountSource,
 	}
 }
 
@@ -218,25 +227,41 @@ func (cs *ClientSet) sync() {
 }
 
 func (cs *ClientSet) ServerCount() int {
-	countFromLeases := 0
-	if cs.leaseCounter != nil {
-		countFromLeases = cs.leaseCounter.Count()
-	}
-	countFromResponses := cs.lastReceivedServerCount
 
-	serverCount := countFromLeases
-	countSource := "KNP server lease count"
-	if countFromResponses > serverCount {
-		serverCount = countFromResponses
-		countSource = "KNP server response headers"
-	}
-	if serverCount == 0 {
-		serverCount = 1
-		countSource = "fallback to 1"
+	var serverCount int
+	var countSourceLabel string
+
+	switch cs.serverCountSource {
+	case "", "default":
+		if cs.leaseCounter != nil {
+			serverCount = cs.leaseCounter.Count()
+			countSourceLabel = fromLeases
+		} else {
+			serverCount = cs.lastReceivedServerCount
+			countSourceLabel = fromResponses
+		}
+	case "max":
+		countFromLeases := 0
+		if cs.leaseCounter != nil {
+			countFromLeases = cs.leaseCounter.Count()
+		}
+		countFromResponses := cs.lastReceivedServerCount
+
+		serverCount = countFromLeases
+		countSourceLabel = fromLeases
+		if countFromResponses > serverCount {
+			serverCount = countFromResponses
+			countSourceLabel = fromResponses
+		}
+		if serverCount == 0 {
+			serverCount = 1
+			countSourceLabel = fromFallback
+		}
+
 	}
 
 	if serverCount != cs.lastServerCount {
-		klog.Warningf("change detected in proxy server count (was: %d, now: %d, source: %q)", cs.lastServerCount, serverCount, countSource)
+		klog.Warningf("change detected in proxy server count (was: %d, now: %d, source: %q)", cs.lastServerCount, serverCount, countSourceLabel)
 		cs.lastServerCount = serverCount
 	}
 

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -39,7 +39,7 @@ type ClientSet struct {
 	agentID string // ID of this agent
 	address string // proxy server address. Assuming HA proxy server
 
-	leaseCounter            *ServerLeaseCounter // counts number of proxy server leases
+	leaseCounter            ServerCounter // counts number of proxy server leases
 	lastReceivedServerCount int                 // last server count received from a proxy server
 	lastServerCount         int                 // last server count value from either lease system or proxy server, former takes priority
 
@@ -147,7 +147,7 @@ type ClientSetConfig struct {
 	WarnOnChannelLimit      bool
 	SyncForever             bool
 	XfrChannelSize          int
-	ServerLeaseCounter      *ServerLeaseCounter
+	ServerLeaseCounter      ServerCounter
 }
 
 func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *ClientSet {

--- a/pkg/agent/clientset_test.go
+++ b/pkg/agent/clientset_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"testing"
+)
+
+type FakeServerCounter struct {
+	count int
+}
+
+func (f *FakeServerCounter) Count() int {
+	return f.count
+}
+
+func TestServerCount(t *testing.T) {
+	testCases := []struct{
+		name string
+		responseCount int
+		leaseCount int
+		want int
+	} {
+		{
+			name: "higher from response",
+			responseCount: 42,
+			leaseCount: 24,
+			want: 42,
+		},
+		{
+			name: "higher from leases",
+			responseCount: 3,
+			leaseCount: 6,
+			want: 6,
+		},
+		{
+			name: "both zero",
+			responseCount: 0,
+			leaseCount: 0,
+			want: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			lc := &FakeServerCounter{
+				count: tc.leaseCount,
+			}
+
+			cs := &ClientSet{
+				clients: make(map[string]*Client),
+				leaseCounter: lc,
+			}
+			cs.lastReceivedServerCount = tc.responseCount
+			if got := cs.ServerCount(); got != tc.want {
+				t.Errorf("cs.ServerCount() = %v, want: %v", got, tc.want)
+			}
+		})
+	}
+
+}

--- a/pkg/agent/lease_counter.go
+++ b/pkg/agent/lease_counter.go
@@ -36,6 +36,10 @@ import (
 	coordinationv1lister "k8s.io/client-go/listers/coordination/v1"
 )
 
+type ServerCounter interface {
+	Count() int
+}
+
 // A ServerLeaseCounter counts leases in the k8s apiserver to determine the
 // current proxy server count.
 type ServerLeaseCounter struct {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseLabels takes a comma-separated string of key-value pairs and returns a map of labels.
+func ParseLabels(labelStr string) (map[string]string, error) {
+	labels := make(map[string]string)
+
+	if len(labelStr) == 0 {
+		return labels, fmt.Errorf("empty string provided")
+	}
+	pairs := strings.Split(labelStr, ",")
+
+	for _, pair := range pairs {
+		keyValue := strings.Split(pair, "=")
+		if len(keyValue) != 2 {
+			return nil, fmt.Errorf("invalid label format: %s", pair)
+		}
+		key := strings.TrimSpace(keyValue[0])
+		value := strings.TrimSpace(keyValue[1])
+		labels[key] = value
+	}
+	return labels, nil
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,74 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestParseLabels(t *testing.T) {
+	testCases := []struct {
+		input          string
+		expectedOutput map[string]string
+		shouldError    bool
+	}{
+		{
+			input: "app=myapp,env=prod,version=1.0",
+			expectedOutput: map[string]string{
+				"app":     "myapp",
+				"env":     "prod",
+				"version": "1.0",
+			},
+			shouldError: false,
+		},
+		{
+			input:          "app=myapp,env=prod,invalid",
+			expectedOutput: nil,
+			shouldError:    true,
+		},
+		{
+			input: "app=myapp",
+			expectedOutput: map[string]string{
+				"app": "myapp",
+			},
+			shouldError: false,
+		},
+		{
+			input:          "",
+			expectedOutput: map[string]string{},
+			shouldError:    true,
+		},
+		{
+			input: " key = value , another = test ",
+			expectedOutput: map[string]string{
+				"key":     "value",
+				"another": "test",
+			},
+			shouldError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		output, err := ParseLabels(tc.input)
+
+		// Check for unexpected errors or missing errors
+		if tc.shouldError && err == nil {
+			t.Errorf("expected error for input %q but got none", tc.input)
+			continue
+		}
+		if !tc.shouldError && err != nil {
+			t.Errorf("did not expect error for input %q but got: %v", tc.input, err)
+			continue
+		}
+
+		// Compare maps if there was no error
+		if !tc.shouldError {
+			if len(output) != len(tc.expectedOutput) {
+				t.Errorf("for input %q, expected map length %d but got %d", tc.input, len(tc.expectedOutput), len(output))
+			}
+			for key, expectedValue := range tc.expectedOutput {
+				if output[key] != expectedValue {
+					t.Errorf("for input %q, expected %q=%q but got %q=%q", tc.input, key, expectedValue, key, output[key])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Change #675 was lost.

This way, when agent and server both switch from server-provided counts to counting leases, we will maintain compatibility in both directions:

response-reliant agent with lease-enabled server: would work, as servers still send down the (static, flag-provided) server count in the response header
lease-counting agent with non-lease-enabled server: would work, as agent would fall back on the number provided by the servers
Thanks to this compatibility, enabling lease-counting in a fleet of clusters is much more practical (there's no need for two separate, interdependent rollouts).

Also missing
make lease label and lease namespace configurable #670