### PR TITLE
Make lease labels a real label selector for the agent

### DIFF
--- a/cmd/agent/app/options/options.go
+++ b/cmd/agent/app/options/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"cmp"
 	"fmt"
 	"net"
 	"net/url"
@@ -27,6 +28,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 
@@ -87,8 +89,8 @@ type GrpcProxyAgentOptions struct {
 	CountServerLeases bool
 	// Namespace where lease objects are managed.
 	LeaseNamespace string
-	// Labels on which lease objects are managed.
-	LeaseLabel string
+	// Label selector for leases to take into account when counting servers.
+	LeaseLabelSelector labels.Selector
 	// ServerCountSource describes how server counts should be combined.
 	ServerCountSource string
 	// Path to kubeconfig (used by kubernetes client for lease listing)
@@ -140,7 +142,10 @@ func (o *GrpcProxyAgentOptions) Flags() *pflag.FlagSet {
 	flags.IntVar(&o.XfrChannelSize, "xfr-channel-size", 150, "Set the size of the channel for transferring data between the agent and the proxy server.")
 	flags.BoolVar(&o.CountServerLeases, "count-server-leases", o.CountServerLeases, "Enables lease counting system to determine the number of proxy servers to connect to.")
 	flags.StringVar(&o.LeaseNamespace, "lease-namespace", o.LeaseNamespace, "Namespace where lease objects are managed.")
-	flags.StringVar(&o.LeaseLabel, "lease-label", o.LeaseLabel, "The labels on which the lease objects are managed.")
+	flags.VarP(labelSelectorFlag{&o.LeaseLabelSelector}, "lease-label-selector", "", "Label selector for leases to take into account when counting servers.")
+	leaseLabelFlag := flags.VarPF(labelSelectorFlag{&o.LeaseLabelSelector}, "lease-label", "", "")
+	leaseLabelFlag.Hidden = true
+	leaseLabelFlag.Deprecated = "Use --lease-label-selector instead"
 	flags.StringVar(&o.ServerCountSource, "server-count-source", o.ServerCountSource, "Defines how the server counts from lease and from server responses are combined. Possible values: 'default' to use only one source (server or leases depending on other flags), 'max' to take the larger value.")
 	flags.StringVar(&o.KubeconfigPath, "kubeconfig", o.KubeconfigPath, "Path to the kubeconfig file")
 	flags.StringVar(&o.APIContentType, "kube-api-content-type", o.APIContentType, "Content type of requests sent to apiserver.")
@@ -171,7 +176,7 @@ func (o *GrpcProxyAgentOptions) Print() {
 	klog.V(1).Infof("SyncForever set to %v.\n", o.SyncForever)
 	klog.V(1).Infof("CountServerLeases set to %v.\n", o.CountServerLeases)
 	klog.V(1).Infof("LeaseNamespace set to %s.\n", o.LeaseNamespace)
-	klog.V(1).Infof("LeaseLabel set to %s.\n", o.LeaseLabel)
+	klog.V(1).Infof("LeaseLabelSelector set to %s.\n", o.LeaseLabelSelector)
 	klog.V(1).Infof("ServerCountSource set to %s.\n", o.ServerCountSource)
 	klog.V(1).Infof("ChannelSize set to %d.\n", o.XfrChannelSize)
 	klog.V(1).Infof("APIContentType set to %v.\n", o.APIContentType)
@@ -231,12 +236,6 @@ func (o *GrpcProxyAgentOptions) Validate() error {
 		}
 	}
 	// Validate labels provided.
-	if o.CountServerLeases {
-		_, err := util.ParseLabels(o.LeaseLabel)
-		if err != nil {
-			return err
-		}
-	}
 	if o.ServerCountSource != "" {
 		if o.ServerCountSource != "default" && o.ServerCountSource != "max" {
 			return fmt.Errorf("--server-count-source must be one of '', 'default', 'max', got %v", o.ServerCountSource)
@@ -290,7 +289,7 @@ func NewGrpcProxyAgentOptions() *GrpcProxyAgentOptions {
 		XfrChannelSize:            150,
 		CountServerLeases:         false,
 		LeaseNamespace:            "kube-system",
-		LeaseLabel:                "k8s-app=konnectivity-server",
+		LeaseLabelSelector:        labels.ValidatedSetSelector{"k8s-app": "konnectivity-server"},
 		ServerCountSource:         "default",
 		KubeconfigPath:            "",
 		APIContentType:            runtime.ContentTypeProtobuf,
@@ -305,4 +304,29 @@ func defaultAgentID() string {
 		return id
 	}
 	return uuid.New().String()
+}
+
+type labelSelectorFlag struct {
+	inner *labels.Selector
+}
+
+// Type implements [pflag.Value].
+func (l labelSelectorFlag) Type() string {
+	return "string"
+}
+
+// String implements [pflag.Value].
+func (l labelSelectorFlag) String() string {
+	return cmp.Or(*l.inner, labels.Everything()).String()
+}
+
+// Set implements [pflag.Value].
+func (l labelSelectorFlag) Set(value string) error {
+	parsed, err := labels.Parse(value)
+	if err != nil {
+		return err
+	}
+
+	*l.inner = parsed
+	return nil
 }

--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -51,6 +51,11 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "WarnOnChannelLimit", defaultAgentOptions.WarnOnChannelLimit, false)
 	assertDefaultValue(t, "SyncForever", defaultAgentOptions.SyncForever, false)
 	assertDefaultValue(t, "XfrChannelSize", defaultAgentOptions.XfrChannelSize, 150)
+	assertDefaultValue(t, "CountServerLeases", defaultAgentOptions.CountServerLeases, false)
+	assertDefaultValue(t, "LeaseNamespace", defaultAgentOptions.LeaseNamespace, "kube-system")
+	assertDefaultValue(t, "LeaseLabel", defaultAgentOptions.LeaseLabel, "k8s-app=konnectivity-server")
+	assertDefaultValue(t, "ServerCountSource", defaultAgentOptions.ServerCountSource, "default")
+	assertDefaultValue(t, "KubeconfigPath", defaultAgentOptions.KubeconfigPath, "")
 	assertDefaultValue(t, "APIContentType", defaultAgentOptions.APIContentType, "application/vnd.kubernetes.protobuf")
 }
 
@@ -159,6 +164,41 @@ func TestValidate(t *testing.T) {
 		"ServerCountSource": {
 			fieldMap: map[string]interface{}{"ServerCountSource": "foobar"},
 			expected: fmt.Errorf("--server-count-source must be one of '', 'default', 'max', got foobar"),
+		},
+		"LeaseLabelValidWithCountServerLeases": {
+			fieldMap: map[string]any{
+				"CountServerLeases": true,
+				"LeaseLabel":        "k8s-app=konnectivity-server",
+			},
+			expected: nil,
+		},
+		"LeaseLabelEmptyWithCountServerLeases": {
+			fieldMap: map[string]any{
+				"CountServerLeases": true,
+				"LeaseLabel":        "",
+			},
+			expected: fmt.Errorf("empty string provided"),
+		},
+		"LeaseLabelInvalidFormatWithCountServerLeases": {
+			fieldMap: map[string]any{
+				"CountServerLeases": true,
+				"LeaseLabel":        "notavalidlabel",
+			},
+			expected: fmt.Errorf("invalid label format: notavalidlabel"),
+		},
+		"LeaseLabelMultipleValidWithCountServerLeases": {
+			fieldMap: map[string]any{
+				"CountServerLeases": true,
+				"LeaseLabel":        "k8s-app=konnectivity-server,component=proxy",
+			},
+			expected: nil,
+		},
+		"LeaseLabelInvalidIgnoredWithoutCountServerLeases": {
+			fieldMap: map[string]any{
+				"CountServerLeases": false,
+				"LeaseLabel":        "notavalidlabel",
+			},
+			expected: nil,
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {

--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -18,7 +18,6 @@ package options
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -67,161 +66,157 @@ func assertDefaultValue(t *testing.T, fieldName string, actual, expected interfa
 
 func TestValidate(t *testing.T) {
 	for desc, tc := range map[string]struct {
-		fieldMap map[string]interface{}
-		expected error
+		fieldMap map[string]any
+		expected string
 	}{
 		"default": {
-			fieldMap: map[string]interface{}{},
-			expected: nil,
+			fieldMap: map[string]any{},
+			expected: "",
 		},
 		"ZeroProxyServerPort": {
-			fieldMap: map[string]interface{}{"ProxyServerPort": 0},
-			expected: fmt.Errorf("proxy server port 0 must be greater than 0"),
+			fieldMap: map[string]any{"proxy-server-port": 0},
+			expected: "proxy server port 0 must be greater than 0",
 		},
 		"NegativeProxyServerPort": {
-			fieldMap: map[string]interface{}{"ProxyServerPort": -1},
-			expected: fmt.Errorf("proxy server port -1 must be greater than 0"),
+			fieldMap: map[string]any{"proxy-server-port": -1},
+			expected: "proxy server port -1 must be greater than 0",
 		},
 		"ReservedProxyServerPort": {
-			fieldMap: map[string]interface{}{"ProxyServerPort": 1023},
-			expected: nil, //TODO: fmt.Errorf("please do not try to use reserved port 1023 for the proxy server port"),
+			fieldMap: map[string]any{"proxy-server-port": 1023},
+			expected: "", //TODO: "please do not try to use reserved port 1023 for the proxy server port",
 		},
 		"StartValidProxyServerPort": {
-			fieldMap: map[string]interface{}{"ProxyServerPort": 1024},
-			expected: nil,
+			fieldMap: map[string]any{"proxy-server-port": 1024},
+			expected: "",
 		},
 		"EndValidProxyServerPort": {
-			fieldMap: map[string]interface{}{"ProxyServerPort": 49151},
-			expected: nil,
+			fieldMap: map[string]any{"proxy-server-port": 49151},
+			expected: "",
 		},
 		"StartEphemeralProxyServerPort": {
-			fieldMap: map[string]interface{}{"ProxyServerPort": 49152},
-			expected: nil, //TODO: fmt.Errorf("please do not try to use ephemeral port 49152 for the proxy server port"),
+			fieldMap: map[string]any{"proxy-server-port": 49152},
+			expected: "", //TODO: "please do not try to use ephemeral port 49152 for the proxy server port",
 		},
 		"ZeroHealthServerPort": {
-			fieldMap: map[string]interface{}{"HealthServerPort": 0},
-			expected: fmt.Errorf("health server port 0 must be greater than 0"),
+			fieldMap: map[string]any{"health-server-port": 0},
+			expected: "health server port 0 must be greater than 0",
 		},
 		"NegativeHealthServerPort": {
-			fieldMap: map[string]interface{}{"HealthServerPort": -1},
-			expected: fmt.Errorf("health server port -1 must be greater than 0"),
+			fieldMap: map[string]any{"health-server-port": -1},
+			expected: "health server port -1 must be greater than 0",
 		},
 		"ReservedHealthServerPort": {
-			fieldMap: map[string]interface{}{"HealthServerPort": 1023},
-			expected: nil, //TODO: fmt.Errorf("please do not try to use reserved port 1023 for the health server port"),
+			fieldMap: map[string]any{"health-server-port": 1023},
+			expected: "", //TODO: "please do not try to use reserved port 1023 for the health server port",
 		},
 		"StartValidHealthServerPort": {
-			fieldMap: map[string]interface{}{"HealthServerPort": 1024},
-			expected: nil,
+			fieldMap: map[string]any{"health-server-port": 1024},
+			expected: "",
 		},
 		"EndValidHealthServerPort": {
-			fieldMap: map[string]interface{}{"HealthServerPort": 49151},
-			expected: nil,
+			fieldMap: map[string]any{"health-server-port": 49151},
+			expected: "",
 		},
 		"StartEphemeralHealthServerPort": {
-			fieldMap: map[string]interface{}{"HealthServerPort": 49152},
-			expected: nil, //TODO: fmt.Errorf("please do not try to use ephemeral port 49152 for the health server port"),
+			fieldMap: map[string]any{"health-server-port": 49152},
+			expected: "", //TODO: "please do not try to use ephemeral port 49152 for the health server port",
 		},
 		"ZeroAdminServerPort": {
-			fieldMap: map[string]interface{}{"AdminServerPort": 0},
-			expected: fmt.Errorf("admin server port 0 must be greater than 0"),
+			fieldMap: map[string]any{"admin-server-port": 0},
+			expected: "admin server port 0 must be greater than 0",
 		},
 		"NegativeAdminServerPort": {
-			fieldMap: map[string]interface{}{"AdminServerPort": -1},
-			expected: fmt.Errorf("admin server port -1 must be greater than 0"),
+			fieldMap: map[string]any{"admin-server-port": -1},
+			expected: "admin server port -1 must be greater than 0",
 		},
 		"ReservedAdminServerPort": {
-			fieldMap: map[string]interface{}{"AdminServerPort": 1023},
-			expected: nil, //TODO: fmt.Errorf("please do not try to use reserved port 1023 for the health port"),
+			fieldMap: map[string]any{"admin-server-port": 1023},
+			expected: "", //TODO: "please do not try to use reserved port 1023 for the health port",
 		},
 		"StartValidAdminServerPort": {
-			fieldMap: map[string]interface{}{"AdminServerPort": 1024},
-			expected: nil,
+			fieldMap: map[string]any{"admin-server-port": 1024},
+			expected: "",
 		},
 		"EndValidAdminServerPort": {
-			fieldMap: map[string]interface{}{"AdminServerPort": 49151},
-			expected: nil,
+			fieldMap: map[string]any{"admin-server-port": 49151},
+			expected: "",
 		},
 		"StartEphemeralAdminServerPort": {
-			fieldMap: map[string]interface{}{"AdminServerPort": 49152},
-			expected: nil, //TODO: fmt.Errorf("please do not try to use ephemeral port 49152 for the health port"),
+			fieldMap: map[string]any{"admin-server-port": 49152},
+			expected: "", //TODO: "please do not try to use ephemeral port 49152 for the health port",
 		},
 		"ContentionProfilingRequiresProfiling": {
-			fieldMap: map[string]interface{}{
-				"EnableContentionProfiling": true,
-				"EnableProfiling":           false,
+			fieldMap: map[string]any{
+				"enable-contention-profiling": true,
+				"enable-profiling":            false,
 			},
-			expected: fmt.Errorf("if --enable-contention-profiling is set, --enable-profiling must also be set"),
+			expected: "if --enable-contention-profiling is set, --enable-profiling must also be set",
 		},
 		"ZeroXfrChannelSize": {
-			fieldMap: map[string]interface{}{"XfrChannelSize": 0},
-			expected: fmt.Errorf("channel size 0 must be greater than 0"),
+			fieldMap: map[string]any{"xfr-channel-size": 0},
+			expected: "channel size 0 must be greater than 0",
 		},
 		"NegativeXfrChannelSize": {
-			fieldMap: map[string]interface{}{"XfrChannelSize": -10},
-			expected: fmt.Errorf("channel size -10 must be greater than 0"),
+			fieldMap: map[string]any{"xfr-channel-size": -10},
+			expected: "channel size -10 must be greater than 0",
 		},
 		"ServerCountSource": {
-			fieldMap: map[string]interface{}{"ServerCountSource": "foobar"},
-			expected: fmt.Errorf("--server-count-source must be one of '', 'default', 'max', got foobar"),
+			fieldMap: map[string]any{"server-count-source": "foobar"},
+			expected: "--server-count-source must be one of '', 'default', 'max', got foobar",
 		},
 		"LeaseLabelValidWithCountServerLeases": {
 			fieldMap: map[string]any{
-				"CountServerLeases": true,
-				"LeaseLabel":        "k8s-app=konnectivity-server",
+				"count-server-leases": true,
+				"lease-label":         "k8s-app=konnectivity-server",
 			},
-			expected: nil,
+			expected: "",
 		},
 		"LeaseLabelEmptyWithCountServerLeases": {
 			fieldMap: map[string]any{
-				"CountServerLeases": true,
-				"LeaseLabel":        "",
+				"count-server-leases": true,
+				"lease-label":         "",
 			},
-			expected: fmt.Errorf("empty string provided"),
+			expected: "empty string provided",
 		},
 		"LeaseLabelInvalidFormatWithCountServerLeases": {
 			fieldMap: map[string]any{
-				"CountServerLeases": true,
-				"LeaseLabel":        "notavalidlabel",
+				"count-server-leases": true,
+				"lease-label":         "notavalidlabel",
 			},
-			expected: fmt.Errorf("invalid label format: notavalidlabel"),
+			expected: "invalid label format: notavalidlabel",
 		},
 		"LeaseLabelMultipleValidWithCountServerLeases": {
 			fieldMap: map[string]any{
-				"CountServerLeases": true,
-				"LeaseLabel":        "k8s-app=konnectivity-server,component=proxy",
+				"count-server-leases": true,
+				"lease-label":         "k8s-app=konnectivity-server,component=proxy",
 			},
-			expected: nil,
+			expected: "",
 		},
 		"LeaseLabelInvalidIgnoredWithoutCountServerLeases": {
 			fieldMap: map[string]any{
-				"CountServerLeases": false,
-				"LeaseLabel":        "notavalidlabel",
+				"count-server-leases": false,
+				"lease-label":         "notavalidlabel",
 			},
-			expected: nil,
+			expected: "",
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
 			testAgentOptions := NewGrpcProxyAgentOptions()
+			args := make([]string, 0, len(tc.fieldMap))
 			for field, value := range tc.fieldMap {
-				rv := reflect.ValueOf(testAgentOptions)
-				rv = rv.Elem()
-				fv := rv.FieldByName(field)
-				switch reflect.TypeOf(value).Kind() {
-				case reflect.String:
-					svalue := value.(string)
-					fv.SetString(svalue)
-				case reflect.Int:
-					ivalue := value.(int)
-					fv.SetInt(int64(ivalue))
-				case reflect.Bool:
-					bvalue := value.(bool)
-					fv.SetBool(bvalue)
-				}
+				args = append(args, "--"+field+"="+fmt.Sprint(value))
 			}
-			actual := testAgentOptions.Validate()
-			assert.IsType(t, tc.expected, actual, "Validation for case %s, got the wrong type.", desc)
-			assert.Equal(t, tc.expected, actual, "Validation for case %s, got the wrong value.", desc)
+
+			actual := testAgentOptions.Flags().Parse(args)
+			if actual == nil {
+				actual = testAgentOptions.Validate()
+			}
+
+			if tc.expected == "" {
+				assert.NoError(t, actual)
+			} else if assert.Errorf(t, actual, "Expected message: %s", tc.expected) {
+				assert.ErrorContains(t, actual, tc.expected)
+			}
 		})
 	}
 }

--- a/cmd/agent/app/options/options_test.go
+++ b/cmd/agent/app/options/options_test.go
@@ -52,7 +52,7 @@ func TestDefaultServerOptions(t *testing.T) {
 	assertDefaultValue(t, "XfrChannelSize", defaultAgentOptions.XfrChannelSize, 150)
 	assertDefaultValue(t, "CountServerLeases", defaultAgentOptions.CountServerLeases, false)
 	assertDefaultValue(t, "LeaseNamespace", defaultAgentOptions.LeaseNamespace, "kube-system")
-	assertDefaultValue(t, "LeaseLabel", defaultAgentOptions.LeaseLabel, "k8s-app=konnectivity-server")
+	assertDefaultValue(t, "LeaseLabelSelector", defaultAgentOptions.LeaseLabelSelector.String(), "k8s-app=konnectivity-server")
 	assertDefaultValue(t, "ServerCountSource", defaultAgentOptions.ServerCountSource, "default")
 	assertDefaultValue(t, "KubeconfigPath", defaultAgentOptions.KubeconfigPath, "")
 	assertDefaultValue(t, "APIContentType", defaultAgentOptions.APIContentType, "application/vnd.kubernetes.protobuf")
@@ -164,38 +164,51 @@ func TestValidate(t *testing.T) {
 			fieldMap: map[string]any{"server-count-source": "foobar"},
 			expected: "--server-count-source must be one of '', 'default', 'max', got foobar",
 		},
-		"LeaseLabelValidWithCountServerLeases": {
+		"LeaseLabelValid": {
 			fieldMap: map[string]any{
-				"count-server-leases": true,
-				"lease-label":         "k8s-app=konnectivity-server",
+				"lease-label": "k8s-app=konnectivity-server",
 			},
 			expected: "",
 		},
-		"LeaseLabelEmptyWithCountServerLeases": {
+		"LeaseLabelEmpty": {
 			fieldMap: map[string]any{
-				"count-server-leases": true,
-				"lease-label":         "",
-			},
-			expected: "empty string provided",
-		},
-		"LeaseLabelInvalidFormatWithCountServerLeases": {
-			fieldMap: map[string]any{
-				"count-server-leases": true,
-				"lease-label":         "notavalidlabel",
-			},
-			expected: "invalid label format: notavalidlabel",
-		},
-		"LeaseLabelMultipleValidWithCountServerLeases": {
-			fieldMap: map[string]any{
-				"count-server-leases": true,
-				"lease-label":         "k8s-app=konnectivity-server,component=proxy",
+				"lease-label": "",
 			},
 			expected: "",
 		},
-		"LeaseLabelInvalidIgnoredWithoutCountServerLeases": {
+		"LeaseLabelInvalidFormat": {
 			fieldMap: map[string]any{
-				"count-server-leases": false,
-				"lease-label":         "notavalidlabel",
+				"lease-label": "*notavalidlabel*",
+			},
+			expected: `invalid argument "*notavalidlabel*" for "--lease-label" flag`,
+		},
+		"LeaseLabelMultipleValid": {
+			fieldMap: map[string]any{
+				"lease-label": "k8s-app=konnectivity-server,component=proxy",
+			},
+			expected: "",
+		},
+		"LeaseLabelSelectorValid": {
+			fieldMap: map[string]any{
+				"lease-label-selector": "k8s-app=konnectivity-server",
+			},
+			expected: "",
+		},
+		"LeaseLabelSelectorEmpty": {
+			fieldMap: map[string]any{
+				"lease-label-selector": "",
+			},
+			expected: "",
+		},
+		"LeaseLabelSelectorInvalidFormat": {
+			fieldMap: map[string]any{
+				"lease-label-selector": "*notavalidlabel*",
+			},
+			expected: `invalid argument "*notavalidlabel*" for "--lease-label-selector" flag`,
+		},
+		"LeaseLabelSelectorMultipleValid": {
+			fieldMap: map[string]any{
+				"lease-label-selector": "k8s-app=konnectivity-server,component=proxy",
 			},
 			expected: "",
 		},

--- a/cmd/agent/app/server.go
+++ b/cmd/agent/app/server.go
@@ -38,7 +38,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	coordinationv1lister "k8s.io/client-go/listers/coordination/v1"
 	"k8s.io/client-go/rest"
@@ -167,11 +166,10 @@ func (a *Agent) runProxyConnection(o *options.GrpcProxyAgentOptions, drainCh, st
 		go leaseInformer.Run(stopCh)
 		cache.WaitForCacheSync(stopCh, leaseInformer.HasSynced)
 		leaseLister := coordinationv1lister.NewLeaseLister(leaseInformer.GetIndexer())
-		serverLeaseSelector, _ := labels.Parse(o.LeaseLabel)
 		leaseCounter = agent.NewServerLeaseCounter(
 			clock.RealClock{},
 			leaseLister,
-			serverLeaseSelector,
+			o.LeaseLabelSelector,
 		)
 	}
 


### PR DESCRIPTION
The lease labels are already converted into a label selector anyways, so allowing the full label selector syntax removes an artificial
constraint.