### PR TITLE
Fix panic when mtls is disabled

### DIFF
--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -40,7 +40,7 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer metrics.Metrics.HTTPConnectionDec()
 
 	klog.V(2).InfoS("Received request for host", "method", r.Method, "host", r.Host, "userAgent", r.UserAgent())
-	if r.TLS != nil {
+	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
 		klog.V(2).InfoS("TLS", "commonName", r.TLS.PeerCertificates[0].Subject.CommonName)
 	}
 	if r.Method != http.MethodConnect {


### PR DESCRIPTION
When mTLS is disabled (no --server-ca-cert) previously the server panic'ed due to an index error when trying to access the first peer certificate since go does not even parse client certificates in this case. As this was only accessed for logging the common name of the client, I've added a second check to check if there is a peer certificate present to the existing check that already checked if tls is enabled.