### PR TITLE
docs: add Konnectivity tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ deploys the proxy agent on a worker node and the proxy server on a control plane
 See this [README.md](examples/kind-multinode/README.md) for a similar example that creates a `kind` cluster with a 
 user-configurable number of control plane and worker nodes and optionally sideloads custom proxy agent and server images.
 
+### Tutorials
+
+See this [Set up Konnectivity service](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) tutorial for
+an example of the Konnectivity service providing a TCP level proxy for the control plane to cluster communication.
+
 ### Clients
 
 `apiserver-network-proxy` components are intended to run as standalone binaries and should not be imported as a library. Clients communicating with the network proxy can import the `konnectivity-client` module.


### PR DESCRIPTION
Add new Tutorial section and link to [Set up Konnectivity service](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/)

Fixes: https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/461