### PR TITLE
Prevent dependabot from updating konnectivity-client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     interval: weekly
 - package-ecosystem: gomod
   directory: /
+  exclude-paths:
+    - "konnectivity-client/**"
   schedule:
     interval: weekly
   groups:


### PR DESCRIPTION
konnectivity-client should be in line with the oldest supported K/K. 
It should be ok for K/K to push newer libraries than ANP. 
That is what we expect to happen on newer K/K releases. 
ANP should not be forcing upgrades on K/K.