### PR TITLE
fix: k8s client setup if agent service account auth is not used

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
         path: _output/konnectivity-agent.tar
   kind-e2e:
     name: kind-e2e
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 100
     needs:
     - build
@@ -98,7 +98,7 @@ jobs:
       run: make test-e2e-ci
   e2e:
     name: e2e
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 100
     needs:
       - build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -136,7 +136,7 @@ jobs:
         sudo cp ${TMP_DIR}/e2e.test /usr/local/bin/e2e.test
         sudo cp ${TMP_DIR}/kubectl /usr/local/bin/kubectl
         sudo cp ${TMP_DIR}/kind /usr/local/bin/kind
-        sudo chmod +x /usr/local/bin/*
+        sudo chmod +x /usr/local/bin/ginkgo /usr/local/bin/e2e.test /usr/local/bin/kubectl /usr/local/bin/kind
 
     - name: Create multi node cluster
       run: |

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -105,7 +105,7 @@ func (p *Proxy) Run(o *options.ProxyRunOptions, stopCh <-chan struct{}) error {
 	defer cancel()
 
 	var k8sClient *kubernetes.Clientset
-	if o.AgentNamespace != "" {
+	if o.NeedsKubernetesClient {
 		config, err := clientcmd.BuildConfigFromFlags("", o.KubeconfigPath)
 		if err != nil {
 			return fmt.Errorf("failed to load kubernetes client config: %v", err)


### PR DESCRIPTION
Currently the setting up of k8s client is broken if service account
authentication is not used between server and agent.

This condition  `if o.AgentNamespace != "" {` acts as a gatekeeper for
setting the k8s client which worked fine previously as server never
needed to talk to apiserver apart from authenticating agents using
service account token.

However when lease controller logic was added, it meant that setting up
k8s client was required if lease controller was enabled but
authentication was done using mTLS instead of service account
authentication.

This fixes that.

Closing https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/728  in favour of this.