### PR TITLE
chore: update kind to v0.29.0

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,9 +13,9 @@ on:
 env:
   GO_TOOLCHAIN: "golang"
   # TODO: match BASEIMAGE with Makefile default (nonroot variant)
-  BASEIMAGE: "gcr.io/distroless/static-debian11"
+  BASEIMAGE: "gcr.io/distroless/static-debian12"
   KIND_CLUSTER_NAME: "kind"
-  KIND_VERSION: "v0.27.0"
+  KIND_VERSION: "v0.29.0"
 
 jobs:
   build:


### PR DESCRIPTION
update ci baseimage to gcr.io/distroless/static-debian12