### PR TITLE
Backport to release-0.32 Revert "Merge pull request #685 from makhov/respect-log-level-from-args"

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -36,11 +36,9 @@ func main() {
 	flags.AddFlagSet(o.Flags())
 	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(local)
-	if local.Lookup("v") == nil {
-		err := local.Set("v", "4")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error setting klog flags: %v", err)
-		}
+	err := local.Set("v", "4")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error setting klog flags: %v", err)
 	}
 	local.VisitAll(func(fl *flag.Flag) {
 		fl.Name = util.Normalize(fl.Name)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -36,11 +36,9 @@ func main() {
 	flags.AddFlagSet(o.Flags())
 	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(local)
-	if local.Lookup("v") == nil {
-		err := local.Set("v", "4")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error setting klog flags: %v", err)
-		}
+	err := local.Set("v", "4")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error setting klog flags: %v", err)
 	}
 	local.VisitAll(func(fl *flag.Flag) {
 		fl.Name = util.Normalize(fl.Name)


### PR DESCRIPTION
This reverts commit 4ce5f068f3d2acf9e906da7ea9ea430ac877d798.

This commit reverts a previous modification to the flag handling logic in the agent and server's main() functions.

A prior change introduced a condition (`if local.Lookup("v") == nil`) before setting the default klog verbosity level. This condition was incorrect because `klog.InitFlags()` always defines the `-v` flag, meaning the default verbosity was never being applied. This caused the effective log level to fall back to klog's default of `0` instead of the intended `4`.

This change restores the original, correct behavior by unconditionally setting the verbosity to `4`. This ensures logs are visible by default while still allowing the user to override the setting via the command line.

https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/685#issuecomment-3309950955

Fixes: #780 