### PR TITLE
server: avoid selecting draining backends

### DIFF
--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -216,7 +216,12 @@ type DefaultBackendStorage struct {
 	// randomly pick a key from a map (in this case, the backends) in
 	// Golang.
 	agentIDs []string
-	random   *rand.Rand
+	// nonDrainingIDs tracks identifiers whose primary backend is not draining.
+	// Used to avoid scanning all identifiers on every selection.
+	nonDrainingIDs []string
+	// nonDrainingIndex tracks index positions in nonDrainingIDs for O(1) removals.
+	nonDrainingIndex map[string]int
+	random           *rand.Rand
 	// idTypes contains the valid identifier types for this
 	// DefaultBackendStorage. The DefaultBackendStorage may only tolerate certain
 	// types of identifiers when associating to a specific BackendManager,
@@ -244,10 +249,11 @@ func NewDefaultBackendStorage(idTypes []header.IdentifierType, proxyStrategy pro
 	metrics.Metrics.SetTotalBackendCount(proxyStrategy, 0)
 
 	return &DefaultBackendStorage{
-		backends:      make(map[string][]*Backend),
-		random:        rand.New(rand.NewSource(time.Now().UnixNano())), /* #nosec G404 */
-		idTypes:       idTypes,
-		proxyStrategy: proxyStrategy,
+		backends:         make(map[string][]*Backend),
+		nonDrainingIndex: make(map[string]int),
+		random:           rand.New(rand.NewSource(time.Now().UnixNano())), /* #nosec G404 */
+		idTypes:          idTypes,
+		proxyStrategy:    proxyStrategy,
 	}
 }
 
@@ -255,15 +261,57 @@ func containIDType(idTypes []header.IdentifierType, idType header.IdentifierType
 	return slices.Contains(idTypes, idType)
 }
 
+func (s *DefaultBackendStorage) addNonDrainingIdentifierLocked(identifier string) {
+	if _, ok := s.nonDrainingIndex[identifier]; ok {
+		return
+	}
+	s.nonDrainingIDs = append(s.nonDrainingIDs, identifier)
+	s.nonDrainingIndex[identifier] = len(s.nonDrainingIDs) - 1
+}
+
+func (s *DefaultBackendStorage) removeNonDrainingIdentifierLocked(identifier string) {
+	idx, ok := s.nonDrainingIndex[identifier]
+	if !ok {
+		return
+	}
+	lastIdx := len(s.nonDrainingIDs) - 1
+	if idx != lastIdx {
+		lastIdentifier := s.nonDrainingIDs[lastIdx]
+		s.nonDrainingIDs[idx] = lastIdentifier
+		s.nonDrainingIndex[lastIdentifier] = idx
+	}
+	s.nonDrainingIDs = s.nonDrainingIDs[:lastIdx]
+	delete(s.nonDrainingIndex, identifier)
+}
+
+func (s *DefaultBackendStorage) refreshNonDrainingIdentifierLocked(identifier string) {
+	backends, ok := s.backends[identifier]
+	if !ok || len(backends) == 0 {
+		s.removeNonDrainingIdentifierLocked(identifier)
+		return
+	}
+
+	// For a given identifier, routing always uses the first backend.
+	if backends[0].IsDraining() {
+		s.removeNonDrainingIdentifierLocked(identifier)
+		return
+	}
+	s.addNonDrainingIdentifierLocked(identifier)
+}
+
 // addBackend adds a backend.
 func (s *DefaultBackendStorage) addBackend(identifier string, idType header.IdentifierType, backend *Backend) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.addBackendLocked(identifier, idType, backend)
+}
+
+func (s *DefaultBackendStorage) addBackendLocked(identifier string, idType header.IdentifierType, backend *Backend) {
 	if !containIDType(s.idTypes, idType) {
 		klog.V(3).InfoS("fail to add backend", "backend", identifier, "error", &ErrWrongIDType{idType, s.idTypes})
 		return
 	}
 	klog.V(2).InfoS("Register backend for agent", "agentID", identifier)
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	_, ok := s.backends[identifier]
 	if ok {
 		for _, b := range s.backends[identifier] {
@@ -276,6 +324,7 @@ func (s *DefaultBackendStorage) addBackend(identifier string, idType header.Iden
 		return
 	}
 	s.backends[identifier] = []*Backend{backend}
+	s.refreshNonDrainingIdentifierLocked(identifier)
 	metrics.Metrics.SetBackendCountDeprecated(len(s.backends))
 	metrics.Metrics.SetTotalBackendCount(s.proxyStrategy, len(s.backends))
 	s.agentIDs = append(s.agentIDs, identifier)
@@ -283,30 +332,39 @@ func (s *DefaultBackendStorage) addBackend(identifier string, idType header.Iden
 
 // removeBackend removes a backend.
 func (s *DefaultBackendStorage) removeBackend(identifier string, idType header.IdentifierType, backend *Backend) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.removeBackendLocked(identifier, idType, backend)
+}
+
+func (s *DefaultBackendStorage) removeBackendLocked(identifier string, idType header.IdentifierType, backend *Backend) {
 	if !containIDType(s.idTypes, idType) {
 		klog.ErrorS(&ErrWrongIDType{idType, s.idTypes}, "fail to remove backend")
 		return
 	}
 	klog.V(2).InfoS("Remove connection for agent", "agentID", identifier)
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	backends, ok := s.backends[identifier]
 	if !ok {
 		klog.V(1).InfoS("Cannot find agent in backends", "identifier", identifier)
 		return
 	}
 	var found bool
+	var removedFirst bool
 	for i, b := range backends {
 		if b == backend {
 			s.backends[identifier] = append(s.backends[identifier][:i], s.backends[identifier][i+1:]...)
 			if i == 0 && len(s.backends[identifier]) != 0 {
 				klog.V(1).InfoS("This should not happen. Removed connection that is not the first connection", "agentID", identifier)
 			}
+			if i == 0 {
+				removedFirst = true
+			}
 			found = true
 		}
 	}
 	if len(s.backends[identifier]) == 0 {
 		delete(s.backends, identifier)
+		s.removeNonDrainingIdentifierLocked(identifier)
 		for i := range s.agentIDs {
 			if s.agentIDs[i] == identifier {
 				s.agentIDs[i] = s.agentIDs[len(s.agentIDs)-1]
@@ -314,6 +372,8 @@ func (s *DefaultBackendStorage) removeBackend(identifier string, idType header.I
 				break
 			}
 		}
+	} else if removedFirst {
+		s.refreshNonDrainingIdentifierLocked(identifier)
 	}
 	if !found {
 		klog.V(1).InfoS("Could not find connection matching identifier to remove", "agentID", identifier, "idType", idType)
@@ -361,35 +421,30 @@ func (s *DefaultBackendStorage) GetRandomBackend() (*Backend, error) {
 		return nil, &ErrNotFound{}
 	}
 
-	var firstDrainingBackend *Backend
-
-	// Start at a random agent and check each agent in sequence
-	startIdx := s.random.Intn(len(s.agentIDs))
-	for i := 0; i < len(s.agentIDs); i++ {
-		// Wrap around using modulo
-		currentIdx := (startIdx + i) % len(s.agentIDs)
-		agentID := s.agentIDs[currentIdx]
-		// always return the first connection to an agent, because the agent
-		// will close later connections if there are multiple.
-		backend := s.backends[agentID][0]
-
-		if !backend.IsDraining() {
-			klog.V(3).InfoS("Pick agent as backend", "agentID", agentID)
-			return backend, nil
+	// Prefer random selection from known non-draining identifiers.
+	// This avoids a full scan on every selection.
+	for len(s.nonDrainingIDs) > 0 {
+		idx := s.random.Intn(len(s.nonDrainingIDs))
+		identifier := s.nonDrainingIDs[idx]
+		backends, ok := s.backends[identifier]
+		if !ok || len(backends) == 0 {
+			s.removeNonDrainingIdentifierLocked(identifier)
+			continue
 		}
-
-		// Keep track of first draining backend as fallback
-		if firstDrainingBackend == nil {
-			firstDrainingBackend = backend
+		backend := backends[0]
+		// A backend may have transitioned to draining since the pool was updated.
+		// Remove stale entries lazily and retry.
+		if backend.IsDraining() {
+			s.removeNonDrainingIdentifierLocked(identifier)
+			continue
 		}
+		klog.V(3).InfoS("Pick agent as backend", "agentID", identifier)
+		return backend, nil
 	}
 
 	// All agents are draining, use one as fallback
-	if firstDrainingBackend != nil {
-		agentID := firstDrainingBackend.id
-		klog.V(3).InfoS("No non-draining backends available, using draining backend as fallback", "agentID", agentID)
-		return firstDrainingBackend, nil
-	}
-
-	return nil, &ErrNotFound{}
+	agentID := s.agentIDs[s.random.Intn(len(s.agentIDs))]
+	backend := s.backends[agentID][0]
+	klog.V(3).InfoS("No non-draining backends available, using draining backend as fallback", "agentID", agentID)
+	return backend, nil
 }

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -68,6 +68,8 @@ func (b *Backend) SetDraining() {
 	b.draining.Store(true)
 }
 
+// Retire marks the backend as draining and closes Done once.
+// It does not remove the backend from its backend managers.
 func (b *Backend) Retire() {
 	b.SetDraining()
 	b.retireOnce.Do(func() {
@@ -184,10 +186,18 @@ type BackendManager interface {
 	Backend(ctx context.Context) (*Backend, error)
 	// AddBackend adds a backend.
 	AddBackend(backend *Backend)
-	// RemoveBackend adds a backend.
+	// RemoveBackend removes a backend.
 	RemoveBackend(backend *Backend)
 	BackendStorage
 	ReadinessManager
+}
+
+// backendDrainingMarker is implemented by managers that maintain an index of
+// non-draining backends and therefore need notification of state transitions.
+// The caller must publish the backend's draining state before notification;
+// implementations only reclassify their own index.
+type backendDrainingMarker interface {
+	markBackendDraining(backend *Backend)
 }
 
 var _ BackendManager = &DefaultBackendManager{}
@@ -208,6 +218,11 @@ func (dbm *DefaultBackendManager) AddBackend(backend *Backend) {
 	dbm.addBackend(agentID, header.UID, backend)
 }
 
+func (dbm *DefaultBackendManager) markBackendDraining(backend *Backend) {
+	agentID := backend.GetAgentID()
+	dbm.DefaultBackendStorage.markIdentifierBackendDraining(agentID, header.UID, backend)
+}
+
 func (dbm *DefaultBackendManager) RemoveBackend(backend *Backend) {
 	agentID := backend.GetAgentID()
 	klog.V(5).InfoS("Remove the agent from the DefaultBackendManager", "agentID", agentID)
@@ -225,12 +240,14 @@ type DefaultBackendStorage struct {
 	// TODO: fix documentation. This is not always agentID, e.g. in
 	// the case of DestHostBackendManager.
 	backends map[string][]*Backend
-	// agentID is tracked in this slice to enable randomly picking an
-	// agentID in the Backend() method. There is no reliable way to
-	// randomly pick a key from a map (in this case, the backends) in
-	// Golang.
-	agentIDs []string
-	random   *rand.Rand
+	// These slices are the candidate index used by random routing. Each
+	// registered agent ID appears in exactly one slice, classified by the
+	// draining state of backends[agentID][0]. Destination-host routing does not
+	// use this index.
+	nonDrainingAgentIDs        []string
+	drainingAgentIDs           []string
+	maintainRandomRoutingIndex bool
+	random                     *rand.Rand
 	// idTypes contains the valid identifier types for this
 	// DefaultBackendStorage. The DefaultBackendStorage may only tolerate certain
 	// types of identifiers when associating to a specific BackendManager,
@@ -258,15 +275,54 @@ func NewDefaultBackendStorage(idTypes []header.IdentifierType, proxyStrategy pro
 	metrics.Metrics.SetTotalBackendCount(proxyStrategy, 0)
 
 	return &DefaultBackendStorage{
-		backends:      make(map[string][]*Backend),
-		random:        rand.New(rand.NewSource(time.Now().UnixNano())), /* #nosec G404 */
-		idTypes:       idTypes,
+		backends: make(map[string][]*Backend),
+		random:   rand.New(rand.NewSource(time.Now().UnixNano())), /* #nosec G404 */
+		idTypes:  idTypes,
+		maintainRandomRoutingIndex: proxyStrategy == proxystrategies.ProxyStrategyDefault ||
+			proxyStrategy == proxystrategies.ProxyStrategyDefaultRoute,
 		proxyStrategy: proxyStrategy,
 	}
 }
 
 func containIDType(idTypes []header.IdentifierType, idType header.IdentifierType) bool {
 	return slices.Contains(idTypes, idType)
+}
+
+// removeIdentifier removes identifier by replacing it with the final element.
+// It does not preserve order.
+func removeIdentifier(identifiers []string, identifier string) []string {
+	for i := range identifiers {
+		if identifiers[i] == identifier {
+			identifiers[i] = identifiers[len(identifiers)-1]
+			return identifiers[:len(identifiers)-1]
+		}
+	}
+	return identifiers
+}
+
+// refreshIdentifierState reconciles identifier's routing-index membership with
+// its primary backend. An identifier with no backends is removed from both
+// lists; otherwise it belongs to exactly one list. The caller must hold s.mu.
+func (s *DefaultBackendStorage) refreshIdentifierState(identifier string) {
+	backends := s.backends[identifier]
+	if len(backends) == 0 {
+		s.nonDrainingAgentIDs = removeIdentifier(s.nonDrainingAgentIDs, identifier)
+		s.drainingAgentIDs = removeIdentifier(s.drainingAgentIDs, identifier)
+		return
+	}
+	if backends[0].IsDraining() {
+		s.nonDrainingAgentIDs = removeIdentifier(s.nonDrainingAgentIDs, identifier)
+		if slices.Contains(s.drainingAgentIDs, identifier) {
+			return
+		}
+		s.drainingAgentIDs = append(s.drainingAgentIDs, identifier)
+		return
+	}
+	s.drainingAgentIDs = removeIdentifier(s.drainingAgentIDs, identifier)
+	if slices.Contains(s.nonDrainingAgentIDs, identifier) {
+		return
+	}
+	s.nonDrainingAgentIDs = append(s.nonDrainingAgentIDs, identifier)
 }
 
 // addBackend adds a backend.
@@ -290,9 +346,32 @@ func (s *DefaultBackendStorage) addBackend(identifier string, idType header.Iden
 		return
 	}
 	s.backends[identifier] = []*Backend{backend}
+	if s.maintainRandomRoutingIndex {
+		if backend.IsDraining() {
+			s.drainingAgentIDs = append(s.drainingAgentIDs, identifier)
+		} else {
+			s.nonDrainingAgentIDs = append(s.nonDrainingAgentIDs, identifier)
+		}
+	}
 	metrics.Metrics.SetBackendCountDeprecated(len(s.backends))
 	metrics.Metrics.SetTotalBackendCount(s.proxyStrategy, len(s.backends))
-	s.agentIDs = append(s.agentIDs, identifier)
+}
+
+// markIdentifierBackendDraining moves an identifier only when backend is its
+// primary connection. A draining secondary affects routing only if it is later
+// promoted.
+func (s *DefaultBackendStorage) markIdentifierBackendDraining(identifier string, idType header.IdentifierType, backend *Backend) {
+	if !containIDType(s.idTypes, idType) {
+		klog.ErrorS(&ErrWrongIDType{idType, s.idTypes}, "fail to mark backend draining")
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	backends, ok := s.backends[identifier]
+	if !ok || len(backends) == 0 || backends[0] != backend {
+		return
+	}
+	s.refreshIdentifierState(identifier)
 }
 
 // removeBackend removes a backend.
@@ -321,13 +400,9 @@ func (s *DefaultBackendStorage) removeBackend(identifier string, idType header.I
 	}
 	if len(s.backends[identifier]) == 0 {
 		delete(s.backends, identifier)
-		for i := range s.agentIDs {
-			if s.agentIDs[i] == identifier {
-				s.agentIDs[i] = s.agentIDs[len(s.agentIDs)-1]
-				s.agentIDs = s.agentIDs[:len(s.agentIDs)-1]
-				break
-			}
-		}
+	}
+	if s.maintainRandomRoutingIndex {
+		s.refreshIdentifierState(identifier)
 	}
 	if !found {
 		klog.V(1).InfoS("Could not find connection matching identifier to remove", "agentID", identifier, "idType", idType)
@@ -367,7 +442,8 @@ func ignoreNotFound(err error) error {
 	return err
 }
 
-// GetRandomBackend returns a random backend connection from all connected agents.
+// GetRandomBackend returns a random non-draining backend, falling back to a
+// random draining backend only when no non-draining agents are available.
 func (s *DefaultBackendStorage) GetRandomBackend() (*Backend, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -375,34 +451,25 @@ func (s *DefaultBackendStorage) GetRandomBackend() (*Backend, error) {
 		return nil, &ErrNotFound{}
 	}
 
-	var firstDrainingBackend *Backend
-
-	// Start at a random agent and check each agent in sequence
-	startIdx := s.random.Intn(len(s.agentIDs))
-	for i := 0; i < len(s.agentIDs); i++ {
-		// Wrap around using modulo
-		currentIdx := (startIdx + i) % len(s.agentIDs)
-		agentID := s.agentIDs[currentIdx]
-		// always return the first connection to an agent, because the agent
-		// will close later connections if there are multiple.
+	for len(s.nonDrainingAgentIDs) > 0 {
+		index := s.random.Intn(len(s.nonDrainingAgentIDs))
+		agentID := s.nonDrainingAgentIDs[index]
 		backend := s.backends[agentID][0]
-
-		if !backend.IsDraining() {
-			klog.V(3).InfoS("Pick agent as backend", "agentID", agentID)
-			return backend, nil
+		// SetDraining publishes before each manager updates its state lists.
+		// Repair that short-lived stale entry instead of routing to it.
+		if backend.IsDraining() {
+			s.refreshIdentifierState(agentID)
+			continue
 		}
-
-		// Keep track of first draining backend as fallback
-		if firstDrainingBackend == nil {
-			firstDrainingBackend = backend
-		}
+		klog.V(3).InfoS("Pick agent as backend", "agentID", agentID)
+		return backend, nil
 	}
 
-	// All agents are draining, use one as fallback
-	if firstDrainingBackend != nil {
-		agentID := firstDrainingBackend.id
+	if len(s.drainingAgentIDs) > 0 {
+		agentID := s.drainingAgentIDs[s.random.Intn(len(s.drainingAgentIDs))]
+		backend := s.backends[agentID][0]
 		klog.V(3).InfoS("No non-draining backends available, using draining backend as fallback", "agentID", agentID)
-		return firstDrainingBackend, nil
+		return backend, nil
 	}
 
 	return nil, &ErrNotFound{}

--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -39,6 +40,17 @@ func mockAgentConn(ctrl *gomock.Controller, agentID string, agentIdentifiers []s
 	agentConnCtx := metadata.NewIncomingContext(context.Background(), agentConnMD)
 	agentConn.EXPECT().Context().Return(agentConnCtx).AnyTimes()
 	return agentConn
+}
+
+func expectedBackendIndex(backends map[string][]*Backend) map[string]map[*Backend]int {
+	index := make(map[string]map[*Backend]int, len(backends))
+	for identifier, bes := range backends {
+		index[identifier] = make(map[*Backend]int, len(bes))
+		for i, backend := range bes {
+			index[identifier][backend] = i
+		}
+	}
+	return index
 }
 
 func TestNewBackend(t *testing.T) {
@@ -384,6 +396,74 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 	}
 }
 
+func TestDestHostBackendManager_NonDrainingCacheTracksCurrentBackends(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	backend1, _ := NewBackend(mockAgentConn(ctrl, "agent1", []string{"host=localhost"}))
+	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{"host=localhost"}))
+	backend2.SetDraining()
+	backend3, _ := NewBackend(mockAgentConn(ctrl, "agent3", []string{"host=localhost"}))
+
+	p := NewDestHostBackendManager()
+
+	p.AddBackend(backend1)
+	p.AddBackend(backend2)
+
+	expectedBackends := map[string][]*Backend{
+		"localhost": {backend1, backend2},
+	}
+	expectedNonDraining := map[string][]*Backend{
+		"localhost": {backend1},
+	}
+
+	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedNonDraining, p.nonDrainingBackends; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedBackendIndex(expectedNonDraining), p.nonDrainingIndex; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+
+	p.RemoveBackend(backend1)
+
+	expectedBackends = map[string][]*Backend{
+		"localhost": {backend2},
+	}
+	expectedNonDraining = map[string][]*Backend{}
+
+	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedNonDraining, p.nonDrainingBackends; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedBackendIndex(expectedNonDraining), p.nonDrainingIndex; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+
+	p.AddBackend(backend3)
+
+	expectedBackends = map[string][]*Backend{
+		"localhost": {backend2, backend3},
+	}
+	expectedNonDraining = map[string][]*Backend{
+		"localhost": {backend3},
+	}
+
+	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedNonDraining, p.nonDrainingBackends; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := expectedBackendIndex(expectedNonDraining), p.nonDrainingIndex; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+}
+
 func TestDefaultBackendManager_GetRandomBackend_DrainingFallback(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -441,6 +521,44 @@ func TestDefaultBackendManager_GetRandomBackend_DrainingFallback(t *testing.T) {
 	}
 	if !b.IsDraining() {
 		t.Error("expected draining backend as fallback")
+	}
+}
+
+func TestDefaultBackendManager_GetRandomBackend_LazilyEvictsDrainingCandidate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	backend1, _ := NewBackend(mockAgentConn(ctrl, "agent1", []string{}))
+	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{}))
+
+	p := NewDefaultBackendManager()
+	// Seed so the first selection checks the stale entry for agent1.
+	p.random = rand.New(rand.NewSource(0))
+
+	p.AddBackend(backend1)
+	p.AddBackend(backend2)
+
+	if e, a := []string{"agent1", "agent2"}, p.nonDrainingIDs; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := map[string]int{"agent1": 0, "agent2": 1}, p.nonDrainingIndex; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+
+	backend1.SetDraining()
+
+	b, err := p.Backend(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b != backend2 {
+		t.Fatalf("expected backend2 after lazy eviction, got %v", b)
+	}
+	if e, a := []string{"agent2"}, p.nonDrainingIDs; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
+	}
+	if e, a := map[string]int{"agent2": 0}, p.nonDrainingIndex; !reflect.DeepEqual(e, a) {
+		t.Fatalf("expected %v, got %v", e, a)
 	}
 }
 
@@ -510,5 +628,91 @@ func TestDestHostBackendManager_Backend_DrainingFallback(t *testing.T) {
 	}
 	if b.IsDraining() {
 		t.Error("expected non-draining backend for otherhost")
+	}
+}
+
+func TestDefaultBackendManager_GetRandomBackend_DistributesAcrossNonDrainingCandidates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	backend1, _ := NewBackend(mockAgentConn(ctrl, "agent1", []string{}))
+	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{}))
+	backend3, _ := NewBackend(mockAgentConn(ctrl, "agent3", []string{}))
+
+	p := NewDefaultBackendManager()
+	// Use a deterministic random source so this test is stable.
+	p.random = rand.New(rand.NewSource(7))
+
+	p.AddBackend(backend1)
+	p.AddBackend(backend2)
+	p.AddBackend(backend3)
+	backend1.SetDraining()
+
+	const iterations = 6000
+	counts := map[*Backend]int{
+		backend2: 0,
+		backend3: 0,
+	}
+
+	for i := 0; i < iterations; i++ {
+		b, err := p.Backend(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if b == backend1 {
+			t.Fatalf("expected non-draining backend, got draining backend1")
+		}
+		counts[b]++
+	}
+
+	diff := counts[backend2] - counts[backend3]
+	if diff < 0 {
+		diff = -diff
+	}
+	// With random selection from the non-draining set, distribution should be
+	// approximately even. Allow 5% skew to avoid flakiness.
+	if diff > iterations/20 {
+		t.Fatalf("expected near-even distribution across non-draining backends, got backend2=%d backend3=%d", counts[backend2], counts[backend3])
+	}
+}
+
+func TestDestHostBackendManager_Backend_DistributesAcrossNonDrainingCandidates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	backend1, _ := NewBackend(mockAgentConn(ctrl, "agent1", []string{"host=localhost"}))
+	backend2, _ := NewBackend(mockAgentConn(ctrl, "agent2", []string{"host=localhost"}))
+
+	p := NewDestHostBackendManager()
+	// Use a deterministic random source so this test is stable.
+	p.random = rand.New(rand.NewSource(11))
+
+	p.AddBackend(backend1)
+	p.AddBackend(backend2)
+
+	ctx := context.WithValue(context.Background(), destHostKey, "localhost")
+
+	const iterations = 6000
+	counts := map[*Backend]int{
+		backend1: 0,
+		backend2: 0,
+	}
+
+	for i := 0; i < iterations; i++ {
+		b, err := p.Backend(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		counts[b]++
+	}
+
+	diff := counts[backend1] - counts[backend2]
+	if diff < 0 {
+		diff = -diff
+	}
+	// With random selection from non-draining candidates, distribution should
+	// be approximately even. Allow 5% skew to avoid flakiness.
+	if diff > iterations/20 {
+		t.Fatalf("expected near-even distribution across non-draining backends, got backend1=%d backend2=%d", counts[backend1], counts[backend2])
 	}
 }

--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -41,6 +41,24 @@ func mockAgentConn(ctrl *gomock.Controller, agentID string, agentIdentifiers []s
 	return agentConn
 }
 
+func assertAgentIDs(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("agent IDs = %v, want %v", got, want)
+	}
+	gotSet := make(map[string]struct{}, len(got))
+	for _, agentID := range got {
+		gotSet[agentID] = struct{}{}
+	}
+	wantSet := make(map[string]struct{}, len(want))
+	for _, agentID := range want {
+		wantSet[agentID] = struct{}{}
+	}
+	if !reflect.DeepEqual(gotSet, wantSet) {
+		t.Fatalf("agent IDs = %v, want %v", got, want)
+	}
+}
+
 func TestNewBackend(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -124,7 +142,7 @@ func TestDefaultBackendManager_AddRemoveBackends(t *testing.T) {
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+	if e, a := expectedAgentIDs, p.nonDrainingAgentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -147,9 +165,53 @@ func TestDefaultBackendManager_AddRemoveBackends(t *testing.T) {
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+	if e, a := expectedAgentIDs, p.nonDrainingAgentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+}
+
+func TestDefaultBackendManager_AgentListsFollowPrimaryBackendState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	primary, _ := NewBackend(mockAgentConn(ctrl, "agent1", nil))
+	drainingReplacement, _ := NewBackend(mockAgentConn(ctrl, "agent1", nil))
+	healthyReplacement, _ := NewBackend(mockAgentConn(ctrl, "agent1", nil))
+	drainingAgent, _ := NewBackend(mockAgentConn(ctrl, "agent2", nil))
+	drainingAgent.SetDraining()
+
+	manager := NewDefaultBackendManager()
+	manager.AddBackend(primary)
+	manager.AddBackend(drainingReplacement)
+	manager.AddBackend(healthyReplacement)
+	manager.AddBackend(drainingAgent)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs, "agent1")
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent2")
+
+	// Draining a secondary connection does not change the agent's state while
+	// its non-draining primary remains selected.
+	drainingReplacement.SetDraining()
+	manager.markBackendDraining(drainingReplacement)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs, "agent1")
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent2")
+
+	primary.SetDraining()
+	manager.markBackendDraining(primary)
+	manager.markBackendDraining(primary) // The state transition is idempotent.
+	assertAgentIDs(t, manager.nonDrainingAgentIDs)
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent1", "agent2")
+
+	// Removing primaries reclassifies the agent according to the promoted
+	// connection rather than retaining the removed primary's state.
+	manager.RemoveBackend(primary)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs)
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent1", "agent2")
+	manager.RemoveBackend(drainingReplacement)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs, "agent1")
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent2")
+
+	manager.RemoveBackend(healthyReplacement)
+	manager.RemoveBackend(drainingAgent)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs)
+	assertAgentIDs(t, manager.drainingAgentIDs)
 }
 
 func TestDefaultRouteBackendManager_AddRemoveBackends(t *testing.T) {
@@ -171,7 +233,7 @@ func TestDefaultRouteBackendManager_AddRemoveBackends(t *testing.T) {
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+	if e, a := expectedAgentIDs, p.nonDrainingAgentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -196,9 +258,35 @@ func TestDefaultRouteBackendManager_AddRemoveBackends(t *testing.T) {
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+	if e, a := expectedAgentIDs, p.nonDrainingAgentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+}
+
+func TestDefaultBackendManager_SelectionRepairsDirectRetirement(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	retired, _ := NewBackend(mockAgentConn(ctrl, "retired", nil))
+	healthy, _ := NewBackend(mockAgentConn(ctrl, "healthy", nil))
+
+	manager := NewDefaultBackendManager()
+	manager.AddBackend(retired)
+	manager.AddBackend(healthy)
+
+	// Some lifecycle paths publish retirement immediately and remove the
+	// backend from its managers shortly afterward. Selection must repair the
+	// classification during that interval.
+	retired.Retire()
+	for i := 0; i < 20; i++ {
+		got, err := manager.Backend(context.Background())
+		if err != nil {
+			t.Fatalf("Backend failed: %v", err)
+		}
+		if got != healthy {
+			t.Fatalf("Backend returned retired backend %q, want %q", got.id, healthy.id)
+		}
+	}
+	assertAgentIDs(t, manager.nonDrainingAgentIDs, "healthy")
+	assertAgentIDs(t, manager.drainingAgentIDs, "retired")
 }
 
 func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
@@ -216,11 +304,7 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 	p.AddBackend(backend1)
 	p.RemoveBackend(backend1)
 	expectedBackends := make(map[string][]*Backend)
-	expectedAgentIDs := []string{}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -233,17 +317,7 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 		"9878::7675:1292:9183:7562": {backend1},
 		"node1.mydomain.com":        {backend1},
 	}
-	expectedAgentIDs = []string{
-		"1.2.3.4",
-		"9878::7675:1292:9183:7562",
-		"localhost",
-		"node1.mydomain.com",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -259,22 +333,11 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 		"9878::7675:1292:9183:7562": {backend1},
 		"::":                        {backend3},
 	}
-	expectedAgentIDs = []string{
-		"1.2.3.4",
-		"9878::7675:1292:9183:7562",
-		"localhost",
-		"node1.mydomain.com",
-		"5.6.7.8",
-		"::",
-		"node2.mydomain.com",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
+	assertAgentIDs(t, p.nonDrainingAgentIDs)
+	assertAgentIDs(t, p.drainingAgentIDs)
 
 	p.RemoveBackend(backend2)
 	p.RemoveBackend(backend1)
@@ -284,27 +347,14 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 		"5.6.7.8":            {backend3},
 		"::":                 {backend3},
 	}
-	expectedAgentIDs = []string{
-		"node2.mydomain.com",
-		"::",
-		"5.6.7.8",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
 	p.RemoveBackend(backend3)
 	expectedBackends = map[string][]*Backend{}
-	expectedAgentIDs = []string{}
 
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }
@@ -332,22 +382,11 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 		"node1.mydomain.com":        {backend1, backend2},
 		"node2.mydomain.com":        {backend3},
 	}
-	expectedAgentIDs := []string{
-		"1.2.3.4",
-		"9878::7675:1292:9183:7562",
-		"localhost",
-		"node1.mydomain.com",
-		"5.6.7.8",
-		"::",
-		"node2.mydomain.com",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
+	assertAgentIDs(t, p.nonDrainingAgentIDs)
+	assertAgentIDs(t, p.drainingAgentIDs)
 
 	p.RemoveBackend(backend1)
 	p.RemoveBackend(backend3)
@@ -358,28 +397,14 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 		"9878::7675:1292:9183:7562": {backend2},
 		"node1.mydomain.com":        {backend2},
 	}
-	expectedAgentIDs = []string{
-		"1.2.3.4",
-		"9878::7675:1292:9183:7562",
-		"localhost",
-		"node1.mydomain.com",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
 	p.RemoveBackend(backend2)
 	expectedBackends = map[string][]*Backend{}
-	expectedAgentIDs = []string{}
 
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }
@@ -416,6 +441,7 @@ func TestDefaultBackendManager_GetRandomBackend_DrainingFallback(t *testing.T) {
 
 	// Test 3: When some backends are draining, non-draining ones are prioritized
 	backend1.SetDraining()
+	p.markBackendDraining(backend1)
 
 	// Call multiple times to ensure we never get the draining backend
 	for i := 0; i < 20; i++ {
@@ -430,7 +456,9 @@ func TestDefaultBackendManager_GetRandomBackend_DrainingFallback(t *testing.T) {
 
 	// Test 4: When all backends are draining, fallback to a draining backend
 	backend2.SetDraining()
+	p.markBackendDraining(backend2)
 	backend3.SetDraining()
+	p.markBackendDraining(backend3)
 
 	b, err = p.Backend(context.Background())
 	if err != nil {

--- a/pkg/server/default_route_backend_manager.go
+++ b/pkg/server/default_route_backend_manager.go
@@ -50,6 +50,13 @@ func (dibm *DefaultRouteBackendManager) AddBackend(backend *Backend) {
 	}
 }
 
+func (dibm *DefaultRouteBackendManager) markBackendDraining(backend *Backend) {
+	agentID := backend.GetAgentID()
+	if backend.GetAgentIdentifiers().DefaultRoute {
+		dibm.DefaultBackendStorage.markIdentifierBackendDraining(agentID, header.DefaultRoute, backend)
+	}
+}
+
 func (dibm *DefaultRouteBackendManager) RemoveBackend(backend *Backend) {
 	agentID := backend.GetAgentID()
 	agentIdentifiers := backend.GetAgentIdentifiers()

--- a/pkg/server/desthost_backend_manager.go
+++ b/pkg/server/desthost_backend_manager.go
@@ -26,6 +26,11 @@ import (
 
 type DestHostBackendManager struct {
 	*DefaultBackendStorage
+	// nonDrainingBackends tracks non-draining backends per destination host.
+	// This avoids scanning all candidate backends on each request.
+	nonDrainingBackends map[string][]*Backend
+	// nonDrainingIndex tracks backend index positions for O(1) removals.
+	nonDrainingIndex map[string]map[*Backend]int
 }
 
 var _ BackendManager = &DestHostBackendManager{}
@@ -33,71 +38,127 @@ var _ BackendManager = &DestHostBackendManager{}
 func NewDestHostBackendManager() *DestHostBackendManager {
 	return &DestHostBackendManager{
 		DefaultBackendStorage: NewDefaultBackendStorage(
-			[]header.IdentifierType{header.IPv4, header.IPv6, header.Host}, proxystrategies.ProxyStrategyDestHost)}
+			[]header.IdentifierType{header.IPv4, header.IPv6, header.Host}, proxystrategies.ProxyStrategyDestHost),
+		nonDrainingBackends: make(map[string][]*Backend),
+		nonDrainingIndex:    make(map[string]map[*Backend]int),
+	}
+}
+
+func (dibm *DestHostBackendManager) addNonDrainingBackendLocked(identifier string, backend *Backend) {
+	backendIndexByIdentifier, ok := dibm.nonDrainingIndex[identifier]
+	if !ok {
+		backendIndexByIdentifier = make(map[*Backend]int)
+		dibm.nonDrainingIndex[identifier] = backendIndexByIdentifier
+	}
+	if _, ok := backendIndexByIdentifier[backend]; ok {
+		return
+	}
+	dibm.nonDrainingBackends[identifier] = append(dibm.nonDrainingBackends[identifier], backend)
+	backendIndexByIdentifier[backend] = len(dibm.nonDrainingBackends[identifier]) - 1
+}
+
+func (dibm *DestHostBackendManager) removeNonDrainingBackendLocked(identifier string, backend *Backend) {
+	backendIndexByIdentifier, ok := dibm.nonDrainingIndex[identifier]
+	if !ok {
+		return
+	}
+	idx, ok := backendIndexByIdentifier[backend]
+	if !ok {
+		return
+	}
+
+	lastIdx := len(dibm.nonDrainingBackends[identifier]) - 1
+	if idx != lastIdx {
+		lastBackend := dibm.nonDrainingBackends[identifier][lastIdx]
+		dibm.nonDrainingBackends[identifier][idx] = lastBackend
+		backendIndexByIdentifier[lastBackend] = idx
+	}
+	dibm.nonDrainingBackends[identifier] = dibm.nonDrainingBackends[identifier][:lastIdx]
+	delete(backendIndexByIdentifier, backend)
+
+	if len(dibm.nonDrainingBackends[identifier]) == 0 {
+		delete(dibm.nonDrainingBackends, identifier)
+		delete(dibm.nonDrainingIndex, identifier)
+	}
+}
+
+func (dibm *DestHostBackendManager) addBackendForIdentifierLocked(identifier string, idType header.IdentifierType, backend *Backend, isDraining bool) {
+	dibm.addBackendLocked(identifier, idType, backend)
+	if !isDraining {
+		dibm.addNonDrainingBackendLocked(identifier, backend)
+	}
+}
+
+func (dibm *DestHostBackendManager) removeBackendForIdentifierLocked(identifier string, idType header.IdentifierType, backend *Backend) {
+	dibm.removeBackendLocked(identifier, idType, backend)
+	dibm.removeNonDrainingBackendLocked(identifier, backend)
 }
 
 func (dibm *DestHostBackendManager) AddBackend(backend *Backend) {
+	isDraining := backend.IsDraining()
 	agentIdentifiers := backend.GetAgentIdentifiers()
+	dibm.mu.Lock()
+	defer dibm.mu.Unlock()
 	for _, ipv4 := range agentIdentifiers.IPv4 {
 		klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", ipv4)
-		dibm.addBackend(ipv4, header.IPv4, backend)
+		dibm.addBackendForIdentifierLocked(ipv4, header.IPv4, backend, isDraining)
 	}
 	for _, ipv6 := range agentIdentifiers.IPv6 {
 		klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", ipv6)
-		dibm.addBackend(ipv6, header.IPv6, backend)
+		dibm.addBackendForIdentifierLocked(ipv6, header.IPv6, backend, isDraining)
 	}
 	for _, host := range agentIdentifiers.Host {
 		klog.V(5).InfoS("Add the agent to DestHostBackendManager", "agent address", host)
-		dibm.addBackend(host, header.Host, backend)
+		dibm.addBackendForIdentifierLocked(host, header.Host, backend, isDraining)
 	}
 }
 
 func (dibm *DestHostBackendManager) RemoveBackend(backend *Backend) {
 	agentIdentifiers := backend.GetAgentIdentifiers()
+	dibm.mu.Lock()
+	defer dibm.mu.Unlock()
 	for _, ipv4 := range agentIdentifiers.IPv4 {
 		klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", ipv4)
-		dibm.removeBackend(ipv4, header.IPv4, backend)
+		dibm.removeBackendForIdentifierLocked(ipv4, header.IPv4, backend)
 	}
 	for _, ipv6 := range agentIdentifiers.IPv6 {
 		klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", ipv6)
-		dibm.removeBackend(ipv6, header.IPv6, backend)
+		dibm.removeBackendForIdentifierLocked(ipv6, header.IPv6, backend)
 	}
 	for _, host := range agentIdentifiers.Host {
 		klog.V(5).InfoS("Remove the agent from the DestHostBackendManager", "agentHost", host)
-		dibm.removeBackend(host, header.Host, backend)
+		dibm.removeBackendForIdentifierLocked(host, header.Host, backend)
 	}
 }
 
 // Backend tries to get a backend associating to the request destination host.
 func (dibm *DestHostBackendManager) Backend(ctx context.Context) (*Backend, error) {
-	dibm.mu.RLock()
-	defer dibm.mu.RUnlock()
+	dibm.mu.Lock()
+	defer dibm.mu.Unlock()
 	if len(dibm.backends) == 0 {
 		return nil, &ErrNotFound{}
 	}
-	destHost := ctx.Value(destHostKey).(string)
+	destHost, _ := ctx.Value(destHostKey).(string)
 	if destHost != "" {
+		// Prefer random selection from known non-draining backends.
+		// Remove stale entries lazily when backends transition to draining.
+		for len(dibm.nonDrainingBackends[destHost]) > 0 {
+			idx := dibm.random.Intn(len(dibm.nonDrainingBackends[destHost]))
+			backend := dibm.nonDrainingBackends[destHost][idx]
+			if backend.IsDraining() {
+				dibm.removeNonDrainingBackendLocked(destHost, backend)
+				continue
+			}
+			klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
+			return backend, nil
+		}
+
+		// All backends for this destination are draining, use one as fallback.
 		bes, exist := dibm.backends[destHost]
 		if exist && len(bes) > 0 {
-			var firstDrainingBackend *Backend
-
-			// Find a non-draining backend for this destination host
-			for _, backend := range bes {
-				if !backend.IsDraining() {
-					klog.V(5).InfoS("Get the backend through the DestHostBackendManager", "destHost", destHost)
-					return backend, nil
-				}
-				// Keep track of first draining backend as fallback
-				if firstDrainingBackend == nil {
-					firstDrainingBackend = backend
-				}
-			}
-
-			// All backends for this destination are draining, use one as fallback
-			if firstDrainingBackend != nil {
-				klog.V(3).InfoS("All backends for destination host are draining, using one as fallback", "destHost", destHost)
-				return firstDrainingBackend, nil
-			}
+			backend := bes[dibm.random.Intn(len(bes))]
+			klog.V(3).InfoS("All backends for destination host are draining, using one as fallback", "destHost", destHost)
+			return backend, nil
 		}
 	}
 	return nil, &ErrNotFound{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -390,6 +390,17 @@ func (s *ProxyServer) addBackend(backend *Backend) {
 	}
 }
 
+func (s *ProxyServer) markBackendDraining(backend *Backend) {
+	// Publish the state before notifying managers so concurrent selection can
+	// reject or repair a stale non-draining index entry.
+	backend.SetDraining()
+	for _, bm := range s.BackendManagers {
+		if marker, ok := bm.(backendDrainingMarker); ok {
+			marker.markBackendDraining(backend)
+		}
+	}
+}
+
 func (s *ProxyServer) removeBackend(backend *Backend) {
 	for _, bm := range s.BackendManagers {
 		bm.RemoveBackend(backend)
@@ -1109,7 +1120,7 @@ func (s *ProxyServer) serveRecvBackend(backend *Backend, agentID string, recvCh 
 
 		case client.PacketType_DRAIN:
 			klog.V(2).InfoS("agent is draining", "agentID", agentID)
-			backend.SetDraining()
+			s.markBackendDraining(backend)
 			klog.V(2).InfoS("marked backend as draining, will not route new requests to this agent", "agentID", agentID)
 		default:
 			klog.V(5).InfoS("Ignoring unrecognized packet from backend", "packet", pkt, "agentID", agentID)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -327,6 +327,28 @@ func TestHTTPConnectTunnelBlockedBackendDialSendTimesOutCleansPendingDialAndReti
 	}
 }
 
+func TestBackendDrainPacketReclassifiesAgent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	backend, err := NewBackend(mockAgentConn(ctrl, "agent1", nil))
+	if err != nil {
+		t.Fatalf("NewBackend failed: %v", err)
+	}
+	manager := NewDefaultBackendManager()
+	manager.AddBackend(backend)
+	proxyServer := &ProxyServer{
+		BackendManagers: []BackendManager{manager},
+		established:     map[string]map[int64]*ProxyClientConnection{"agent1": {}},
+	}
+	recvCh := make(chan *client.Packet, 1)
+	recvCh <- &client.Packet{Type: client.PacketType_DRAIN}
+	close(recvCh)
+
+	proxyServer.serveRecvBackend(backend, "agent1", recvCh)
+
+	assertAgentIDs(t, manager.nonDrainingAgentIDs)
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent1")
+}
+
 func TestAddRemoveFrontends(t *testing.T) {
 	agent1ConnID1 := new(ProxyClientConnection)
 	agent1ConnID2 := new(ProxyClientConnection)


### PR DESCRIPTION
Track non-draining backend candidates so selection avoids scanning and
does not route new requests to draining backends when healthy choices
exist.

```
go test ./pkg/server -count=1
go test ./pkg/server -race -run Test(DefaultBackendManager_GetRandomBackend_LazilyEvictsDrainingCandidate|DestHostBackendManager_Backend_DrainingFallback|DestHostBackendManager_Backend_DistributesAcrossNonDrainingCandidates|DestHostBackendManager_NonDrainingCacheTracksCurrentBackends)$'
-count=1
```
