### PR TITLE
Use toolchain directive to select Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module sigs.k8s.io/apiserver-network-proxy
 
-go 1.26.2
+go 1.26.0
+
+toolchain go1.26.2
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Use the go directive to define the minimum supported Go version, and the toolchain directive to select the preferred Go version. This makes it nicer for downstream consumers, so they can still build konnectivity with older Go patch releases, and aren't artificially forced to upgrade their toolchains.