### PR TITLE
Upgrade to go v1.26

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -11,8 +11,8 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: v1.24.7
-  GOLANGCI_LINT_VERSION: v2.1.6
+  GO_VERSION: v1.26.2
+  GOLANGCI_LINT_VERSION: v2.9.0
 
 jobs:
   golangci:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ ALL_ARCH ?= amd64 arm arm64 ppc64le s390x
 # The output type could either be docker (local), or registry.
 OUTPUT_TYPE ?= docker
 GO_TOOLCHAIN ?= golang
-GO_VERSION ?= 1.24.7
+GO_VERSION ?= 1.26.2
+GOTOOLCHAIN ?= go$(GO_VERSION)+auto
+export GOTOOLCHAIN
 BASEIMAGE ?= gcr.io/distroless/static-debian12:nonroot
 
 ifeq ($(GOPATH),)
@@ -33,7 +35,7 @@ endif
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 INSTALL_LOCATION:=$(shell go env GOPATH)/bin
-GOLANGCI_LINT_VERSION ?= 2.1.6
+GOLANGCI_LINT_VERSION ?= 2.9.0
 GOSEC_VERSION ?= 2.13.1
 
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
@@ -82,7 +84,10 @@ fast-test:
 # Unit tests with fuller coverage, invoked by CI system.
 .PHONY: test
 test:
-	go test -v -mod=vendor -race -covermode=atomic -coverprofile=konnectivity.out $(shell go list ./... | grep -v -e "/e2e$$" -e "/e2e/.*") && go tool cover -html=konnectivity.out -o=konnectivity.html
+	$(eval TEST_LIST := $(shell go list -test ./... | egrep " \[.*\]" | cut -d' ' -f1 | grep -v -e "/e2e$$" -e "/e2e/.*"))
+	echo "Running tests on $(TEST_LIST)"
+	$(info GOTOOLCHAIN is $(GOTOOLCHAIN))
+	go test -v -mod=vendor -race -covermode=atomic -coverprofile=konnectivity.out $(TEST_LIST) && go tool cover -html=konnectivity.out -o=konnectivity.html
 	cd konnectivity-client && go test -race -covermode=atomic -coverprofile=client.out ./... && go tool cover -html=client.out -o=client.html
 
 .PHONY: test-integration

--- a/cmd/test-client/main.go
+++ b/cmd/test-client/main.go
@@ -122,7 +122,7 @@ func (o *GrpcProxyClientOptions) Print() {
 	klog.V(1).Infof("ProxyHost set to %q.\n", o.proxyHost)
 	klog.V(1).Infof("ProxyPort set to %d.\n", o.proxyPort)
 	klog.V(1).Infof("ProxyUdsName set to %q.\n", o.proxyUdsName)
-	klog.V(1).Infof("TestRequests set to %q.\n", o.testRequests)
+	klog.V(1).Infof("TestRequests set to %d.\n", o.testRequests)
 	klog.V(1).Infof("TestDelaySec set to %d.\n", o.testDelaySec)
 	klog.V(1).Infof("AfterDelaySec set to %d.\n", o.afterDelaySec)
 	klog.V(1).Infof("CloseIdleConn set to %t.\n", o.closeIdleConn)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/apiserver-network-proxy
 
-go 1.24.7
+go 1.26.2
 
 require (
 	github.com/google/uuid v1.6.0

--- a/pkg/agent/metrics/metrics.go
+++ b/pkg/agent/metrics/metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package metrics //nolint:revive
 
 import (
 	"strconv"

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package metrics //nolint:revive
 
 import (
 	"strconv"

--- a/pkg/testing/leases.go
+++ b/pkg/testing/leases.go
@@ -1,4 +1,4 @@
-package testing
+package testing //nolint:revive
 
 import (
 	"time"

--- a/pkg/testing/metrics/metrics.go
+++ b/pkg/testing/metrics/metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testing
+package testing //nolint:revive
 
 import (
 	"fmt"

--- a/pkg/util/certificates.go
+++ b/pkg/util/certificates.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package util //nolint:revive
 
 import (
 	"crypto/tls"

--- a/pkg/util/flags.go
+++ b/pkg/util/flags.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package util //nolint:revive
 
 import "strings"
 

--- a/pkg/util/handlers.go
+++ b/pkg/util/handlers.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package util //nolint:revive
 
 import "net/http"
 

--- a/pkg/util/leases.go
+++ b/pkg/util/leases.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package util
+package util //nolint:revive
 
 import (
 	"time"

--- a/pkg/util/leases_test.go
+++ b/pkg/util/leases_test.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package util
+package util //nolint:revive
 
 import (
 	"testing"

--- a/pkg/util/net.go
+++ b/pkg/util/net.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package util //nolint:revive
 
 import (
 	"crypto/tls"

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package util //nolint:revive
 
 import (
 	"testing"

--- a/pkg/util/url.go
+++ b/pkg/util/url.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package util //nolint:revive
 
 import (
 	"bytes"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,4 +1,4 @@
-package util
+package util //nolint:revive
 
 import (
 	"fmt"

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,4 +1,4 @@
-package util
+package util //nolint:revive
 
 import (
 	"testing"


### PR DESCRIPTION
Prompt:
please upgrade the top level go.mod to use go version 1.26.0. Ensure all the tests pass. Do not make changes in
   konnectivity-client.