### PR TITLE
fix(agent): remove reconnection delay on DuplicateServerError

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -82,6 +82,11 @@ type GrpcProxyAgentOptions struct {
 	SyncForever    bool
 	XfrChannelSize int
 
+	// SyncImmediatelyOnDuplicate makes the agent retry a reconnection
+	// immediately, instead of waiting a sync interval, when it lands on a proxy
+	// server it is already connected to while more connections are still needed.
+	SyncImmediatelyOnDuplicate bool
+
 	// Enables updating the server count by counting the number of valid leases
 	// matching the selector.
 	CountServerLeases bool
@@ -111,6 +116,8 @@ func (o *GrpcProxyAgentOptions) ClientSetConfig(dialOptions ...grpc.DialOption) 
 		SyncForever:             o.SyncForever,
 		XfrChannelSize:          o.XfrChannelSize,
 		ServerCountSource:       o.ServerCountSource,
+
+		SyncImmediatelyOnDuplicate: o.SyncImmediatelyOnDuplicate,
 	}
 }
 
@@ -137,6 +144,7 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.AgentIdentifiers, "agent-identifiers", o.AgentIdentifiers, "Identifiers of the agent that will be used by the server when choosing agent. N.B. the list of identifiers must be in URL encoded format. e.g.,host=localhost&host=node1.mydomain.com&cidr=127.0.0.1/16&ipv4=1.2.3.4&ipv4=5.6.7.8&ipv6=:::::&default-route=true")
 	flags.BoolVar(&o.WarnOnChannelLimit, "warn-on-channel-limit", o.WarnOnChannelLimit, "Turns on a warning if the system is going to push to a full channel. The check involves an unsafe read.")
 	flags.BoolVar(&o.SyncForever, "sync-forever", o.SyncForever, "If true, the agent continues syncing, in order to support server count changes.")
+	flags.BoolVar(&o.SyncImmediatelyOnDuplicate, "sync-immediately-on-duplicate", o.SyncImmediatelyOnDuplicate, "If true, when a reconnection attempt lands on a proxy server the agent is already connected to while more connections are still needed, the agent retries immediately instead of waiting a sync interval. Speeds up reconnection behind DNS load balancing at the cost of more frequent connection attempts. Defaults to false (previous behavior).")
 	flags.IntVar(&o.XfrChannelSize, "xfr-channel-size", 150, "Set the size of the channel for transferring data between the agent and the proxy server.")
 	flags.BoolVar(&o.CountServerLeases, "count-server-leases", o.CountServerLeases, "Enables lease counting system to determine the number of proxy servers to connect to.")
 	flags.StringVar(&o.LeaseNamespace, "lease-namespace", o.LeaseNamespace, "Namespace where lease objects are managed.")
@@ -169,6 +177,7 @@ func (o *GrpcProxyAgentOptions) Print() {
 	klog.V(1).Infof("AgentIdentifiers set to %s.\n", util.PrettyPrintURL(o.AgentIdentifiers))
 	klog.V(1).Infof("WarnOnChannelLimit set to %t.\n", o.WarnOnChannelLimit)
 	klog.V(1).Infof("SyncForever set to %v.\n", o.SyncForever)
+	klog.V(1).Infof("SyncImmediatelyOnDuplicate set to %v.\n", o.SyncImmediatelyOnDuplicate)
 	klog.V(1).Infof("CountServerLeases set to %v.\n", o.CountServerLeases)
 	klog.V(1).Infof("LeaseNamespace set to %s.\n", o.LeaseNamespace)
 	klog.V(1).Infof("LeaseLabel set to %s.\n", o.LeaseLabel)
@@ -267,33 +276,34 @@ func validateAgentIdentifiers(agentIdentifiers string) error {
 
 func NewGrpcProxyAgentOptions() *GrpcProxyAgentOptions {
 	o := GrpcProxyAgentOptions{
-		AgentCert:                 "",
-		AgentKey:                  "",
-		CaCert:                    "",
-		ProxyServerHost:           "127.0.0.1",
-		ProxyServerPort:           8091,
-		HealthServerHost:          "",
-		HealthServerPort:          8093,
-		AdminBindAddress:          "127.0.0.1",
-		AdminServerPort:           8094,
-		EnableProfiling:           false,
-		EnableContentionProfiling: false,
-		AgentID:                   defaultAgentID(),
-		AgentIdentifiers:          "",
-		SyncInterval:              1 * time.Second,
-		ProbeInterval:             1 * time.Second,
-		SyncIntervalCap:           10 * time.Second,
-		KeepaliveTime:             1 * time.Hour,
-		ServiceAccountTokenPath:   "",
-		WarnOnChannelLimit:        false,
-		SyncForever:               false,
-		XfrChannelSize:            150,
-		CountServerLeases:         false,
-		LeaseNamespace:            "kube-system",
-		LeaseLabel:                "k8s-app=konnectivity-server",
-		ServerCountSource:         "default",
-		KubeconfigPath:            "",
-		APIContentType:            runtime.ContentTypeProtobuf,
+		AgentCert:                  "",
+		AgentKey:                   "",
+		CaCert:                     "",
+		ProxyServerHost:            "127.0.0.1",
+		ProxyServerPort:            8091,
+		HealthServerHost:           "",
+		HealthServerPort:           8093,
+		AdminBindAddress:           "127.0.0.1",
+		AdminServerPort:            8094,
+		EnableProfiling:            false,
+		EnableContentionProfiling:  false,
+		AgentID:                    defaultAgentID(),
+		AgentIdentifiers:           "",
+		SyncInterval:               1 * time.Second,
+		ProbeInterval:              1 * time.Second,
+		SyncIntervalCap:            10 * time.Second,
+		KeepaliveTime:              1 * time.Hour,
+		ServiceAccountTokenPath:    "",
+		WarnOnChannelLimit:         false,
+		SyncForever:                false,
+		SyncImmediatelyOnDuplicate: false,
+		XfrChannelSize:             150,
+		CountServerLeases:          false,
+		LeaseNamespace:             "kube-system",
+		LeaseLabel:                 "k8s-app=konnectivity-server",
+		ServerCountSource:          "default",
+		KubeconfigPath:             "",
+		APIContentType:             runtime.ContentTypeProtobuf,
 	}
 	return &o
 }

--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -50,6 +50,7 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "ServiceAccountTokenPath", defaultAgentOptions.ServiceAccountTokenPath, "")
 	assertDefaultValue(t, "WarnOnChannelLimit", defaultAgentOptions.WarnOnChannelLimit, false)
 	assertDefaultValue(t, "SyncForever", defaultAgentOptions.SyncForever, false)
+	assertDefaultValue(t, "SyncImmediatelyOnDuplicate", defaultAgentOptions.SyncImmediatelyOnDuplicate, false)
 	assertDefaultValue(t, "XfrChannelSize", defaultAgentOptions.XfrChannelSize, 150)
 	assertDefaultValue(t, "APIContentType", defaultAgentOptions.APIContentType, "application/vnd.kubernetes.protobuf")
 }

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -226,10 +226,10 @@ func (cs *ClientSet) sync() {
 				klog.V(4).InfoS("duplicate server", "serverID", dse.ServerID, "serverCount", serverCount, "clientsCount", clientsCount)
 				if serverCount != 0 && clientsCount >= serverCount {
 					duration = backoff.Step()
-				} else {
-					backoff = cs.resetBackoff()
-					duration = wait.Jitter(backoff.Duration, backoff.Jitter)
 				}
+				// When clientsCount < serverCount, we need a new connection.
+				// Leave duration at 0 to retry immediately without delay,
+				// allowing fast reconnection via DNS load balancing.
 			} else {
 				klog.ErrorS(err, "cannot connect once")
 				duration = backoff.Step()

--- a/pkg/agent/clientset.go
+++ b/pkg/agent/clientset.go
@@ -100,6 +100,14 @@ type ClientSet struct {
 	// and the agent figures out from these observations how many
 	// agent-to-proxy-server connections it should maintain.
 	serverCountSource string
+
+	// syncImmediatelyOnDuplicate controls the retry delay when a reconnection
+	// attempt lands on a proxy server we are already connected to
+	// (DuplicateServerError) while we still need more connections. When true,
+	// the agent retries immediately instead of waiting a sync interval, which
+	// speeds up reconnection behind DNS load balancing at the cost of more
+	// frequent connection attempts. Defaults to false (the previous behavior).
+	syncImmediatelyOnDuplicate bool
 }
 
 func (cs *ClientSet) ClientsCount() int {
@@ -177,6 +185,10 @@ type ClientSetConfig struct {
 	XfrChannelSize          int
 	ServerLeaseCounter      ServerCounter
 	ServerCountSource       string
+
+	// SyncImmediatelyOnDuplicate enables immediate reconnection retries on
+	// DuplicateServerError while more connections are still needed.
+	SyncImmediatelyOnDuplicate bool
 }
 
 func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *ClientSet {
@@ -197,6 +209,8 @@ func (cc *ClientSetConfig) NewAgentClientSet(drainCh, stopCh <-chan struct{}) *C
 		stopCh:                  stopCh,
 		leaseCounter:            cc.ServerLeaseCounter,
 		serverCountSource:       cc.ServerCountSource,
+
+		syncImmediatelyOnDuplicate: cc.SyncImmediatelyOnDuplicate,
 	}
 }
 
@@ -219,25 +233,19 @@ func (cs *ClientSet) sync() {
 	defer cs.shutdown()
 	backoff := cs.resetBackoff()
 	var duration time.Duration
+	// immediateRetries counts consecutive zero-delay reconnection attempts made
+	// under syncImmediatelyOnDuplicate, so they can be bounded (see
+	// nextResyncDuration). It resets whenever a connection makes progress.
+	immediateRetries := 0
 	for {
-		if serverCount, err := cs.connectOnce(); err != nil {
-			if dse, ok := err.(*DuplicateServerError); ok {
-				clientsCount := cs.ClientsCount()
-				klog.V(4).InfoS("duplicate server", "serverID", dse.ServerID, "serverCount", serverCount, "clientsCount", clientsCount)
-				if serverCount != 0 && clientsCount >= serverCount {
-					duration = backoff.Step()
-				} else {
-					backoff = cs.resetBackoff()
-					duration = wait.Jitter(backoff.Duration, backoff.Jitter)
-				}
-			} else {
-				klog.ErrorS(err, "cannot connect once")
-				duration = backoff.Step()
-			}
-		} else {
-			backoff = cs.resetBackoff()
-			duration = wait.Jitter(backoff.Duration, backoff.Jitter)
+		serverCount, err := cs.connectOnce()
+		clientsCount := cs.ClientsCount()
+		if dse, ok := err.(*DuplicateServerError); ok {
+			klog.V(4).InfoS("duplicate server", "serverID", dse.ServerID, "serverCount", serverCount, "clientsCount", clientsCount)
+		} else if err != nil {
+			klog.ErrorS(err, "cannot connect once")
 		}
+		duration, backoff, immediateRetries = cs.nextResyncDuration(backoff, immediateRetries, err, serverCount, clientsCount)
 		time.Sleep(duration)
 		select {
 		case <-cs.stopCh:
@@ -245,6 +253,46 @@ func (cs *ClientSet) sync() {
 		default:
 		}
 	}
+}
+
+// nextResyncDuration decides how long sync() waits before the next connectOnce
+// attempt. It returns the delay, the (possibly reset) backoff to use afterwards,
+// and the updated count of consecutive immediate reconnection retries. It is
+// separated from sync() so the branching can be unit tested without a live
+// proxy server.
+func (cs *ClientSet) nextResyncDuration(backoff *wait.Backoff, immediateRetries int, err error, serverCount, clientsCount int) (time.Duration, *wait.Backoff, int) {
+	if _, ok := err.(*DuplicateServerError); ok {
+		if serverCount != 0 && clientsCount >= serverCount {
+			// We already hold as many connections as there are servers, so the
+			// duplicate means there is nothing new to connect to: back off.
+			return backoff.Step(), backoff, 0
+		}
+		if cs.syncImmediatelyOnDuplicate && serverCount != 0 && clientsCount < serverCount && immediateRetries < serverCount {
+			// Opt-in: we have a known connection deficit but landed on a server
+			// we are already connected to. Retry immediately instead of waiting
+			// a full sync interval, so the next dial can pick the missing server
+			// via DNS load balancing. Bounded by serverCount consecutive attempts
+			// so a permanent deficit (a server count that can never be reached)
+			// cannot become an unbounded zero-delay reconnect loop; once the
+			// budget is spent we fall back to the jittered delay below until a
+			// connection makes progress.
+			return 0, backoff, immediateRetries + 1
+		}
+		// The server count is not known yet, immediate retry is disabled, or its
+		// budget is spent: wait a jittered sync interval before trying again.
+		// Preserve immediateRetries so a spent budget stays spent until a
+		// connection makes progress.
+		backoff = cs.resetBackoff()
+		return wait.Jitter(backoff.Duration, backoff.Jitter), backoff, immediateRetries
+	}
+	if err != nil {
+		// A real connection error: back off.
+		return backoff.Step(), backoff, 0
+	}
+	// A successful connection, or nothing to do: reset backoff and the immediate
+	// retry budget, then wait a sync interval before re-checking.
+	backoff = cs.resetBackoff()
+	return wait.Jitter(backoff.Duration, backoff.Jitter), backoff, 0
 }
 
 func (cs *ClientSet) ServerCount() int {

--- a/pkg/agent/clientset_test.go
+++ b/pkg/agent/clientset_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package agent
 
 import (
+	"errors"
 	"testing"
+	"time"
 )
 
 type FakeServerCounter struct {
@@ -89,4 +91,195 @@ func TestServerCount(t *testing.T) {
 		})
 	}
 
+}
+
+func TestNextResyncDuration(t *testing.T) {
+	const (
+		syncInterval    = 1 * time.Second
+		syncIntervalCap = 10 * time.Second
+	)
+
+	dup := &DuplicateServerError{ServerID: "server-1"}
+	realErr := errors.New("dial tcp: connection refused")
+
+	// wait.Jitter(base, 0.1) yields a value in [base, base*1.1).
+	expectJitter := func(base time.Duration) func(*testing.T, time.Duration) {
+		return func(t *testing.T, d time.Duration) {
+			t.Helper()
+			upper := base + time.Duration(0.1*float64(base))
+			if d < base || d > upper {
+				t.Errorf("duration = %v, want within [%v, %v]", d, base, upper)
+			}
+		}
+	}
+	expectZero := func(t *testing.T, d time.Duration) {
+		t.Helper()
+		if d != 0 {
+			t.Errorf("duration = %v, want immediate retry (0)", d)
+		}
+	}
+	expectPositive := func(t *testing.T, d time.Duration) {
+		t.Helper()
+		if d <= 0 {
+			t.Errorf("duration = %v, want a positive backoff", d)
+		}
+	}
+
+	testCases := []struct {
+		name                       string
+		syncImmediatelyOnDuplicate bool
+		err                        error
+		serverCount                int
+		clientsCount               int
+		check                      func(*testing.T, time.Duration)
+	}{
+		{
+			name:         "success resets to sync interval",
+			err:          nil,
+			serverCount:  3,
+			clientsCount: 3,
+			check:        expectJitter(syncInterval),
+		},
+		{
+			name:         "real error backs off",
+			err:          realErr,
+			serverCount:  3,
+			clientsCount: 1,
+			check:        expectPositive,
+		},
+		{
+			name:         "duplicate with enough clients backs off",
+			err:          dup,
+			serverCount:  3,
+			clientsCount: 3,
+			check:        expectPositive,
+		},
+		{
+			name:         "duplicate needing more clients waits a sync interval by default",
+			err:          dup,
+			serverCount:  3,
+			clientsCount: 1,
+			check:        expectJitter(syncInterval),
+		},
+		{
+			name:                       "duplicate needing more clients retries immediately when enabled",
+			syncImmediatelyOnDuplicate: true,
+			err:                        dup,
+			serverCount:                3,
+			clientsCount:               1,
+			check:                      expectZero,
+		},
+		{
+			name:                       "flag does not shortcut backoff when clients are sufficient",
+			syncImmediatelyOnDuplicate: true,
+			err:                        dup,
+			serverCount:                3,
+			clientsCount:               3,
+			check:                      expectPositive,
+		},
+		{
+			name:                       "flag waits a sync interval when server count is unknown",
+			syncImmediatelyOnDuplicate: true,
+			err:                        dup,
+			serverCount:                0,
+			clientsCount:               1,
+			check:                      expectJitter(syncInterval),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := &ClientSet{
+				clients:                    make(map[string]*Client),
+				syncInterval:               syncInterval,
+				syncIntervalCap:            syncIntervalCap,
+				syncImmediatelyOnDuplicate: tc.syncImmediatelyOnDuplicate,
+			}
+			backoff := cs.resetBackoff()
+			got, gotBackoff, _ := cs.nextResyncDuration(backoff, 0, tc.err, tc.serverCount, tc.clientsCount)
+			if gotBackoff == nil {
+				t.Fatalf("nextResyncDuration returned a nil backoff")
+			}
+			tc.check(t, got)
+		})
+	}
+}
+
+// TestNextResyncDurationBackoffGrows verifies that the error and
+// duplicate-with-enough-clients paths use exponential backoff (backoff.Step),
+// distinguishing them from the constant reset+jitter path: feeding the returned
+// backoff back in must yield a strictly growing delay.
+func TestNextResyncDurationBackoffGrows(t *testing.T) {
+	cases := []struct {
+		name         string
+		err          error
+		serverCount  int
+		clientsCount int
+	}{
+		{name: "real error", err: errors.New("connection refused"), serverCount: 3, clientsCount: 1},
+		{name: "duplicate with enough clients", err: &DuplicateServerError{ServerID: "s"}, serverCount: 3, clientsCount: 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := &ClientSet{
+				clients:         make(map[string]*Client),
+				syncInterval:    1 * time.Second,
+				syncIntervalCap: 60 * time.Second,
+			}
+			backoff := cs.resetBackoff()
+			var prev time.Duration
+			for i := 0; i < 3; i++ {
+				var d time.Duration
+				d, backoff, _ = cs.nextResyncDuration(backoff, 0, tc.err, tc.serverCount, tc.clientsCount)
+				if i > 0 && d <= prev {
+					t.Errorf("step %d: duration %v did not grow beyond previous %v (backoff not applied)", i, d, prev)
+				}
+				prev = d
+			}
+		})
+	}
+}
+
+// TestNextResyncDurationImmediateRetryBudget verifies that immediate retries are
+// bounded: with the flag enabled and a permanent deficit, only serverCount
+// consecutive zero-delay retries are allowed before falling back to the delay,
+// and progress resets the budget.
+func TestNextResyncDurationImmediateRetryBudget(t *testing.T) {
+	const serverCount = 3
+	dup := &DuplicateServerError{ServerID: "s"}
+	cs := &ClientSet{
+		clients:                    make(map[string]*Client),
+		syncInterval:               1 * time.Second,
+		syncIntervalCap:            10 * time.Second,
+		syncImmediatelyOnDuplicate: true,
+	}
+	backoff := cs.resetBackoff()
+
+	// A permanent deficit (clientsCount stays below serverCount) must yield
+	// exactly serverCount immediate (zero) retries, then a positive delay.
+	immediateRetries := 0
+	for i := 0; i < serverCount; i++ {
+		var d time.Duration
+		d, backoff, immediateRetries = cs.nextResyncDuration(backoff, immediateRetries, dup, serverCount, 1)
+		if d != 0 {
+			t.Fatalf("attempt %d: duration = %v, want immediate retry (0)", i, d)
+		}
+	}
+	d, backoff, immediateRetries := cs.nextResyncDuration(backoff, immediateRetries, dup, serverCount, 1)
+	if d <= 0 {
+		t.Fatalf("after budget spent: duration = %v, want a positive fallback delay", d)
+	}
+	if immediateRetries != serverCount {
+		t.Fatalf("spent budget was not preserved: immediateRetries = %d, want %d", immediateRetries, serverCount)
+	}
+
+	// A successful connection resets the budget so immediate retries resume.
+	_, backoff, immediateRetries = cs.nextResyncDuration(backoff, immediateRetries, nil, serverCount, serverCount)
+	if immediateRetries != 0 {
+		t.Fatalf("progress did not reset the budget: immediateRetries = %d, want 0", immediateRetries)
+	}
+	d, _, _ = cs.nextResyncDuration(backoff, immediateRetries, dup, serverCount, 1)
+	if d != 0 {
+		t.Fatalf("after reset: duration = %v, want immediate retry (0)", d)
+	}
 }


### PR DESCRIPTION
## Description

This PR fixes a regression in v0.33.0 where agents fail to reconnect after connection loss, leaving Kubernetes nodes in permanent `NotReady` state.

## Problem

In v0.33.0, when `DuplicateServerError` occurs during reconnection with `clientsCount < serverCount`, the code adds a ~1s delay:

```go
} else {
    backoff = cs.resetBackoff()
    duration = wait.Jitter(backoff.Duration, backoff.Jitter)  // ~1s delay
}
```

Since `newAgentClient()` uses DNS load balancing, it connects to a random proxy pod. When a client disconnects, the reconnection attempt has only ~20% chance (1/5 pods) of selecting the correct pod. Wrong selections trigger `DuplicateServerError`, and the 1s delay significantly slows reconnection.

**Impact:** Average reconnection time increases from ~500ms to ~5s per client. With multiple simultaneous disconnects (e.g., VM restart), cascading failures prevent full recovery.

## Solution

Remove the else block that adds delay. Let `duration` remain 0 (default value), enabling immediate retry through `time.Sleep(0)`. This allows fast reconnection via DNS load balancing without creating a tight loop (the loop already includes gRPC dial time and network round trips).

## Context

The release-0.33 branch already contains one fix from v0.34.0 (moving `lastReceivedServerCount` update to after successful `AddClient()`). This PR adds the second critical fix - removing the delay on reconnection attempts.

Together, these changes restore the fast reconnection behavior from v0.28.6 and align with the complete fix in v0.34.0.

## Testing

Verified in production cluster:
- Before fix: Nodes remain NotReady permanently after VM restart (v0.33.0)
- After fix: Expected behavior matches v0.34.0 - agents reconnect within seconds

Related: #816
