### PR TITLE
Add configurable timeout for pending backend dials

### DIFF
--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -122,6 +122,8 @@ type ProxyRunOptions struct {
 	NeedsKubernetesClient bool
 	// Graceful shutdown timeout duration
 	GracefulShutdownTimeout time.Duration
+	// Backend dial timeout duration for requests from the server to backend agents.
+	BackendDialTimeout time.Duration
 }
 
 func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
@@ -164,6 +166,7 @@ func (o *ProxyRunOptions) Flags() *pflag.FlagSet {
 	flags.StringVar(&o.LeaseNamespace, "lease-namespace", o.LeaseNamespace, "The namespace where lease objects are managed by the controller.")
 	flags.StringVar(&o.LeaseLabel, "lease-label", o.LeaseLabel, "The labels on which the lease objects are managed.")
 	flags.DurationVar(&o.GracefulShutdownTimeout, "graceful-shutdown-timeout", o.GracefulShutdownTimeout, "Timeout duration for graceful shutdown of the server. The server will wait for active connections to close before forcefully terminating. Set to 0 to disable graceful shutdown (default: 0).")
+	flags.DurationVar(&o.BackendDialTimeout, "backend-dial-timeout", o.BackendDialTimeout, "Timeout duration for sending DIAL_REQ packets to backend agent streams and waiting for DIAL_RSP. Set to 0 to disable timeout (default: 0).")
 	flags.Bool("warn-on-channel-limit", true, "This behavior is now thread safe and always on. This flag will be removed in a future release.")
 	flags.MarkDeprecated("warn-on-channel-limit", "This behavior is now thread safe and always on. This flag will be removed in a future release.")
 
@@ -209,6 +212,7 @@ func (o *ProxyRunOptions) Print() {
 	klog.V(1).Infof("TLSMinVersion set to %q.\n", o.TLSMinVersion)
 	klog.V(1).Infof("XfrChannelSize set to %d.\n", o.XfrChannelSize)
 	klog.V(1).Infof("GracefulShutdownTimeout set to %v.\n", o.GracefulShutdownTimeout)
+	klog.V(1).Infof("BackendDialTimeout set to %v.\n", o.BackendDialTimeout)
 }
 
 func (o *ProxyRunOptions) Validate() error {
@@ -368,6 +372,9 @@ func (o *ProxyRunOptions) Validate() error {
 	if o.GracefulShutdownTimeout < 0 {
 		return fmt.Errorf("graceful-shutdown-timeout must be >= 0, got %v", o.GracefulShutdownTimeout)
 	}
+	if o.BackendDialTimeout < 0 {
+		return fmt.Errorf("backend-dial-timeout must be >= 0, got %v", o.BackendDialTimeout)
+	}
 
 	o.NeedsKubernetesClient = usingServiceAccountAuth || o.EnableLeaseController
 
@@ -414,6 +421,7 @@ func NewProxyRunOptions() *ProxyRunOptions {
 		LeaseNamespace:            "kube-system",
 		LeaseLabel:                "k8s-app=konnectivity-server",
 		GracefulShutdownTimeout:   0,
+		BackendDialTimeout:        0,
 	}
 	return &o
 }

--- a/cmd/server/app/options/options_test.go
+++ b/cmd/server/app/options/options_test.go
@@ -66,6 +66,7 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "XfrChannelSize", defaultServerOptions.XfrChannelSize, 10)
 	assertDefaultValue(t, "APIContentType", defaultServerOptions.APIContentType, "application/vnd.kubernetes.protobuf")
 	assertDefaultValue(t, "GracefulShutdownTimeout", defaultServerOptions.GracefulShutdownTimeout, 0*time.Second)
+	assertDefaultValue(t, "BackendDialTimeout", defaultServerOptions.BackendDialTimeout, 0*time.Second)
 
 }
 
@@ -217,6 +218,21 @@ func TestValidate(t *testing.T) {
 		},
 		"PositiveGracefulShutdownTimeout": {
 			field:    "GracefulShutdownTimeout",
+			value:    30 * time.Second,
+			expected: nil,
+		},
+		"NegativeBackendDialTimeout": {
+			field:    "BackendDialTimeout",
+			value:    -1 * time.Second,
+			expected: fmt.Errorf("backend-dial-timeout must be >= 0, got -1s"),
+		},
+		"ZeroBackendDialTimeout": {
+			field:    "BackendDialTimeout",
+			value:    0 * time.Second,
+			expected: nil,
+		},
+		"PositiveBackendDialTimeout": {
+			field:    "BackendDialTimeout",
 			value:    30 * time.Second,
 			expected: nil,
 		},

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -140,6 +140,7 @@ func (p *Proxy) Run(o *options.ProxyRunOptions, stopCh <-chan struct{}) error {
 		return err
 	}
 	p.server = server.NewProxyServer(o.ServerID, ps, o.ServerCount, authOpt, o.XfrChannelSize)
+	p.server.SetBackendDialTimeout(o.BackendDialTimeout)
 
 	frontendStop, err := p.runFrontendServer(ctx, o, p.server)
 	if err != nil {

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -43,13 +43,16 @@ import (
 // agent.AgentService_ConnectServer, provides synchronization and
 // emits common stream metrics.
 type Backend struct {
-	sendLock sync.Mutex
-	recvLock sync.Mutex
-	conn     agent.AgentService_ConnectServer
+	sendLock   sync.Mutex
+	recvLock   sync.Mutex
+	retireOnce sync.Once
+	conn       agent.AgentService_ConnectServer
 
 	// cached from conn.Context()
 	id     string
 	idents header.Identifiers
+
+	done chan struct{}
 
 	// draining indicates if this backend is draining and should not accept new connections
 	draining atomic.Bool
@@ -63,6 +66,17 @@ func (b *Backend) IsDraining() bool {
 // SetDraining marks the backend as draining
 func (b *Backend) SetDraining() {
 	b.draining.Store(true)
+}
+
+func (b *Backend) Retire() {
+	b.SetDraining()
+	b.retireOnce.Do(func() {
+		close(b.done)
+	})
+}
+
+func (b *Backend) Done() <-chan struct{} {
+	return b.done
 }
 
 func (b *Backend) Send(p *client.Packet) error {
@@ -145,7 +159,7 @@ func NewBackend(conn agent.AgentService_ConnectServer) (*Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Backend{conn: conn, id: agentID, idents: agentIdentifiers}, nil
+	return &Backend{conn: conn, id: agentID, idents: agentIdentifiers, done: make(chan struct{})}, nil
 }
 
 // BackendStorage is an interface to manage the storage of the backend

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -328,6 +328,7 @@ const (
 	DialFailureUnrecognizedResponse DialFailureReason = "unrecognized_response" // Dial repsonse received for unrecognozide dial ID.
 	DialFailureSendResponse         DialFailureReason = "send_rsp"              // Successful dial response from agent, but failed to send to frontend.
 	DialFailureBackendClose         DialFailureReason = "backend_close"         // Received a DIAL_CLS from the backend before the dial completed.
+	DialFailureBackendDialTimeout   DialFailureReason = "backend_dial_timeout"  // Timed out sending DIAL_REQ to or waiting for DIAL_RSP from the backend.
 	DialFailureFrontendClose        DialFailureReason = "frontend_close"        // Received a DIAL_CLS from the frontend before the dial completed.
 )
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -90,6 +90,10 @@ const (
 	ModeHTTPConnect = "http-connect"
 )
 
+const defaultBackendDialTimeout = 0
+
+var errBackendDialTimeout = errors.New("timed out waiting for backend dial")
+
 type ProxyClientConnection struct {
 	Mode        string
 	HTTP        io.ReadWriter
@@ -274,6 +278,8 @@ type ProxyServer struct {
 	// TODO: move strategies into BackendStorage
 	proxyStrategies []proxystrategies.ProxyStrategy
 	xfrChannelSize  int
+
+	backendDialTimeout time.Duration
 }
 
 // AgentTokenAuthenticationOptions contains list of parameters required for agent token based authentication
@@ -317,6 +323,65 @@ func (s *ProxyServer) getBackend(reqHost string) (*Backend, error) {
 	return nil, &ErrNotFound{}
 }
 
+func (s *ProxyServer) sendDialRequestToBackend(backend *Backend, pkt *client.Packet) error {
+	timeout := s.backendDialTimeout
+	if timeout <= 0 {
+		return backend.Send(pkt)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- backend.Send(pkt)
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	ctx := backend.Context()
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		s.retireBackend(backend, "backend dial request send timed out")
+		return errBackendDialTimeout
+	}
+}
+
+func (s *ProxyServer) startPendingDialTimeout(random int64, backend *Backend, frontend *GrpcFrontend) {
+	timeout := s.backendDialTimeout
+	if timeout <= 0 {
+		return
+	}
+
+	go func() {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+
+		select {
+		case <-timer.C:
+			if s.PendingDial.Remove(random) == nil {
+				return
+			}
+			metrics.Metrics.ObserveDialFailure(metrics.DialFailureBackendDialTimeout)
+			resp := &client.Packet{
+				Type: client.PacketType_DIAL_RSP,
+				Payload: &client.Packet_DialResponse{
+					DialResponse: &client.DialResponse{
+						Random: random,
+						Error:  errBackendDialTimeout.Error(),
+					},
+				},
+			}
+			if err := frontend.Send(resp); err != nil {
+				klog.V(5).InfoS("Failed to send DIAL_RSP for backend dial timeout", "error", err, "dialID", random)
+			}
+		case <-backend.Context().Done():
+		}
+	}()
+}
+
 func (s *ProxyServer) addBackend(backend *Backend) {
 	// TODO: refactor BackendStorage to acquire lock once, not up to 3 times.
 	for _, bm := range s.BackendManagers {
@@ -328,6 +393,12 @@ func (s *ProxyServer) removeBackend(backend *Backend) {
 	for _, bm := range s.BackendManagers {
 		bm.RemoveBackend(backend)
 	}
+}
+
+func (s *ProxyServer) retireBackend(backend *Backend, reason string) {
+	backend.Retire()
+	klog.V(2).InfoS("Retire backend connection", "agentID", backend.GetAgentID(), "reason", reason)
+	s.removeBackend(backend)
 }
 
 func (s *ProxyServer) addEstablished(agentID string, connID int64, p *ProxyClientConnection) {
@@ -455,10 +526,15 @@ func NewProxyServer(serverID string, proxyStrategies []proxystrategies.ProxyStra
 		BackendManagers:            bms,
 		AgentAuthenticationOptions: agentAuthenticationOptions,
 		// use the first backend-manager as the Readiness Manager
-		Readiness:       bms[0],
-		proxyStrategies: proxyStrategies,
-		xfrChannelSize:  channelSize,
+		Readiness:          bms[0],
+		proxyStrategies:    proxyStrategies,
+		xfrChannelSize:     channelSize,
+		backendDialTimeout: defaultBackendDialTimeout,
 	}
+}
+
+func (s *ProxyServer) SetBackendDialTimeout(timeout time.Duration) {
+	s.backendDialTimeout = timeout
 }
 
 // Proxy handles incoming streams from gRPC frontend.
@@ -613,11 +689,31 @@ func (s *ProxyServer) serveRecvFrontend(frontend *GrpcFrontend, recvCh <-chan *c
 					backend:     backend,
 					dialAddress: address,
 				})
-			if err := backend.Send(pkt); err != nil {
+			if err := s.sendDialRequestToBackend(backend, pkt); err != nil {
 				klog.ErrorS(err, "DIAL_REQ to Backend failed", "dialID", random)
-			} else {
-				klog.V(5).InfoS("DIAL_REQ sent to backend", "dialID", random)
+				if s.PendingDial.Remove(random) != nil {
+					reason := metrics.DialFailureBackendClose
+					if errors.Is(err, errBackendDialTimeout) {
+						reason = metrics.DialFailureBackendDialTimeout
+					}
+					metrics.Metrics.ObserveDialFailure(reason)
+				}
+				resp := &client.Packet{
+					Type: client.PacketType_DIAL_RSP,
+					Payload: &client.Packet_DialResponse{
+						DialResponse: &client.DialResponse{
+							Random: random,
+							Error:  err.Error(),
+						},
+					},
+				}
+				if err := frontend.Send(resp); err != nil {
+					klog.V(5).InfoS("Failed to send DIAL_RSP for backend send failure", "error", err, "dialID", random)
+				}
+				return
 			}
+			klog.V(5).InfoS("DIAL_REQ sent to backend", "dialID", random)
+			s.startPendingDialTimeout(random, backend, frontend)
 
 		case client.PacketType_CLOSE_REQ:
 			connID := pkt.GetCloseRequest().ConnectID
@@ -806,17 +902,21 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 
 	go runpprof.Do(context.Background(), labels, func(context.Context) { s.serveRecvBackend(backend, agentID, recvCh) })
 
-	defer func() {
-		close(recvCh)
-	}()
-
-	stopCh := make(chan error)
+	stopCh := make(chan error, 1)
 	go runpprof.Do(context.Background(), labels, func(context.Context) { s.readBackendToChannel(backend, recvCh, stopCh) })
 
-	return <-stopCh
+	select {
+	case err := <-stopCh:
+		return err
+	case <-backend.Done():
+		klog.V(2).InfoS("Backend connection retired", "agentID", agentID)
+		return nil
+	}
 }
 
 func (s *ProxyServer) readBackendToChannel(backend *Backend, recvCh chan *client.Packet, stopCh chan error) {
+	defer close(recvCh)
+
 	agentID := backend.GetAgentID()
 	for {
 		in, err := backend.Recv()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package server
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"sync"
 	"testing"
@@ -216,6 +221,108 @@ func TestRemovePendingDialForStream(t *testing.T) {
 	p.PendingDial.removeForStream("")
 	if e, a := expectedPending, p.PendingDial.pendingDial; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestHTTPConnectTunnelBlockedBackendDialSendTimesOutCleansPendingDialAndRetiresBackend(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	metrics.Metrics.Reset()
+
+	proxyServer := NewProxyServer(uuid.New().String(), []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, &AgentTokenAuthenticationOptions{}, xfrChannelSize)
+	proxyServer.SetBackendDialTimeout(500 * time.Millisecond)
+
+	agentConn, backend := prepareAgentConnMD(t, ctrl, proxyServer, nil)
+	sendStarted := make(chan *client.Packet, 1)
+	releaseSend := make(chan struct{})
+	sendReleased := make(chan struct{})
+	agentConn.EXPECT().Send(gomock.AssignableToTypeOf(&client.Packet{})).DoAndReturn(func(pkt *client.Packet) error {
+		sendStarted <- pkt
+		<-releaseSend
+		close(sendReleased)
+		return nil
+	}).Times(1)
+
+	front := httptest.NewServer(&Tunnel{Server: proxyServer})
+	defer front.Close()
+
+	frontURL, err := url.Parse(front.URL)
+	if err != nil {
+		t.Fatalf("failed to parse front URL: %v", err)
+	}
+	conn, err := net.Dial("tcp", frontURL.Host)
+	if err != nil {
+		t.Fatalf("failed to connect to HTTP CONNECT front: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := fmt.Fprintf(conn, "CONNECT 127.0.0.1:443 HTTP/1.1\r\nHost: 127.0.0.1:443\r\n\r\n"); err != nil {
+		t.Fatalf("failed to write CONNECT request: %v", err)
+	}
+
+	var sent *client.Packet
+	select {
+	case sent = <-sendStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for backend DIAL_REQ send to start")
+	}
+	if sent.Type != client.PacketType_DIAL_REQ {
+		t.Fatalf("expected DIAL_REQ to backend, got %v", sent.Type)
+	}
+	if got := pendingDialCount(proxyServer); got != 1 {
+		t.Fatalf("expected one pending dial while backend Send is blocked, got %d", got)
+	}
+
+	respCh := make(chan struct {
+		resp *http.Response
+		err  error
+	}, 1)
+	go func() {
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		respCh <- struct {
+			resp *http.Response
+			err  error
+		}{resp: resp, err: err}
+	}()
+
+	var resp *http.Response
+	select {
+	case got := <-respCh:
+		if got.err != nil {
+			t.Fatalf("failed to read CONNECT response: %v", got.err)
+		}
+		resp = got.resp
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for backend dial timeout response")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("expected %d for blocked backend dial send, got %s", http.StatusGatewayTimeout, resp.Status)
+	}
+	if got := pendingDialCount(proxyServer); got != 0 {
+		t.Fatalf("expected pending dial to be cleaned after backend dial timeout, got %d", got)
+	}
+	if !backend.IsDraining() {
+		t.Fatal("expected backend to be marked draining after backend dial timeout")
+	}
+	select {
+	case <-backend.Done():
+	case <-time.After(time.Second):
+		t.Fatal("expected backend retire signal after backend dial timeout")
+	}
+	for _, bm := range proxyServer.BackendManagers {
+		if got := bm.NumBackends(); got != 0 {
+			t.Fatalf("expected timed-out backend to be retired from manager, got %d backends", got)
+		}
+	}
+
+	close(releaseSend)
+	select {
+	case <-sendReleased:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for blocked backend Send goroutine to exit")
 	}
 }
 
@@ -948,6 +1055,12 @@ func assertEstablishedConnsMetric(t testing.TB, expect int) {
 	if err := metricstest.DefaultTester.ExpectServerEstablishedConns(expect); err != nil {
 		t.Errorf("Expected %d %s metric: %v", expect, "established_connections", err)
 	}
+}
+
+func pendingDialCount(p *ProxyServer) int {
+	p.PendingDial.mu.RLock()
+	defer p.PendingDial.mu.RUnlock()
+	return len(p.PendingDial.pendingDial)
 }
 
 func assertReadyBackendsMetric(t testing.TB, expect int) {

--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -120,26 +121,41 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// This defer acts as a safeguard to ensure we clean up the pending dial
 	// if the connection is never successfully established.
 	established := false
+	dialFailureObserved := false
 	defer func() {
 		if !established {
 			if t.Server.PendingDial.Remove(random) != nil {
-				// This metric is observed only when the frontend closes the connection.
-				// Other failure reasons are observed elsewhere.
-				metrics.Metrics.ObserveDialFailure(metrics.DialFailureFrontendClose)
+				if !dialFailureObserved {
+					metrics.Metrics.ObserveDialFailure(metrics.DialFailureFrontendClose)
+				}
 			}
 		}
 	}()
 
-	if err := backend.Send(dialRequest); err != nil {
+	if err := t.Server.sendDialRequestToBackend(backend, dialRequest); err != nil {
 		klog.ErrorS(err, "failed to tunnel dial request", "host", r.Host, "dialID", connection.dialID, "agentID", connection.agentID)
-		metrics.Metrics.ObserveDialFailure(metrics.DialFailureBackendClose)
-		// Send proper HTTP error response
-		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nFailed to tunnel dial request: %v\r\n", err)))
+		dialFailureObserved = true
+		statusCode := http.StatusBadGateway
+		reason := metrics.DialFailureBackendClose
+		if errors.Is(err, errBackendDialTimeout) {
+			statusCode = http.StatusGatewayTimeout
+			reason = metrics.DialFailureBackendDialTimeout
+		}
+		metrics.Metrics.ObserveDialFailure(reason)
+		statusText := http.StatusText(statusCode)
+		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 %d %s\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nFailed to tunnel dial request: %v\r\n", statusCode, statusText, err)))
 		// The deferred cleanup will run when we return here.
 		return
 	}
 
 	ctxt := backend.Context()
+	var timeoutCh <-chan time.Time
+	var dialTimer *time.Timer
+	if t.Server.backendDialTimeout > 0 {
+		dialTimer = time.NewTimer(t.Server.backendDialTimeout)
+		defer dialTimer.Stop()
+		timeoutCh = dialTimer.C
+	}
 
 	select {
 	case <-connection.connected: // Waiting for response before we begin full communication.
@@ -166,8 +182,17 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case <-ctxt.Done(): // Backend connection died before being established
 		klog.ErrorS(ctxt.Err(), "backend context closed before connection was established", "host", r.Host, "dialID", connection.dialID, "agentID", connection.agentID)
 		metrics.Metrics.ObserveDialFailure(metrics.DialFailureBackendClose)
+		dialFailureObserved = true
 		// Send proper HTTP error response
 		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nBackend context error: %v\r\n", ctxt.Err())))
+		// The deferred cleanup will run when we return here.
+		return
+
+	case <-timeoutCh:
+		klog.ErrorS(errBackendDialTimeout, "backend dial timed out before connection was established", "host", r.Host, "dialID", connection.dialID, "agentID", connection.agentID)
+		metrics.Metrics.ObserveDialFailure(metrics.DialFailureBackendDialTimeout)
+		dialFailureObserved = true
+		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 504 Gateway Timeout\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nBackend dial timeout: %v\r\n", errBackendDialTimeout)))
 		// The deferred cleanup will run when we return here.
 		return
 	}


### PR DESCRIPTION
## Summary

This PR adds an opt-in `--backend-dial-timeout` option to the proxy server.

When configured, the proxy server bounds how long a frontend dial can remain pending while sending `DIAL_REQ` to the selected backend or waiting for `DIAL_RSP`. On timeout, the pending dial is removed and the frontend receives a bounded error.

The default value is `0`, so existing behavior is preserved unless operators explicitly enable the timeout.

## Motivation

In HTTPConnect deployments used by kube-apiserver egress-selector setups, we observed a failure mode where backend connections remained registered while new HTTP CONNECT dials accumulated in `pending_backend_dials`. This can surface as admission webhook failures when the server-to-agent path stops making forward progress but the backend is still considered available.

The new option gives operators a guardrail against unbounded pending dial accumulation without changing default behavior.

## Changes

- Add `--backend-dial-timeout` to proxy-server options.
- Keep the default disabled with `0`.
- Apply the timeout while sending frontend `DIAL_REQ` packets to the selected backend.
- Apply the timeout while waiting for a backend `DIAL_RSP` before the HTTPConnect tunnel is established.
- Remove pending dial entries on timeout.
- Add a `backend_dial_timeout` dial failure metric reason.
- Add a reduced HTTPConnect regression test for blocked backend dial send.

## Compatibility

The default behavior is unchanged because `--backend-dial-timeout` defaults to `0`.

Operators can opt in with a value such as:

`--backend-dial-timeout=30s`

## Testing

Ran:

`go test ./cmd/server/app/options ./pkg/server -count=1`

Added test:

`TestHTTPConnectTunnelBlockedBackendDialSendTimesOutAndCleansPendingDial`

The test starts the HTTPConnect tunnel handler, blocks backend `Send(DIAL_REQ)`, verifies the dial enters pending state, and then verifies the configured timeout returns HTTP 504 and cleans up the pending dial.

## Related Issue

https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/855
