### PR TITLE
feat: add --tls-min-version flag to proxy server

### DIFF
--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 	"time"
@@ -104,7 +105,11 @@ type ProxyRunOptions struct {
 	// also checks if given comma separated list contains cipher from tls.InsecureCipherSuites().
 	// NOTE that cipher suites are not configurable for TLS1.3,
 	// see: https://pkg.go.dev/crypto/tls#Config, so in that case, this option won't have any effect.
-	CipherSuites   []string
+	CipherSuites []string
+	// Minimum TLS version for server connections.
+	// Accepted values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+	// If empty, defaults to VersionTLS12.
+	TLSMinVersion  string
 	XfrChannelSize int
 
 	// Lease controller configuration
@@ -153,6 +158,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.AuthenticationAudience, "authentication-audience", o.AuthenticationAudience, "Expected agent's token authentication audience (used with agent-namespace, agent-service-account, kubeconfig).")
 	flags.StringVar(&o.ProxyStrategies, "proxy-strategies", o.ProxyStrategies, "The list of proxy strategies used by the server to pick an agent/tunnel, available strategies are: default, destHost, defaultRoute.")
 	flags.StringSliceVar(&o.CipherSuites, "cipher-suites", o.CipherSuites, "The comma separated list of allowed cipher suites. Has no effect on TLS1.3. Empty means allow default list.")
+	flags.StringVar(&o.TLSMinVersion, "tls-min-version", o.TLSMinVersion, "Minimum TLS version for server connections. Accepted values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. Empty defaults to VersionTLS12.")
 	flags.IntVar(&o.XfrChannelSize, "xfr-channel-size", o.XfrChannelSize, "The size of the two KNP server channels used in server for transferring data. One channel is for data coming from the Kubernetes API Server, and the other one is for data coming from the KNP agent.")
 	flags.BoolVar(&o.EnableLeaseController, "enable-lease-controller", o.EnableLeaseController, "Enable lease controller to publish and garbage collect proxy server leases.")
 	flags.StringVar(&o.LeaseNamespace, "lease-namespace", o.LeaseNamespace, "The namespace where lease objects are managed by the controller.")
@@ -200,6 +206,7 @@ func (o *ProxyRunOptions) Print() {
 	klog.V(1).Infof("LeaseNamespace set to %s.\n", o.LeaseNamespace)
 	klog.V(1).Infof("LeaseLabel set to %s.\n", o.LeaseLabel)
 	klog.V(1).Infof("CipherSuites set to %q.\n", o.CipherSuites)
+	klog.V(1).Infof("TLSMinVersion set to %q.\n", o.TLSMinVersion)
 	klog.V(1).Infof("XfrChannelSize set to %d.\n", o.XfrChannelSize)
 	klog.V(1).Infof("GracefulShutdownTimeout set to %v.\n", o.GracefulShutdownTimeout)
 }
@@ -325,6 +332,16 @@ func (o *ProxyRunOptions) Validate() error {
 	if o.XfrChannelSize <= 0 {
 		return fmt.Errorf("channel size %d must be greater than 0", o.XfrChannelSize)
 	}
+	// validate the TLS min version
+	if o.TLSMinVersion != "" {
+		tlsVer, err := util.GetTLSVersion(o.TLSMinVersion)
+		if err != nil {
+			return err
+		}
+		if tlsVer < tls.VersionTLS12 {
+			klog.Warningf("--tls-min-version=%s is below TLS 1.2 and is considered insecure (RFC 8996)", o.TLSMinVersion)
+		}
+	}
 	// validate the cipher suites
 	if len(o.CipherSuites) != 0 {
 		acceptedCiphers := util.GetAcceptedCiphers()
@@ -387,6 +404,7 @@ func NewProxyRunOptions() *ProxyRunOptions {
 		AuthenticationAudience:    "",
 		ProxyStrategies:           "default",
 		CipherSuites:              make([]string, 0),
+		TLSMinVersion:             "",
 		XfrChannelSize:            10,
 		EnableLeaseController:     false,
 		LeaseNamespace:            "kube-system",

--- a/cmd/server/app/options/options_test.go
+++ b/cmd/server/app/options/options_test.go
@@ -61,6 +61,7 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "AuthenticationAudience", defaultServerOptions.AuthenticationAudience, "")
 	assertDefaultValue(t, "ProxyStrategies", defaultServerOptions.ProxyStrategies, "default")
 	assertDefaultValue(t, "CipherSuites", defaultServerOptions.CipherSuites, make([]string, 0))
+	assertDefaultValue(t, "TLSMinVersion", defaultServerOptions.TLSMinVersion, "")
 	assertDefaultValue(t, "XfrChannelSize", defaultServerOptions.XfrChannelSize, 10)
 	assertDefaultValue(t, "APIContentType", defaultServerOptions.APIContentType, "application/vnd.kubernetes.protobuf")
 	assertDefaultValue(t, "GracefulShutdownTimeout", defaultServerOptions.GracefulShutdownTimeout, 0*time.Second)
@@ -148,6 +149,21 @@ func TestValidate(t *testing.T) {
 			field:    "CipherSuites",
 			value:    "TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
 			expected: nil,
+		},
+		"ValidTLSMinVersion12": {
+			field:    "TLSMinVersion",
+			value:    "VersionTLS12",
+			expected: nil,
+		},
+		"ValidTLSMinVersion13": {
+			field:    "TLSMinVersion",
+			value:    "VersionTLS13",
+			expected: nil,
+		},
+		"InvalidTLSMinVersion": {
+			field:    "TLSMinVersion",
+			value:    "InvalidVersion",
+			expected: fmt.Errorf("unsupported TLS version \"InvalidVersion\", supported values are: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13"),
 		},
 		"Empty proxy strategies": {
 			field:    "ProxyStrategies",

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -404,7 +404,7 @@ func (p *Proxy) runUDSFrontendServer(ctx context.Context, o *options.ProxyRunOpt
 	return stop, nil
 }
 
-func (p *Proxy) getTLSConfig(caFile, certFile, keyFile string, cipherSuites []string) (*tls.Config, error) {
+func (p *Proxy) getTLSConfig(caFile, certFile, keyFile string, cipherSuites []string, tlsMinVersion string) (*tls.Config, error) {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load X509 key pair %s and %s: %v", certFile, keyFile, err)
@@ -412,8 +412,13 @@ func (p *Proxy) getTLSConfig(caFile, certFile, keyFile string, cipherSuites []st
 
 	cipherSuiteIDs := tlsCipherSuites(cipherSuites)
 
+	minVersion, err := util.GetTLSVersion(tlsMinVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse TLS min version: %v", err)
+	}
+
 	if caFile == "" {
-		return &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12, CipherSuites: cipherSuiteIDs}, nil
+		return &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: minVersion, CipherSuites: cipherSuiteIDs}, nil // #nosec G402
 	}
 
 	certPool := x509.NewCertPool()
@@ -426,11 +431,11 @@ func (p *Proxy) getTLSConfig(caFile, certFile, keyFile string, cipherSuites []st
 		return nil, fmt.Errorf("failed to append cluster CA cert to the cert pool")
 	}
 
-	tlsConfig := &tls.Config{
+	tlsConfig := &tls.Config{ // #nosec G402
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{cert},
 		ClientCAs:    certPool,
-		MinVersion:   tls.VersionTLS12,
+		MinVersion:   minVersion,
 		CipherSuites: cipherSuiteIDs,
 	}
 
@@ -442,7 +447,7 @@ func (p *Proxy) runMTLSFrontendServer(_ context.Context, o *options.ProxyRunOpti
 
 	var tlsConfig *tls.Config
 	var err error
-	if tlsConfig, err = p.getTLSConfig(o.ServerCaCert, o.ServerCert, o.ServerKey, o.CipherSuites); err != nil {
+	if tlsConfig, err = p.getTLSConfig(o.ServerCaCert, o.ServerCert, o.ServerKey, o.CipherSuites, o.TLSMinVersion); err != nil {
 		return nil, err
 	}
 
@@ -500,7 +505,7 @@ func (p *Proxy) runMTLSFrontendServer(_ context.Context, o *options.ProxyRunOpti
 func (p *Proxy) runAgentServer(o *options.ProxyRunOptions, server *server.ProxyServer) error {
 	var tlsConfig *tls.Config
 	var err error
-	if tlsConfig, err = p.getTLSConfig(o.ClusterCaCert, o.ClusterCert, o.ClusterKey, o.CipherSuites); err != nil {
+	if tlsConfig, err = p.getTLSConfig(o.ClusterCaCert, o.ClusterCert, o.ClusterKey, o.CipherSuites, o.TLSMinVersion); err != nil {
 		return err
 	}
 

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"crypto/tls"
+	"fmt"
 	"strings"
 )
 
@@ -57,4 +58,26 @@ func GetAcceptedCiphers() map[string]uint16 {
 		acceptedCiphers[v.Name] = v.ID
 	}
 	return acceptedCiphers
+}
+
+// tlsVersions maps TLS version name strings to their crypto/tls constant values.
+var tlsVersions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// GetTLSVersion returns the TLS version ID for the given version name.
+// If the name is empty, it returns the default (TLS 1.2).
+// Returns an error if the name is not recognized.
+func GetTLSVersion(versionName string) (uint16, error) {
+	if versionName == "" {
+		return tls.VersionTLS12, nil
+	}
+	version, ok := tlsVersions[versionName]
+	if !ok {
+		return 0, fmt.Errorf("unsupported TLS version %q, supported values are: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13", versionName)
+	}
+	return version, nil
 }

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"crypto/tls"
 	"testing"
 )
 
@@ -55,5 +56,43 @@ func TestRemovePortFromHost(t *testing.T) {
 			}
 		}
 		t.Run(st.name, tf)
+	}
+}
+
+func TestGetTLSVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		versionName string
+		expected    uint16
+		expectError bool
+	}{
+		{"EmptyDefaultsToTLS12", "", tls.VersionTLS12, false},
+		{"VersionTLS10", "VersionTLS10", tls.VersionTLS10, false},
+		{"VersionTLS11", "VersionTLS11", tls.VersionTLS11, false},
+		{"VersionTLS12", "VersionTLS12", tls.VersionTLS12, false},
+		{"VersionTLS13", "VersionTLS13", tls.VersionTLS13, false},
+		{"InvalidVersion", "VersionTLS99", 0, true},
+	}
+
+	for _, tt := range tests {
+		st := tt
+		t.Run(st.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := GetTLSVersion(st.versionName)
+			if st.expectError {
+				if err == nil {
+					t.Fatalf("\t%s\texpected error for input %q, but got none", failed, st.versionName)
+				}
+				t.Logf("\t%s\tgot expected error: %v", succeed, err)
+				return
+			}
+			if err != nil {
+				t.Fatalf("\t%s\tunexpected error for input %q: %v", failed, st.versionName, err)
+			}
+			if got != st.expected {
+				t.Fatalf("\t%s\texpect %v, but got %v", failed, st.expected, got)
+			}
+			t.Logf("\t%s\texpect %v, got %v", succeed, st.expected, got)
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Add `--tls-min-version` flag to the proxy server, allowing dynamic configuration of the minimum TLS version
- Previously the minimum TLS version was hardcoded to TLS 1.2 in `getTLSConfig()`
- Accepted values: `VersionTLS10`, `VersionTLS11`, `VersionTLS12`, `VersionTLS13` (defaults to `VersionTLS12` when not specified, maintaining backward compatibility)

## Motivation

The proxy server currently hardcodes `tls.VersionTLS12` as the minimum TLS version. This makes it impossible for operators to enforce stricter TLS policies (e.g., TLS 1.3 only) or to align with platform-wide TLS security profiles. Adding this flag allows the minimum TLS version to be configured at startup, similar to the existing `--cipher-suites` flag.

## Changes

| File | Change |
|------|--------|
| `pkg/util/net.go` | Add `TLSVersions` map and `GetTLSVersion()` helper function |
| `cmd/server/app/options/options.go` | Add `TLSMinVersion` field, `--tls-min-version` flag, validation, and print |
| `cmd/server/app/server.go` | Update `getTLSConfig()` to accept and use dynamic TLS min version |
| `cmd/server/app/options/options_test.go` | Add default value test and validation tests for valid/invalid TLS versions |

## Test plan

- [x] `TestDefaultServerOptions` passes — verifies `TLSMinVersion` defaults to `""`
- [x] `TestValidate` passes — covers `VersionTLS12`, `VersionTLS13`, and invalid version
- [x] All existing tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)