### PR TITLE
implement server agent draining

### DIFF
--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -255,6 +255,14 @@ func (cs *ClientSet) sync() {
 }
 
 func (cs *ClientSet) connectOnce() error {
+	// Skip establishing new connections if draining
+	select {
+	case <-cs.drainCh:
+		klog.V(2).InfoS("Skipping connectOnce - agent is draining")
+		return nil
+	default:
+	}
+
 	serverCount := cs.determineServerCount()
 
 	// If not in syncForever mode, we only connect if we have fewer connections than the server count.

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"google.golang.org/grpc/metadata"
@@ -51,23 +52,17 @@ type Backend struct {
 	idents header.Identifiers
 
 	// draining indicates if this backend is draining and should not accept new connections
-	draining bool
-	// mu protects draining field
-	mu sync.RWMutex
+	draining atomic.Bool
 }
 
 // IsDraining returns true if the backend is draining
 func (b *Backend) IsDraining() bool {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	return b.draining
+	return b.draining.Load()
 }
 
 // SetDraining marks the backend as draining
 func (b *Backend) SetDraining() {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.draining = true
+	b.draining.Store(true)
 }
 
 func (b *Backend) Send(p *client.Packet) error {
@@ -392,7 +387,7 @@ func (s *DefaultBackendStorage) GetRandomBackend() (*Backend, error) {
 	// All agents are draining, use one as fallback
 	if firstDrainingBackend != nil {
 		agentID := firstDrainingBackend.id
-		klog.V(2).InfoS("No non-draining backends available, using draining backend as fallback", "agentID", agentID)
+		klog.V(3).InfoS("No non-draining backends available, using draining backend as fallback", "agentID", agentID)
 		return firstDrainingBackend, nil
 	}
 

--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -383,3 +383,132 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }
+
+func TestDefaultBackendManager_GetRandomBackend_DrainingFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	backend1, _ := NewBackend(mockAgentConn(ctrl, "agent1", []string{}))
+	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{}))
+	backend3, _ := NewBackend(mockAgentConn(ctrl, "agent3", []string{}))
+
+	p := NewDefaultBackendManager()
+
+	// Test 1: Empty backend manager returns ErrNotFound
+	_, err := p.Backend(context.Background())
+	if _, ok := err.(*ErrNotFound); !ok {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+
+	// Add backends
+	p.AddBackend(backend1)
+	p.AddBackend(backend2)
+	p.AddBackend(backend3)
+
+	// Test 2: Non-draining backends are returned
+	b, err := p.Backend(context.Background())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if b.IsDraining() {
+		t.Errorf("expected non-draining backend, got draining")
+	}
+
+	// Test 3: When some backends are draining, non-draining ones are prioritized
+	backend1.SetDraining()
+
+	// Call multiple times to ensure we never get the draining backend
+	for i := 0; i < 20; i++ {
+		b, err = p.Backend(context.Background())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if b == backend1 {
+			t.Errorf("expected non-draining backend, got draining backend1")
+		}
+	}
+
+	// Test 4: When all backends are draining, fallback to a draining backend
+	backend2.SetDraining()
+	backend3.SetDraining()
+
+	b, err = p.Backend(context.Background())
+	if err != nil {
+		t.Errorf("expected fallback to draining backend, got error: %v", err)
+	}
+	if b == nil {
+		t.Error("expected a backend, got nil")
+	}
+	if !b.IsDraining() {
+		t.Error("expected draining backend as fallback")
+	}
+}
+
+func TestDestHostBackendManager_Backend_DrainingFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	backend1, _ := NewBackend(mockAgentConn(ctrl, "agent1", []string{"host=localhost"}))
+	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{"host=localhost"}))
+	backend3, _ := NewBackend(mockAgentConn(ctrl, "agent3", []string{"host=otherhost"}))
+
+	p := NewDestHostBackendManager()
+
+	// Add backends
+	p.AddBackend(backend1)
+	p.AddBackend(backend2)
+	p.AddBackend(backend3)
+
+	ctx := context.WithValue(context.Background(), destHostKey, "localhost")
+
+	// Test 1: Non-draining backends are returned
+	b, err := p.Backend(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if b.IsDraining() {
+		t.Errorf("expected non-draining backend, got draining")
+	}
+
+	// Test 2: When some backends for destHost are draining, non-draining ones are prioritized
+	backend1.SetDraining()
+
+	b, err = p.Backend(ctx)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if b != backend2 {
+		t.Errorf("expected backend2 (non-draining), got different backend")
+	}
+
+	// Test 3: When all backends for destHost are draining, fallback to a draining backend
+	backend2.SetDraining()
+
+	b, err = p.Backend(ctx)
+	if err != nil {
+		t.Errorf("expected fallback to draining backend, got error: %v", err)
+	}
+	if b == nil {
+		t.Error("expected a backend, got nil")
+	}
+	if !b.IsDraining() {
+		t.Error("expected draining backend as fallback")
+	}
+	// Verify we got one of the localhost backends, not otherhost
+	if b != backend1 && b != backend2 {
+		t.Error("expected fallback to be one of the localhost backends")
+	}
+
+	// Test 4: Different destHost still works independently
+	ctx2 := context.WithValue(context.Background(), destHostKey, "otherhost")
+	b, err = p.Backend(ctx2)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if b != backend3 {
+		t.Errorf("expected backend3 for otherhost")
+	}
+	if b.IsDraining() {
+		t.Error("expected non-draining backend for otherhost")
+	}
+}

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -79,8 +79,14 @@ func (dibm *DestHostBackendManager) Backend(ctx context.Context) (*Backend, erro
 	if destHost != "" {
 		bes, exist := dibm.backends[destHost]
 		if exist && len(bes) > 0 {
-			klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
-			return dibm.backends[destHost][0], nil
+			// Find a non-draining backend for this destination host
+			for _, backend := range bes {
+				if !backend.IsDraining() {
+					klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
+					return backend, nil
+				}
+			}
+			klog.V(4).InfoS("All backends for destination host are draining", "destHost", destHost)
 		}
 	}
 	return nil, &ErrNotFound{}

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -79,14 +79,25 @@ func (dibm *DestHostBackendManager) Backend(ctx context.Context) (*Backend, erro
 	if destHost != "" {
 		bes, exist := dibm.backends[destHost]
 		if exist && len(bes) > 0 {
+			var firstDrainingBackend *Backend
+
 			// Find a non-draining backend for this destination host
 			for _, backend := range bes {
 				if !backend.IsDraining() {
 					klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
 					return backend, nil
 				}
+				// Keep track of first draining backend as fallback
+				if firstDrainingBackend == nil {
+					firstDrainingBackend = backend
+				}
 			}
-			klog.V(4).InfoS("All backends for destination host are draining", "destHost", destHost)
+
+			// All backends for this destination are draining, use one as fallback
+			if firstDrainingBackend != nil {
+				klog.V(4).InfoS("All backends for destination host are draining, using one as fallback", "destHost", destHost)
+				return firstDrainingBackend, nil
+			}
 		}
 	}
 	return nil, &ErrNotFound{}

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -95,7 +95,7 @@ func (dibm *DestHostBackendManager) Backend(ctx context.Context) (*Backend, erro
 
 			// All backends for this destination are draining, use one as fallback
 			if firstDrainingBackend != nil {
-				klog.V(4).InfoS("All backends for destination host are draining, using one as fallback", "destHost", destHost)
+				klog.V(3).InfoS("All backends for destination host are draining, using one as fallback", "destHost", destHost)
 				return firstDrainingBackend, nil
 			}
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1000,6 +1000,8 @@ func (s *ProxyServer) serveRecvBackend(backend *Backend, agentID string, recvCh 
 
 		case client.PacketType_DRAIN:
 			klog.V(2).InfoS("agent is draining", "agentID", agentID)
+			backend.SetDraining()
+			klog.V(2).InfoS("marked backend as draining, will not route new requests to this agent", "agentID", agentID)
 		default:
 			klog.V(5).InfoS("Ignoring unrecognized packet from backend", "packet", pkt, "agentID", agentID)
 		}


### PR DESCRIPTION
Currently, the server only logs if it receives a drain request from the agent. Ideally, in that scenario, the server should mark it and not select it for newer requests. This PR implements that.