### PR TITLE
Restore proper non-graceful shutdown behavior

### DIFF
--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -191,22 +191,22 @@ func (p *Proxy) Run(o *options.ProxyRunOptions, stopCh <-chan struct{}) error {
 
 	// If graceful shutdown timeout is 0, use the old behavior (immediate shutdown)
 	if o.GracefulShutdownTimeout == 0 {
-		if frontendStop != nil {
-			if err := frontendStop(context.Background()); err != nil {
-				klog.ErrorS(err, "failed to stop frontend server")
-			}
-		}
-		if p.agentServer != nil {
-			p.agentServer.Stop()
+		if p.healthServer != nil {
+			p.healthServer.Close()
 		}
 		if p.adminServer != nil {
 			p.adminServer.Close()
 		}
-		if p.healthServer != nil {
-			p.healthServer.Close()
-		}
 		if leaseController != nil {
 			leaseController.Stop()
+		}
+		if p.agentServer != nil {
+			p.agentServer.Stop()
+		}
+		if frontendStop != nil {
+			if err := frontendStop(ctx); err != nil {
+				klog.ErrorS(err, "failed to stop frontend server")
+			}
 		}
 		return nil
 	}
@@ -214,7 +214,7 @@ func (p *Proxy) Run(o *options.ProxyRunOptions, stopCh <-chan struct{}) error {
 	klog.V(1).Infoln("Initiating graceful shutdown.")
 
 	// Start graceful shutdown with timeout
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), o.GracefulShutdownTimeout)
+	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, o.GracefulShutdownTimeout)
 	defer shutdownCancel()
 
 	// Create a WaitGroup to track shutdown of all components


### PR DESCRIPTION
PR #794 attempted to retain the old non-graceful shutdown behavior if the graceful shutdown timeout was zero/not specified by converting the deferred close calls into an if block after the server received its shutdown signal. However, the PR didn't account for the fact that those deferred calls were executed in reverse order, having the opposite effect: the frontend server waited indefinitely for all frontend connections to close.

Reorder the close calls so that they are called in the same order as when they were called via the defer statements. Also, pass the `Run` method's context to the call to `frontendShutdown`, as this is the same context that was passed to the wrapped HTTP server's Shutdown method previously.

Fixes:

* #794