### PR TITLE
chore: bump github action runson to ubuntu-24.04

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out code
       uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
         path: _output/konnectivity-agent.tar
   kind-e2e:
     name: kind-e2e
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 100
     needs:
     - build
@@ -98,7 +98,7 @@ jobs:
       run: make test-e2e-ci
   e2e:
     name: e2e
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 100
     needs:
       - build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -136,7 +136,7 @@ jobs:
         sudo cp ${TMP_DIR}/e2e.test /usr/local/bin/e2e.test
         sudo cp ${TMP_DIR}/kubectl /usr/local/bin/kubectl
         sudo cp ${TMP_DIR}/kind /usr/local/bin/kind
-        sudo chmod +x /usr/local/bin/*
+        sudo chmod +x /usr/local/bin/ginkgo /usr/local/bin/e2e.test /usr/local/bin/kubectl /usr/local/bin/kind
 
     - name: Create multi node cluster
       run: |


### PR DESCRIPTION
There is an error in github actions runner that runs on 22.04. This issue hasn't been rectified yet but the issue is not reported on 24.04

issue details: https://github.com/actions/runner-images/issues/11985

So this bumps the action to run on ubuntu 24.04