### PR TITLE
Support proxy_server_ready_backends metric

### DIFF
--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
 )
 
@@ -314,7 +315,7 @@ func (o *ProxyRunOptions) Validate() error {
 	if len(o.ProxyStrategies) == 0 {
 		return fmt.Errorf("ProxyStrategies cannot be empty")
 	}
-	if _, err := server.ParseProxyStrategies(o.ProxyStrategies); err != nil {
+	if _, err := proxystrategies.ParseProxyStrategies(o.ProxyStrategies); err != nil {
 		return fmt.Errorf("invalid proxy strategies: %v", err)
 	}
 	if o.XfrChannelSize <= 0 {

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server/leases"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
 	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 )
@@ -134,7 +135,7 @@ func (p *Proxy) Run(o *options.ProxyRunOptions, stopCh <-chan struct{}) error {
 		AuthenticationAudience: o.AuthenticationAudience,
 	}
 	klog.V(1).Infoln("Starting frontend server for client connections.")
-	ps, err := server.ParseProxyStrategies(o.ProxyStrategies)
+	ps, err := proxystrategies.ParseProxyStrategies(o.ProxyStrategies)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -226,7 +226,7 @@ func NewDefaultBackendManager() *DefaultBackendManager {
 func NewDefaultBackendStorage(idTypes []header.IdentifierType, proxyStrategy proxystrategies.ProxyStrategy) *DefaultBackendStorage {
 	// Set an explicit value, so that the metric is emitted even when
 	// no agent ever successfully connects.
-	metrics.Metrics.SetBackendCount(0)
+	metrics.Metrics.SetBackendCountDeprecated(0)
 	metrics.Metrics.SetTotalBackendCount(proxyStrategy, 0)
 
 	return &DefaultBackendStorage{
@@ -262,7 +262,7 @@ func (s *DefaultBackendStorage) addBackend(identifier string, idType header.Iden
 		return
 	}
 	s.backends[identifier] = []*Backend{backend}
-	metrics.Metrics.SetBackendCount(len(s.backends))
+	metrics.Metrics.SetBackendCountDeprecated(len(s.backends))
 	metrics.Metrics.SetTotalBackendCount(s.proxyStrategy, len(s.backends))
 	s.agentIDs = append(s.agentIDs, identifier)
 }
@@ -304,7 +304,7 @@ func (s *DefaultBackendStorage) removeBackend(identifier string, idType header.I
 	if !found {
 		klog.V(1).InfoS("Could not find connection matching identifier to remove", "agentID", identifier, "idType", idType)
 	}
-	metrics.Metrics.SetBackendCount(len(s.backends))
+	metrics.Metrics.SetBackendCountDeprecated(len(s.backends))
 	metrics.Metrics.SetTotalBackendCount(s.proxyStrategy, len(s.backends))
 }
 

--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -18,11 +18,9 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/metadata"
 
@@ -383,125 +381,5 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 	}
 	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
-	}
-}
-
-func TestProxyStrategy(t *testing.T) {
-	for desc, tc := range map[string]struct {
-		input     ProxyStrategy
-		want      string
-		wantPanic string
-	}{
-		"default": {
-			input: ProxyStrategyDefault,
-			want:  "default",
-		},
-		"destHost": {
-			input: ProxyStrategyDestHost,
-			want:  "destHost",
-		},
-		"defaultRoute": {
-			input: ProxyStrategyDefaultRoute,
-			want:  "defaultRoute",
-		},
-		"unrecognized": {
-			input:     ProxyStrategy(0),
-			wantPanic: "unhandled ProxyStrategy: 0",
-		},
-	} {
-		t.Run(desc, func(t *testing.T) {
-			if tc.wantPanic != "" {
-				assert.PanicsWithValue(t, tc.wantPanic, func() {
-					_ = tc.input.String()
-				})
-			} else {
-				got := tc.input.String()
-				if got != tc.want {
-					t.Errorf("ProxyStrategy.String(): got %v, want %v", got, tc.want)
-				}
-			}
-		})
-	}
-}
-
-func TestParseProxyStrategy(t *testing.T) {
-	for desc, tc := range map[string]struct {
-		input   string
-		want    ProxyStrategy
-		wantErr error
-	}{
-		"empty": {
-			input:   "",
-			wantErr: fmt.Errorf("unknown proxy strategy: "),
-		},
-		"unrecognized": {
-			input:   "unrecognized",
-			wantErr: fmt.Errorf("unknown proxy strategy: unrecognized"),
-		},
-		"default": {
-			input: "default",
-			want:  ProxyStrategyDefault,
-		},
-		"destHost": {
-			input: "destHost",
-			want:  ProxyStrategyDestHost,
-		},
-		"defaultRoute": {
-			input: "defaultRoute",
-			want:  ProxyStrategyDefaultRoute,
-		},
-	} {
-		t.Run(desc, func(t *testing.T) {
-			got, err := ParseProxyStrategy(tc.input)
-			assert.Equal(t, tc.wantErr, err, "ParseProxyStrategy(%s): got error %q, want %v", tc.input, err, tc.wantErr)
-			if got != tc.want {
-				t.Errorf("ParseProxyStrategy(%s): got %v, want %v", tc.input, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestParseProxyStrategies(t *testing.T) {
-	for desc, tc := range map[string]struct {
-		input   string
-		want    []ProxyStrategy
-		wantErr error
-	}{
-		"empty": {
-			input:   "",
-			wantErr: fmt.Errorf("proxy strategies cannot be empty"),
-		},
-		"unrecognized": {
-			input:   "unrecognized",
-			wantErr: fmt.Errorf("unknown proxy strategy: unrecognized"),
-		},
-		"default": {
-			input: "default",
-			want:  []ProxyStrategy{ProxyStrategyDefault},
-		},
-		"destHost": {
-			input: "destHost",
-			want:  []ProxyStrategy{ProxyStrategyDestHost},
-		},
-		"defaultRoute": {
-			input: "defaultRoute",
-			want:  []ProxyStrategy{ProxyStrategyDefaultRoute},
-		},
-		"duplicate": {
-			input: "destHost,defaultRoute,defaultRoute,default",
-			want:  []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefaultRoute, ProxyStrategyDefaultRoute, ProxyStrategyDefault},
-		},
-		"multiple": {
-			input: "destHost,defaultRoute,default",
-			want:  []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefaultRoute, ProxyStrategyDefault},
-		},
-	} {
-		t.Run(desc, func(t *testing.T) {
-			got, err := ParseProxyStrategies(tc.input)
-			assert.Equal(t, tc.wantErr, err, "ParseProxyStrategies(%s): got error %q, want %v", tc.input, err, tc.wantErr)
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("ParseProxyStrategies(%s): got %v, want %v", tc.input, got, tc.want)
-			}
-		})
 	}
 }

--- a/pkg/server/default_route_backend_manager.go
+++ b/pkg/server/default_route_backend_manager.go
@@ -32,7 +32,7 @@ var _ BackendManager = &DefaultRouteBackendManager{}
 func NewDefaultRouteBackendManager() *DefaultRouteBackendManager {
 	return &DefaultRouteBackendManager{
 		DefaultBackendStorage: NewDefaultBackendStorage(
-			[]header.IdentifierType{header.DefaultRoute})}
+			[]header.IdentifierType{header.DefaultRoute}, "DefaultRouteBackendManager")}
 }
 
 // Backend tries to get a backend that advertises default route, with random selection.

--- a/pkg/server/default_route_backend_manager.go
+++ b/pkg/server/default_route_backend_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
@@ -32,7 +33,7 @@ var _ BackendManager = &DefaultRouteBackendManager{}
 func NewDefaultRouteBackendManager() *DefaultRouteBackendManager {
 	return &DefaultRouteBackendManager{
 		DefaultBackendStorage: NewDefaultBackendStorage(
-			[]header.IdentifierType{header.DefaultRoute}, "DefaultRouteBackendManager")}
+			[]header.IdentifierType{header.DefaultRoute}, proxystrategies.ProxyStrategyDefaultRoute)}
 }
 
 // Backend tries to get a backend that advertises default route, with random selection.

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
 )
 
@@ -32,7 +33,7 @@ var _ BackendManager = &DestHostBackendManager{}
 func NewDestHostBackendManager() *DestHostBackendManager {
 	return &DestHostBackendManager{
 		DefaultBackendStorage: NewDefaultBackendStorage(
-			[]header.IdentifierType{header.IPv4, header.IPv6, header.Host}, "DestHostBackendManager")}
+			[]header.IdentifierType{header.IPv4, header.IPv6, header.Host}, proxystrategies.ProxyStrategyDestHost)}
 }
 
 func (dibm *DestHostBackendManager) AddBackend(backend *Backend) {

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -32,7 +32,7 @@ var _ BackendManager = &DestHostBackendManager{}
 func NewDestHostBackendManager() *DestHostBackendManager {
 	return &DestHostBackendManager{
 		DefaultBackendStorage: NewDefaultBackendStorage(
-			[]header.IdentifierType{header.IPv4, header.IPv6, header.Host})}
+			[]header.IdentifierType{header.IPv4, header.IPv6, header.Host}, "DestHostBackendManager")}
 }
 
 func (dibm *DestHostBackendManager) AddBackend(backend *Backend) {

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -112,7 +112,7 @@ func newServerMetrics() *ServerMetrics {
 			Namespace: Namespace,
 			Subsystem: Subsystem,
 			Name:      "ready_backend_connections",
-			Help:      "Number of konnectivity agent connected to the proxy server",
+			Help:      "Number of konnectivity agent connected to the proxy server. DEPRECATED, please use ready_backend_connections_total",
 		},
 		[]string{},
 	)
@@ -295,8 +295,8 @@ func (s *ServerMetrics) HTTPConnectionInc() { s.httpConnections.Inc() }
 // HTTPConnectionDec decrements a finished HTTP CONNECTION connection.
 func (s *ServerMetrics) HTTPConnectionDec() { s.httpConnections.Dec() }
 
-// SetBackendCount sets the number of backend connection.
-func (s *ServerMetrics) SetBackendCount(count int) {
+// SetBackendCountDeprecated sets the number of backend connection.
+func (s *ServerMetrics) SetBackendCountDeprecated(count int) {
 	s.backend.WithLabelValues().Set(float64(count))
 }
 

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -51,6 +51,7 @@ type ServerMetrics struct {
 	grpcConnections      *prometheus.GaugeVec
 	httpConnections      prometheus.Gauge
 	backend              *prometheus.GaugeVec
+	totalBackendCount    *prometheus.GaugeVec
 	pendingDials         *prometheus.GaugeVec
 	establishedConns     *prometheus.GaugeVec
 	fullRecvChannels     *prometheus.GaugeVec
@@ -113,6 +114,17 @@ func newServerMetrics() *ServerMetrics {
 			Help:      "Number of konnectivity agent connected to the proxy server",
 		},
 		[]string{},
+	)
+	totalBackendCount := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "ready_backend_connections_total",
+			Help:      "Total number of konnectivity agent connected to the proxy server",
+		},
+		[]string{
+			"manager",
+		},
 	)
 	pendingDials := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -203,6 +215,7 @@ func newServerMetrics() *ServerMetrics {
 	prometheus.MustRegister(grpcConnections)
 	prometheus.MustRegister(httpConnections)
 	prometheus.MustRegister(backend)
+	prometheus.MustRegister(totalBackendCount)
 	prometheus.MustRegister(pendingDials)
 	prometheus.MustRegister(establishedConns)
 	prometheus.MustRegister(fullRecvChannels)
@@ -220,6 +233,7 @@ func newServerMetrics() *ServerMetrics {
 		grpcConnections:      grpcConnections,
 		httpConnections:      httpConnections,
 		backend:              backend,
+		totalBackendCount:    totalBackendCount,
 		pendingDials:         pendingDials,
 		establishedConns:     establishedConns,
 		fullRecvChannels:     fullRecvChannels,
@@ -240,6 +254,7 @@ func (s *ServerMetrics) Reset() {
 	s.frontendLatencies.Reset()
 	s.grpcConnections.Reset()
 	s.backend.Reset()
+	s.totalBackendCount.Reset()
 	s.pendingDials.Reset()
 	s.establishedConns.Reset()
 	s.fullRecvChannels.Reset()
@@ -282,6 +297,11 @@ func (s *ServerMetrics) HTTPConnectionDec() { s.httpConnections.Dec() }
 // SetBackendCount sets the number of backend connection.
 func (s *ServerMetrics) SetBackendCount(count int) {
 	s.backend.WithLabelValues().Set(float64(count))
+}
+
+// SetTotalBackendCount sets the total number of backend connection.
+func (s *ServerMetrics) SetTotalBackendCount(managerName string, count int) {
+	s.totalBackendCount.WithLabelValues(managerName).Set(float64(count))
 }
 
 // SetPendingDialCount sets the number of pending dials.

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -112,7 +112,7 @@ func newServerMetrics() *ServerMetrics {
 			Namespace: Namespace,
 			Subsystem: Subsystem,
 			Name:      "ready_backend_connections",
-			Help:      "Number of konnectivity agent connected to the proxy server. DEPRECATED, please use ready_backend_connections_total",
+			Help:      "Number of konnectivity agent connected to the proxy server. DEPRECATED, please use ready_backends",
 		},
 		[]string{},
 	)
@@ -120,8 +120,8 @@ func newServerMetrics() *ServerMetrics {
 		prometheus.GaugeOpts{
 			Namespace: Namespace,
 			Subsystem: Subsystem,
-			Name:      "ready_backend_connections_total",
-			Help:      "Total number of konnectivity agent connected to the proxy server",
+			Name:      "ready_backends",
+			Help:      "Number of konnectivity agent connected to the proxy server",
 		},
 		[]string{
 			"proxy_strategy",

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -24,6 +24,7 @@ import (
 
 	commonmetrics "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
 )
 
 const (
@@ -123,7 +124,7 @@ func newServerMetrics() *ServerMetrics {
 			Help:      "Total number of konnectivity agent connected to the proxy server",
 		},
 		[]string{
-			"manager",
+			"proxy_strategy",
 		},
 	)
 	pendingDials := prometheus.NewGaugeVec(
@@ -300,8 +301,8 @@ func (s *ServerMetrics) SetBackendCount(count int) {
 }
 
 // SetTotalBackendCount sets the total number of backend connection.
-func (s *ServerMetrics) SetTotalBackendCount(managerName string, count int) {
-	s.totalBackendCount.WithLabelValues(managerName).Set(float64(count))
+func (s *ServerMetrics) SetTotalBackendCount(proxyStrategy proxystrategies.ProxyStrategy, count int) {
+	s.totalBackendCount.WithLabelValues(proxyStrategy.String()).Set(float64(count))
 }
 
 // SetPendingDialCount sets the number of pending dials.

--- a/pkg/server/proxystrategies/proxystrategies.go
+++ b/pkg/server/proxystrategies/proxystrategies.go
@@ -1,0 +1,68 @@
+package proxystrategies
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ProxyStrategy int
+
+const (
+	// With this strategy the Proxy Server will randomly pick a backend from
+	// the current healthy backends to establish the tunnel over which to
+	// forward requests.
+	ProxyStrategyDefault ProxyStrategy = iota + 1
+	// With this strategy the Proxy Server will pick a backend that has the same
+	// associated host as the request.Host to establish the tunnel.
+	ProxyStrategyDestHost
+	// ProxyStrategyDefaultRoute will only forward traffic to agents that have explicity advertised
+	// they serve the default route through an agent identifier. Typically used in combination with destHost
+	ProxyStrategyDefaultRoute
+)
+
+func (ps ProxyStrategy) String() string {
+	switch ps {
+	case ProxyStrategyDefault:
+		return "default"
+	case ProxyStrategyDestHost:
+		return "destHost"
+	case ProxyStrategyDefaultRoute:
+		return "defaultRoute"
+	}
+	panic(fmt.Sprintf("unhandled ProxyStrategy: %d", ps))
+}
+
+func ParseProxyStrategy(s string) (ProxyStrategy, error) {
+	switch s {
+	case ProxyStrategyDefault.String():
+		return ProxyStrategyDefault, nil
+	case ProxyStrategyDestHost.String():
+		return ProxyStrategyDestHost, nil
+	case ProxyStrategyDefaultRoute.String():
+		return ProxyStrategyDefaultRoute, nil
+	default:
+		return 0, fmt.Errorf("unknown proxy strategy: %s", s)
+	}
+}
+
+// GenProxyStrategiesFromStr generates the list of proxy strategies from the
+// comma-seperated string, i.e., destHost.
+func ParseProxyStrategies(proxyStrategies string) ([]ProxyStrategy, error) {
+	var result []ProxyStrategy
+
+	strs := strings.Split(proxyStrategies, ",")
+	for _, s := range strs {
+		if len(s) == 0 {
+			continue
+		}
+		ps, err := ParseProxyStrategy(s)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, ps)
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("proxy strategies cannot be empty")
+	}
+	return result, nil
+}

--- a/pkg/server/proxystrategies/proxystrategies_test.go
+++ b/pkg/server/proxystrategies/proxystrategies_test.go
@@ -1,0 +1,129 @@
+package proxystrategies
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProxyStrategy(t *testing.T) {
+	for desc, tc := range map[string]struct {
+		input     ProxyStrategy
+		want      string
+		wantPanic string
+	}{
+		"default": {
+			input: ProxyStrategyDefault,
+			want:  "default",
+		},
+		"destHost": {
+			input: ProxyStrategyDestHost,
+			want:  "destHost",
+		},
+		"defaultRoute": {
+			input: ProxyStrategyDefaultRoute,
+			want:  "defaultRoute",
+		},
+		"unrecognized": {
+			input:     ProxyStrategy(0),
+			wantPanic: "unhandled ProxyStrategy: 0",
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			if tc.wantPanic != "" {
+				assert.PanicsWithValue(t, tc.wantPanic, func() {
+					_ = tc.input.String()
+				})
+			} else {
+				got := tc.input.String()
+				if got != tc.want {
+					t.Errorf("ProxyStrategy.String(): got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseProxyStrategy(t *testing.T) {
+	for desc, tc := range map[string]struct {
+		input   string
+		want    ProxyStrategy
+		wantErr error
+	}{
+		"empty": {
+			input:   "",
+			wantErr: fmt.Errorf("unknown proxy strategy: "),
+		},
+		"unrecognized": {
+			input:   "unrecognized",
+			wantErr: fmt.Errorf("unknown proxy strategy: unrecognized"),
+		},
+		"default": {
+			input: "default",
+			want:  ProxyStrategyDefault,
+		},
+		"destHost": {
+			input: "destHost",
+			want:  ProxyStrategyDestHost,
+		},
+		"defaultRoute": {
+			input: "defaultRoute",
+			want:  ProxyStrategyDefaultRoute,
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			got, err := ParseProxyStrategy(tc.input)
+			assert.Equal(t, tc.wantErr, err, "ParseProxyStrategy(%s): got error %q, want %v", tc.input, err, tc.wantErr)
+			if got != tc.want {
+				t.Errorf("ParseProxyStrategy(%s): got %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseProxyStrategies(t *testing.T) {
+	for desc, tc := range map[string]struct {
+		input   string
+		want    []ProxyStrategy
+		wantErr error
+	}{
+		"empty": {
+			input:   "",
+			wantErr: fmt.Errorf("proxy strategies cannot be empty"),
+		},
+		"unrecognized": {
+			input:   "unrecognized",
+			wantErr: fmt.Errorf("unknown proxy strategy: unrecognized"),
+		},
+		"default": {
+			input: "default",
+			want:  []ProxyStrategy{ProxyStrategyDefault},
+		},
+		"destHost": {
+			input: "destHost",
+			want:  []ProxyStrategy{ProxyStrategyDestHost},
+		},
+		"defaultRoute": {
+			input: "defaultRoute",
+			want:  []ProxyStrategy{ProxyStrategyDefaultRoute},
+		},
+		"duplicate": {
+			input: "destHost,defaultRoute,defaultRoute,default",
+			want:  []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefaultRoute, ProxyStrategyDefaultRoute, ProxyStrategyDefault},
+		},
+		"multiple": {
+			input: "destHost,defaultRoute,default",
+			want:  []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefaultRoute, ProxyStrategyDefault},
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			got, err := ParseProxyStrategies(tc.input)
+			assert.Equal(t, tc.wantErr, err, "ParseProxyStrategies(%s): got error %q, want %v", tc.input, err, tc.wantErr)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseProxyStrategies(%s): got %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -960,7 +960,7 @@ func assertReadyBackendsMetric(t testing.TB, expect int) {
 func assertTotalReadyBackendsMetric(t testing.TB, expect map[string]int) {
 	t.Helper()
 	if err := metricstest.DefaultTester.ExpectServerTotalReadyBackends(expect); err != nil {
-		t.Errorf("Expected %s metric for each proxy strategy %+v, but got error: %v", "ready_backend_connections_total", expect, err)
+		t.Errorf("Expected %s metric for each proxy strategy %+v, but got error: %v", "ready_backends", expect, err)
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -39,6 +39,7 @@ import (
 
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
 	metricstest "sigs.k8s.io/apiserver-network-proxy/pkg/testing/metrics"
 	agentmock "sigs.k8s.io/apiserver-network-proxy/proto/agent/mocks"
 	"sigs.k8s.io/apiserver-network-proxy/proto/header"
@@ -169,7 +170,7 @@ func TestAgentTokenAuthenticationErrorsToken(t *testing.T) {
 				conn.EXPECT().Recv().Return(nil, io.EOF)
 			}
 
-			p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{
+			p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{
 				Enabled:             true,
 				KubernetesClient:    kcs,
 				AgentNamespace:      tc.wantNamespace,
@@ -197,7 +198,7 @@ func TestRemovePendingDialForStream(t *testing.T) {
 	pending3 := &ProxyClientConnection{frontend: &GrpcFrontend{streamUID: streamUID}}
 	pending4 := &ProxyClientConnection{frontend: &GrpcFrontend{streamUID: "different-uid"}}
 	pending5 := &ProxyClientConnection{frontend: &GrpcFrontend{streamUID: ""}}
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
 	p.PendingDial.Add(1, pending1)
 	p.PendingDial.Add(2, pending2)
 	p.PendingDial.Add(3, pending3)
@@ -225,7 +226,7 @@ func TestAddRemoveFrontends(t *testing.T) {
 	agent2ConnID2 := new(ProxyClientConnection)
 	agent3ConnID1 := new(ProxyClientConnection)
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
 	p.addEstablished("agent1", int64(1), agent1ConnID1)
 	p.removeEstablished("agent1", int64(1))
 	expectedFrontends := make(map[string]map[int64]*ProxyClientConnection)
@@ -233,7 +234,7 @@ func TestAddRemoveFrontends(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	p = NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p = NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
 	p.addEstablished("agent1", int64(1), agent1ConnID1)
 	p.addEstablished("agent1", int64(2), agent1ConnID2)
 	p.addEstablished("agent2", int64(1), agent2ConnID1)
@@ -263,7 +264,7 @@ func TestAddRemoveBackends_DefaultStrategy(t *testing.T) {
 	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{}))
 	backend3, _ := NewBackend(mockAgentConn(ctrl, "agent3", []string{}))
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
 
 	p.addBackend(backend1)
 
@@ -295,7 +296,7 @@ func TestAddRemoveBackends_DefaultRouteStrategy(t *testing.T) {
 	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{"default-route=false"}))
 	backend3, _ := NewBackend(mockAgentConn(ctrl, "agent3", []string{"default-route=true"}))
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefaultRoute}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefaultRoute}, 1, nil, xfrChannelSize)
 
 	p.addBackend(backend1)
 
@@ -337,7 +338,7 @@ func TestAddRemoveBackends_DestHostStrategy(t *testing.T) {
 	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{"default-route=true"}))
 	backend3, _ := NewBackend(mockAgentConn(ctrl, "agent3", []string{"host=node2.mydomain.com&ipv4=5.6.7.8&ipv6=::"}))
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDestHost}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDestHost}, 1, nil, xfrChannelSize)
 
 	p.addBackend(backend1)
 	p.addBackend(backend2)
@@ -384,7 +385,7 @@ func TestAddRemoveBackends_DestHostSanitizeRequest(t *testing.T) {
 	backend1, _ := NewBackend(mockAgentConn(ctrl, "agent1", []string{"host=localhost&host=node1.mydomain.com&ipv4=1.2.3.4&ipv6=9878::7675:1292:9183:7562"}))
 	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{"host=node2.mydomain.com&ipv4=5.6.7.8&ipv6=::"}))
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDestHost}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDestHost}, 1, nil, xfrChannelSize)
 
 	p.addBackend(backend1)
 	p.addBackend(backend2)
@@ -408,7 +409,7 @@ func TestAddRemoveBackends_DestHostWithDefault(t *testing.T) {
 	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{"default-route=false"}))
 	backend3, _ := NewBackend(mockAgentConn(ctrl, "agent3", []string{"host=node2.mydomain.com&ipv4=5.6.7.8&ipv6=::"}))
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDestHost, proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
 
 	p.addBackend(backend1)
 	p.addBackend(backend2)
@@ -461,7 +462,7 @@ func TestAddRemoveBackends_DestHostWithDuplicateIdents(t *testing.T) {
 	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{"host=localhost&host=node1.mydomain.com&ipv4=1.2.3.4&ipv6=9878::7675:1292:9183:7562"}))
 	backend3, _ := NewBackend(mockAgentConn(ctrl, "agent3", []string{"host=localhost&host=node2.mydomain.com&ipv4=5.6.7.8&ipv6=::"}))
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDestHost, ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDestHost, proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
 
 	p.addBackend(backend1)
 	p.addBackend(backend2)
@@ -518,7 +519,7 @@ func TestEstablishedConnsMetric(t *testing.T) {
 	agent2ConnID2 := new(ProxyClientConnection)
 	agent3ConnID1 := new(ProxyClientConnection)
 
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
 	p.addEstablished("agent1", int64(1), agent1ConnID1)
 	assertEstablishedConnsMetric(t, 1)
 	p.addEstablished("agent1", int64(2), agent1ConnID2)
@@ -550,7 +551,7 @@ func TestRemoveEstablishedForBackendConn(t *testing.T) {
 	agent2ConnID1 := &ProxyClientConnection{backend: backend2}
 	agent2ConnID2 := &ProxyClientConnection{backend: backend2}
 	agent3ConnID1 := &ProxyClientConnection{backend: backend3}
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
 	p.addEstablished("agent1", int64(1), agent1ConnID1)
 	p.addEstablished("agent1", int64(2), agent1ConnID2)
 	p.addEstablished("agent2", int64(1), agent2ConnID1)
@@ -581,7 +582,7 @@ func TestRemoveEstablishedForStream(t *testing.T) {
 	agent2ConnID1 := &ProxyClientConnection{backend: backend2, frontend: &GrpcFrontend{streamUID: streamUID}}
 	agent2ConnID2 := &ProxyClientConnection{backend: backend2}
 	agent3ConnID1 := &ProxyClientConnection{backend: backend3, frontend: &GrpcFrontend{streamUID: streamUID}}
-	p := NewProxyServer("", []ProxyStrategy{ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
 	p.addEstablished("agent1", int64(1), agent1ConnID1)
 	p.addEstablished("agent1", int64(2), agent1ConnID2)
 	p.addEstablished("agent2", int64(1), agent2ConnID1)
@@ -641,7 +642,7 @@ func baseServerProxyTestWithoutBackend(t *testing.T, validate func(*agentmock.Mo
 	defer ctrl.Finish()
 
 	frontendConn := prepareFrontendConn(ctrl)
-	proxyServer := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, xfrChannelSize)
+	proxyServer := NewProxyServer(uuid.New().String(), []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, xfrChannelSize)
 
 	validate(frontendConn)
 
@@ -655,7 +656,7 @@ func baseServerProxyTestWithBackend(t *testing.T, validate func(*agentmock.MockA
 	frontendConn := prepareFrontendConn(ctrl)
 
 	// prepare proxy server
-	proxyServer := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, xfrChannelSize)
+	proxyServer := NewProxyServer(uuid.New().String(), []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, xfrChannelSize)
 
 	agentConn, _ := prepareAgentConnMD(t, ctrl, proxyServer)
 
@@ -861,7 +862,7 @@ func TestReadyBackendsMetric(t *testing.T) {
 
 	metrics.Metrics.Reset()
 
-	p := NewProxyServer(uuid.New().String(), []ProxyStrategy{ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, xfrChannelSize)
+	p := NewProxyServer(uuid.New().String(), []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, xfrChannelSize)
 	assertReadyBackendsMetric(t, 0)
 
 	_, backend := prepareAgentConnMD(t, ctrl, p)

--- a/pkg/testing/metrics/metrics.go
+++ b/pkg/testing/metrics/metrics.go
@@ -42,6 +42,11 @@ const (
 # TYPE konnectivity_network_proxy_server_ready_backend_connections gauge`
 	serverReadyBackendsSample = `konnectivity_network_proxy_server_ready_backend_connections{} %d`
 
+	serverTotalReadyBackendsHeader = `
+# HELP konnectivity_network_proxy_server_ready_backend_connections_total Total number of konnectivity agent connected to the proxy server
+# TYPE konnectivity_network_proxy_server_ready_backend_connections_total gauge`
+	serverTotalReadyBackendsSample = `konnectivity_network_proxy_server_ready_backend_connections_total{proxy_strategy="%s"} %d`
+
 	serverEstablishedConnsHeader = `
 # HELP konnectivity_network_proxy_server_established_connections Current number of established end-to-end connections (post-dial).
 # TYPE konnectivity_network_proxy_server_established_connections gauge`
@@ -104,6 +109,14 @@ func (t *Tester) ExpectServerReadyBackends(v int) error {
 	expect := serverReadyBackendsHeader + "\n"
 	expect += fmt.Sprintf(serverReadyBackendsSample+"\n", v)
 	return t.ExpectMetric(server.Namespace, server.Subsystem, "ready_backend_connections", expect)
+}
+
+func (t *Tester) ExpectServerTotalReadyBackends(expected map[string]int) error {
+	expect := serverTotalReadyBackendsHeader + "\n"
+	for proxyStrategy, numOfBackends := range expected {
+		expect += fmt.Sprintf(serverTotalReadyBackendsSample+"\n", proxyStrategy, numOfBackends)
+	}
+	return t.ExpectMetric(server.Namespace, server.Subsystem, "ready_backend_connections_total", expect)
 }
 
 func (t *Tester) ExpectServerEstablishedConns(v int) error {

--- a/pkg/testing/metrics/metrics.go
+++ b/pkg/testing/metrics/metrics.go
@@ -38,7 +38,7 @@ const (
 	serverPendingDialsSample = `konnectivity_network_proxy_server_pending_backend_dials{} %d`
 
 	serverReadyBackendsHeader = `
-# HELP konnectivity_network_proxy_server_ready_backend_connections Number of konnectivity agent connected to the proxy server
+# HELP konnectivity_network_proxy_server_ready_backend_connections Number of konnectivity agent connected to the proxy server. DEPRECATED, please use ready_backend_connections_total
 # TYPE konnectivity_network_proxy_server_ready_backend_connections gauge`
 	serverReadyBackendsSample = `konnectivity_network_proxy_server_ready_backend_connections{} %d`
 

--- a/pkg/testing/metrics/metrics.go
+++ b/pkg/testing/metrics/metrics.go
@@ -38,14 +38,14 @@ const (
 	serverPendingDialsSample = `konnectivity_network_proxy_server_pending_backend_dials{} %d`
 
 	serverReadyBackendsHeader = `
-# HELP konnectivity_network_proxy_server_ready_backend_connections Number of konnectivity agent connected to the proxy server. DEPRECATED, please use ready_backend_connections_total
+# HELP konnectivity_network_proxy_server_ready_backend_connections Number of konnectivity agent connected to the proxy server. DEPRECATED, please use ready_backends
 # TYPE konnectivity_network_proxy_server_ready_backend_connections gauge`
 	serverReadyBackendsSample = `konnectivity_network_proxy_server_ready_backend_connections{} %d`
 
 	serverTotalReadyBackendsHeader = `
-# HELP konnectivity_network_proxy_server_ready_backend_connections_total Total number of konnectivity agent connected to the proxy server
-# TYPE konnectivity_network_proxy_server_ready_backend_connections_total gauge`
-	serverTotalReadyBackendsSample = `konnectivity_network_proxy_server_ready_backend_connections_total{proxy_strategy="%s"} %d`
+# HELP konnectivity_network_proxy_server_ready_backends Number of konnectivity agent connected to the proxy server
+# TYPE konnectivity_network_proxy_server_ready_backends gauge`
+	serverTotalReadyBackendsSample = `konnectivity_network_proxy_server_ready_backends{proxy_strategy="%s"} %d`
 
 	serverEstablishedConnsHeader = `
 # HELP konnectivity_network_proxy_server_established_connections Current number of established end-to-end connections (post-dial).
@@ -116,7 +116,7 @@ func (t *Tester) ExpectServerTotalReadyBackends(expected map[string]int) error {
 	for proxyStrategy, numOfBackends := range expected {
 		expect += fmt.Sprintf(serverTotalReadyBackendsSample+"\n", proxyStrategy, numOfBackends)
 	}
-	return t.ExpectMetric(server.Namespace, server.Subsystem, "ready_backend_connections_total", expect)
+	return t.ExpectMetric(server.Namespace, server.Subsystem, "ready_backends", expect)
 }
 
 func (t *Tester) ExpectServerEstablishedConns(v int) error {


### PR DESCRIPTION
Fixes #294
Prior art: #295

Added a new metric to track the total number of backends based on proxy strategy. To avoid circular import, I extracted out ProxyStrategy related types, functions and tests into a separate package.

I didn't overwrite the existent `proxy_server_ready_backend_connections` metric because of potential backwards compatibility concern brought up here: https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/295/files#r872839718 Instead, I marked the problematic `proxy_server_ready_backend_connections` metric deprecated in the help message.

Tested locally following [this example](https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/master/README.md#grpc-client-using-mtls-proxy-with-dial-back-agent) and got the following result when supporting both default and desthost backend managers:
```
# HELP konnectivity_network_proxy_server_ready_backend_connections Number of konnectivity agent connected to the proxy server
# TYPE konnectivity_network_proxy_server_ready_backend_connections gauge
konnectivity_network_proxy_server_ready_backend_connections 1
# HELP konnectivity_network_proxy_server_ready_backend_connections_total Total number of konnectivity agent connected to the proxy server
# TYPE konnectivity_network_proxy_server_ready_backend_connections_total gauge
konnectivity_network_proxy_server_ready_backend_connections_total{proxy_strategy="default"} 1
konnectivity_network_proxy_server_ready_backend_connections_total{proxy_strategy="destHost"} 1
```

Added unit tests for the new metric as well.