### PR TITLE
fix: avoid stale server count update

### DIFF
--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -300,11 +300,14 @@ func (cs *ClientSet) connectOnce() (int, error) {
 	if err != nil {
 		return serverCount, err
 	}
-	cs.lastReceivedServerCount = receivedServerCount
 	if err := cs.AddClient(c.serverID, c); err != nil {
 		c.Close()
 		return serverCount, err
 	}
+	// By moving the update to here, we only accept the server count from a server
+	// that we have successfully added to our active client set, implicitly ignoring
+	// stale data from duplicate connection attempts.
+	cs.lastReceivedServerCount = receivedServerCount
 	klog.V(2).InfoS("sync added client connecting to proxy server", "serverID", c.serverID)
 
 	labels := runpprof.Labels(


### PR DESCRIPTION
fixes : https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/739

we only accept the server count from a server that we have successfully added to our active client set, implicitly ignoring stale data from duplicate connection attempts.

This problem in seen in all previous verison as well so this will need to be backported from v0.31 branch onwards where the a new logic is introduced to enable lease-counting. 

However, that means additional dependency on kube-apiserver/etcd for the basic functionality of apiserver-network-proxy. If lease-counting is not enabled, then the problem remains of stale metadata.