### PR TITLE
cloudbuild: pin gcb-docker-gcloud image (fix manifest unknown after GC)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,8 @@ timeout: 9000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
+  # v20260205-38cfa9523f (digest-pinned; see kubernetes/kubernetes#138936)
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2'
     entrypoint: bash
     env:
     - TAG=$_GIT_TAG


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it

The staging registry retention policy has removed older
`gcr.io/k8s-staging-test-infra/gcb-docker-gcloud` tags. The previous tag
(`v20211118-2f2d816b90`) can fail Cloud Build with `manifest unknown`.

Pin the builder image by digest and document the semantic tag in a comment
so post-submit image jobs stay reliable across future retention sweeps.

#### Which issue(s) this PR fixes

Related: https://github.com/kubernetes/kubernetes/issues/138936