### PR TITLE
Decouple send/recv in data->control in agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ KIND_IMAGE ?= kindest/node:v1.30.2
 CONNECTION_MODE ?= grpc
 
 MOCKGEN_VERSION := $(shell mockgen -version)
-DESIRED_MOCKGEN := "v0.5.2"
+DESIRED_MOCKGEN := "v0.6.0"
 
 ## --------------------------------------
 ## Testing

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Please ensure the go bin directory (usually `~/go/bin`) is in your `PATH`.
 
 The [```mockgen```](https://github.com/uber-go/mock) tool must be installed on your system.
 
-Currently, we are using go.uber.org/mock/mockgen@v0.5.2
+Currently, we are using go.uber.org/mock/mockgen@v0.6.0
 
-`go install go.uber.org/mock/mockgen@v0.5.2`
+`go install go.uber.org/mock/mockgen@v0.6.0`
 
 ### Protoc
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -50,6 +50,7 @@ type endpointConn struct {
 	connID    int64
 	cleanFunc func()
 	dataCh    chan []byte
+	sendCh    chan []byte
 	cleanOnce sync.Once
 	warnChLim bool
 	dialDone  chan struct{}
@@ -59,8 +60,7 @@ func (e *endpointConn) cleanup() {
 	e.cleanOnce.Do(e.cleanFunc)
 }
 
-func (e *endpointConn) send(msg []byte) {
-	// TODO (cheftako@): Get perf test working and compare this solution with a lock based solution.
+func (e *endpointConn) sendViaDataChannel(msg []byte) {
 	defer func() {
 		// Handles the race condition where we write to a closed channel
 		if err := recover(); err != nil {
@@ -383,9 +383,11 @@ func (a *Client) Serve() {
 
 			connID := atomic.AddInt64(&a.nextConnID, 1)
 			dataCh := make(chan []byte, a.cs.xfrChannelSize)
+			sendCh := make(chan []byte, a.cs.xfrChannelSize)
 			dialDone := make(chan struct{})
 			eConn := &endpointConn{
 				dataCh:    dataCh,
+				sendCh:    sendCh,
 				dialDone:  dialDone,
 				warnChLim: a.warnOnChannelLimit,
 			}
@@ -476,8 +478,9 @@ func (a *Client) Serve() {
 					go runpprof.Do(context.Background(), labels, func(context.Context) { eConn.cleanup() })
 					return
 				}
-				go runpprof.Do(context.Background(), labels, func(context.Context) { a.remoteToProxy(connID, eConn) })
-				go runpprof.Do(context.Background(), labels, func(context.Context) { a.proxyToRemote(connID, eConn) })
+				go runpprof.Do(context.Background(), labels, func(context.Context) { a.remoteToSendChannel(connID, eConn) })
+				go runpprof.Do(context.Background(), labels, func(context.Context) { a.sendChannelToProxy(connID, eConn) })
+				go runpprof.Do(context.Background(), labels, func(context.Context) { a.dataChannelToRemote(connID, eConn) })
 			})
 
 		case client.PacketType_DATA:
@@ -490,7 +493,7 @@ func (a *Client) Serve() {
 
 			eConn, ok := a.connManager.Get(data.ConnectID)
 			if ok {
-				eConn.send(data.Data)
+				eConn.sendViaDataChannel(data.Data)
 			} else {
 				klog.V(2).InfoS("received DATA for unrecognized connection", "connectionID", data.ConnectID)
 				a.Send(&client.Packet{
@@ -534,20 +537,18 @@ func (a *Client) Serve() {
 	}
 }
 
-func (a *Client) remoteToProxy(connID int64, eConn *endpointConn) {
+func (a *Client) remoteToSendChannel(connID int64, eConn *endpointConn) {
 	defer func() {
 		if panicInfo := recover(); panicInfo != nil {
-			klog.V(2).InfoS("Exiting remoteToProxy with recovery", "panicInfo", panicInfo, "connectionID", connID)
+			klog.V(2).InfoS("Exiting remoteToSendChannel with recovery", "panicInfo", panicInfo, "connectionID", connID)
 		} else {
-			klog.V(4).InfoS("Exiting remoteToProxy", "connectionID", connID)
+			klog.V(4).InfoS("Exiting remoteToSendChannel", "connectionID", connID)
 		}
 	}()
 	defer eConn.cleanup()
+	defer close(eConn.sendCh)
 
 	var buf [1 << 12]byte
-	resp := &client.Packet{
-		Type: client.PacketType_DATA,
-	}
 
 	for {
 		n, err := eConn.conn.Read(buf[:])
@@ -567,8 +568,33 @@ func (a *Client) remoteToProxy(connID int64, eConn *endpointConn) {
 			return
 		}
 
+		data := make([]byte, n)
+		copy(data, buf[:n])
+
+		select {
+		case eConn.sendCh <- data:
+		case <-a.stopCh:
+			return
+		}
+	}
+}
+
+func (a *Client) sendChannelToProxy(connID int64, eConn *endpointConn) {
+	defer func() {
+		if panicInfo := recover(); panicInfo != nil {
+			klog.V(2).InfoS("Exiting sendChannelToProxy with recovery", "panicInfo", panicInfo, "connectionID", connID)
+		} else {
+			klog.V(4).InfoS("Exiting sendChannelToProxy", "connectionID", connID)
+		}
+	}()
+
+	resp := &client.Packet{
+		Type: client.PacketType_DATA,
+	}
+
+	for d := range eConn.sendCh {
 		resp.Payload = &client.Packet_Data{Data: &client.Data{
-			Data:      buf[:n],
+			Data:      d,
 			ConnectID: connID,
 		}}
 		if err := a.Send(resp); err != nil {
@@ -577,12 +603,12 @@ func (a *Client) remoteToProxy(connID int64, eConn *endpointConn) {
 	}
 }
 
-func (a *Client) proxyToRemote(connID int64, eConn *endpointConn) {
+func (a *Client) dataChannelToRemote(connID int64, eConn *endpointConn) {
 	defer func() {
 		if panicInfo := recover(); panicInfo != nil {
-			klog.V(2).InfoS("Exiting proxyToRemote with recovery", "panicInfo", panicInfo, "connectionID", connID)
+			klog.V(2).InfoS("Exiting dataChannelToRemote with recovery", "panicInfo", panicInfo, "connectionID", connID)
 		} else {
-			klog.V(4).InfoS("Exiting proxyToRemote", "connectionID", connID)
+			klog.V(4).InfoS("Exiting dataChannelToRemote", "connectionID", connID)
 		}
 	}()
 	// Not safe to call cleanup here, as cleanup() closes the dataCh
@@ -599,7 +625,7 @@ func (a *Client) proxyToRemote(connID int64, eConn *endpointConn) {
 			discardedPktCount++
 		}
 		if discardedPktCount > 0 {
-			klog.V(2).InfoS("Discard packets while exiting proxyToRemote", "pktCount", discardedPktCount, "connectionID", connID)
+			klog.V(2).InfoS("Discard packets while exiting dataChannelToRemote", "pktCount", discardedPktCount, "connectionID", connID)
 		}
 	}()
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -54,6 +54,7 @@ type endpointConn struct {
 	cleanOnce sync.Once
 	warnChLim bool
 	dialDone  chan struct{}
+	sendDone  chan struct{}
 }
 
 func (e *endpointConn) cleanup() {
@@ -385,10 +386,13 @@ func (a *Client) Serve() {
 			dataCh := make(chan []byte, a.cs.xfrChannelSize)
 			sendCh := make(chan []byte, a.cs.xfrChannelSize)
 			dialDone := make(chan struct{})
+			sendDone := make(chan struct{})
 			eConn := &endpointConn{
+				connID:    connID,
 				dataCh:    dataCh,
 				sendCh:    sendCh,
 				dialDone:  dialDone,
+				sendDone:  sendDone,
 				warnChLim: a.warnOnChannelLimit,
 			}
 			eConn.cleanFunc = func() {
@@ -400,6 +404,8 @@ func (a *Client) Serve() {
 					return
 				}
 				klog.V(4).InfoS("close connection", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
+				close(eConn.sendCh)
+				<-eConn.sendDone
 				var closePkt *client.Packet
 				if connID == 0 {
 					closePkt = &client.Packet{
@@ -423,8 +429,8 @@ func (a *Client) Serve() {
 						klog.ErrorS(err, "close response failure", "connectionID", connID, "dialID", dialReq.Random)
 					}
 				}
-				close(dataCh)
-				a.connManager.Delete(connID)
+				close(eConn.dataCh)
+				a.connManager.Delete(eConn.connID)
 				if err := eConn.conn.Close(); err != nil {
 					klog.ErrorS(err, "failed to close connection to remote", "dialID", dialReq.Random, "connectionID", connID)
 				}
@@ -453,6 +459,7 @@ func (a *Client) Serve() {
 					if err := a.Send(dialResp); err != nil {
 						klog.ErrorS(err, "could not send DIAL_RSP with error", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
 					}
+					close(eConn.sendDone)
 					// Cannot invoke clean up as we have no conn yet.
 					return
 				}
@@ -471,6 +478,7 @@ func (a *Client) Serve() {
 				)
 				if err := a.Send(dialResp); err != nil {
 					klog.ErrorS(err, "could not send DIAL_RSP", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
+					close(eConn.sendDone)
 					// clean-up is normally called from remoteToProxy which we will never invoke.
 					// So we are invoking it here to force the clean-up to occur.
 					// However, cleanup will block until dialDone is closed.
@@ -546,7 +554,6 @@ func (a *Client) remoteToSendChannel(connID int64, eConn *endpointConn) {
 		}
 	}()
 	defer eConn.cleanup()
-	defer close(eConn.sendCh)
 
 	var buf [1 << 12]byte
 
@@ -555,7 +562,6 @@ func (a *Client) remoteToSendChannel(connID int64, eConn *endpointConn) {
 		klog.V(5).InfoS("received data from remote", "bytes", n, "connectionID", connID)
 
 		if err == io.EOF {
-			klog.V(2).InfoS("remote connection EOF", "connectionID", connID)
 			return
 		} else if err != nil {
 			// "use of closed network connection" errors are expected upon receiving CLOSE_REQ
@@ -567,10 +573,12 @@ func (a *Client) remoteToSendChannel(connID int64, eConn *endpointConn) {
 			}
 			return
 		}
-
 		data := make([]byte, n)
 		copy(data, buf[:n])
 
+		if eConn.warnChLim && len(eConn.sendCh) >= cap(eConn.sendCh) {
+			klog.V(2).InfoS("Send channel on agent is full", "connectionID", eConn.connID)
+		}
 		select {
 		case eConn.sendCh <- data:
 		case <-a.stopCh:
@@ -580,6 +588,7 @@ func (a *Client) remoteToSendChannel(connID int64, eConn *endpointConn) {
 }
 
 func (a *Client) sendChannelToProxy(connID int64, eConn *endpointConn) {
+	defer close(eConn.sendDone)
 	defer func() {
 		if panicInfo := recover(); panicInfo != nil {
 			klog.V(2).InfoS("Exiting sendChannelToProxy with recovery", "panicInfo", panicInfo, "connectionID", connID)
@@ -587,16 +596,35 @@ func (a *Client) sendChannelToProxy(connID int64, eConn *endpointConn) {
 			klog.V(4).InfoS("Exiting sendChannelToProxy", "connectionID", connID)
 		}
 	}()
-
-	resp := &client.Packet{
-		Type: client.PacketType_DATA,
-	}
+	// Not safe to call cleanup here, as cleanup() closes the sendCh
+	// and we are the receiver for the dataCh. Also we now have a later
+	// defer which will block until sendCh is closed.
+	defer func() {
+		// As the read side of the dataCh channel, we cannot close it.
+		// However serve() may be blocked writing to the channel,
+		// so we need to consume the channel until it is closed.
+		discardedPktCount := 0
+		for range eConn.sendCh {
+			// Ignore values as this indicates there was a problem
+			// with the remote connection.
+			discardedPktCount++
+		}
+		if discardedPktCount > 0 {
+			klog.V(1).InfoS("Discard packets while exiting sendChannelToProxy", "pktCount", discardedPktCount, "connectionID", connID)
+		}
+	}()
 
 	for d := range eConn.sendCh {
-		resp.Payload = &client.Packet_Data{Data: &client.Data{
-			Data:      d,
-			ConnectID: connID,
-		}}
+		resp := &client.Packet{
+			Type: client.PacketType_DATA,
+			Payload: &client.Packet_Data{
+				Data: &client.Data{
+					Data:      d,
+					ConnectID: connID,
+				},
+			},
+		}
+
 		if err := a.Send(resp); err != nil {
 			klog.ErrorS(err, "could not send DATA", "connectionID", connID)
 		}
@@ -625,7 +653,7 @@ func (a *Client) dataChannelToRemote(connID int64, eConn *endpointConn) {
 			discardedPktCount++
 		}
 		if discardedPktCount > 0 {
-			klog.V(2).InfoS("Discard packets while exiting dataChannelToRemote", "pktCount", discardedPktCount, "connectionID", connID)
+			klog.V(1).InfoS("Discard packets while exiting dataChannelToRemote", "pktCount", discardedPktCount, "connectionID", connID)
 		}
 	}()
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -49,12 +49,25 @@ type endpointConn struct {
 	conn      net.Conn
 	connID    int64
 	cleanFunc func()
+
+	// dataCh is a queue to decouple reads from the ANP Server
+	// to the corresponding writes to the data plane.
+	// This is for traffic coming from the KAS.
 	dataCh    chan []byte
+	// dialDone should be closed by dialChannelToRemote which is reading from the dialCh.
+	// It should only be closed when it has read to the end of the channel and sent the packets.
+	dialDone  chan struct{}
+
+	// sendCh is a queue to decouple reads from the data plane
+	// to the corresponding writes to the ANP Server.
+	// This is for traffic going toward the KAS
 	sendCh    chan []byte
+	// sendDone should be closed by sendChannelToProxy which is reading from sendCh.
+	// It should only be closed when it has read to the end of the channel and sent the packets.
+	sendDone  chan struct{}
+
 	cleanOnce sync.Once
 	warnChLim bool
-	dialDone  chan struct{}
-	sendDone  chan struct{}
 }
 
 func (e *endpointConn) cleanup() {
@@ -384,14 +397,14 @@ func (a *Client) Serve() {
 
 			connID := atomic.AddInt64(&a.nextConnID, 1)
 			dataCh := make(chan []byte, a.cs.xfrChannelSize)
-			sendCh := make(chan []byte, a.cs.xfrChannelSize)
 			dialDone := make(chan struct{})
+			sendCh := make(chan []byte, a.cs.xfrChannelSize)
 			sendDone := make(chan struct{})
 			eConn := &endpointConn{
 				connID:    connID,
 				dataCh:    dataCh,
-				sendCh:    sendCh,
 				dialDone:  dialDone,
+				sendCh:    sendCh,
 				sendDone:  sendDone,
 				warnChLim: a.warnOnChannelLimit,
 			}
@@ -460,6 +473,24 @@ func (a *Client) Serve() {
 						klog.ErrorS(err, "could not send DIAL_RSP with error", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
 					}
 					close(eConn.sendDone)
+					// Consume the channel until it is closed.
+					discardedPktCount := 0
+					reading := true
+					for reading {
+						// Ignore values as this indicates there was a problem
+						// with the remote connection. Pulling non blocking from
+						// the channel as it may not have been closed yet and we
+						// don't want to leave a goroutine hanging.
+						select {
+    						case <- eConn.sendCh:
+							discardedPktCount++
+    						default:
+							reading = false
+    						}
+					}
+					if discardedPktCount > 0 {
+						klog.V(1).InfoS("Discard packets from failed Dial", "pktCount", discardedPktCount, "dialID", dialReq.Random, "connectionID", connID)
+					}
 					// Cannot invoke clean up as we have no conn yet.
 					return
 				}
@@ -479,7 +510,7 @@ func (a *Client) Serve() {
 				if err := a.Send(dialResp); err != nil {
 					klog.ErrorS(err, "could not send DIAL_RSP", "dialID", dialReq.Random, "connectionID", connID, "dialAddress", dialReq.Address)
 					close(eConn.sendDone)
-					// clean-up is normally called from remoteToProxy which we will never invoke.
+					// clean-up is normally called from sendChannelToProxy which we will never invoke.
 					// So we are invoking it here to force the clean-up to occur.
 					// However, cleanup will block until dialDone is closed.
 					// So placing cleanup on its own goroutine to wait for the deferred close(dialDone) to kick in.
@@ -562,6 +593,7 @@ func (a *Client) remoteToSendChannel(connID int64, eConn *endpointConn) {
 		klog.V(5).InfoS("received data from remote", "bytes", n, "connectionID", connID)
 
 		if err == io.EOF {
+			klog.V(2).InfoS("remote connection EOF", "connectionID", connID)
 			return
 		} else if err != nil {
 			// "use of closed network connection" errors are expected upon receiving CLOSE_REQ
@@ -591,9 +623,9 @@ func (a *Client) sendChannelToProxy(connID int64, eConn *endpointConn) {
 	defer close(eConn.sendDone)
 	defer func() {
 		if panicInfo := recover(); panicInfo != nil {
-			klog.V(2).InfoS("Exiting sendChannelToProxy with recovery", "panicInfo", panicInfo, "connectionID", connID)
+			klog.V(0).InfoS("Exiting sendChannelToProxy with recovery", "panicInfo", panicInfo, "connectionID", connID)
 		} else {
-			klog.V(4).InfoS("Exiting sendChannelToProxy", "connectionID", connID)
+			klog.V(2).InfoS("Exiting sendChannelToProxy", "connectionID", connID)
 		}
 	}()
 	// Not safe to call cleanup here, as cleanup() closes the sendCh
@@ -627,6 +659,11 @@ func (a *Client) sendChannelToProxy(connID int64, eConn *endpointConn) {
 
 		if err := a.Send(resp); err != nil {
 			klog.ErrorS(err, "could not send DATA", "connectionID", connID)
+			// We failed to write to the muxed tunnel back to the ANP Server.
+			// Chances are something is fairly wrong. Going to close out what
+			// we are doing so we don't leave hanging goroutines.
+			// Not worried about queued packets as the clean up should handle it.
+			return
 		}
 	}
 }
@@ -676,7 +713,6 @@ func (a *Client) dataChannelToRemote(connID int64, eConn *endpointConn) {
 				} else {
 					klog.ErrorS(err, "conn write failure", "connectionID", connID)
 				}
-
 				return
 			}
 		}

--- a/tests/framework/proxy_server.go
+++ b/tests/framework/proxy_server.go
@@ -73,9 +73,11 @@ func (*InProcessProxyServerRunner) Start(t testing.TB, opts ProxyServerOpts) (Pr
 	}()
 
 	healthAddr := net.JoinHostPort(o.HealthBindAddress, strconv.Itoa(o.HealthPort))
-	if err := wait.PollImmediateWithContext(ctx, 100*time.Millisecond, ForeverTestTimeout, func(context.Context) (bool, error) {
-		return checkLiveness(healthAddr), nil
-	}); err != nil {
+	if err := wait.PollImmediateWithContext(ctx, 100*time.Millisecond, ForeverTestTimeout,
+		func(context.Context) (bool, error) {
+			return checkLiveness(healthAddr), nil
+		},
+	); err != nil {
 		close(stopCh)
 		return nil, fmt.Errorf("server never came up: %v", err)
 	}
@@ -88,7 +90,7 @@ func (*InProcessProxyServerRunner) Start(t testing.TB, opts ProxyServerOpts) (Pr
 		agentAddr:   net.JoinHostPort(o.AgentBindAddress, strconv.Itoa(o.AgentPort)),
 		frontAddr:   o.UdsName,
 	}
-	t.Cleanup(ps.Stop)
+	defer t.Cleanup(ps.Stop)
 	return ps, nil
 }
 

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -39,6 +39,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
 	metricsclient "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics"
 	clientmetricstest "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics/testing"
@@ -78,7 +79,14 @@ func newSizedServer(length, chunks int) *testServer {
 
 func (s *testServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	for i := 0; i < s.chunks; i++ {
-		w.Write(s.echo)
+		n, err := w.Write(s.echo)
+		if err != nil {
+			klog.Error(err, "Test server failed to write")
+		}
+		if n < len(s.echo) {
+			klog.V(1).InfoS("testServer:ServeHTTP write",
+				"length", n, "expected", len(s.echo))
+		}
 	}
 }
 
@@ -562,7 +570,7 @@ func TestProxy_LargeResponse(t *testing.T) {
 	expectCleanShutdown(t)
 
 	ctx := context.Background()
-	length := 1 << 20 // 1M
+	length := 1 << 21 // 1M
 	chunks := 10
 	server := httptest.NewServer(newSizedServer(length, chunks))
 	defer server.Close()
@@ -598,7 +606,7 @@ func TestProxy_LargeResponse(t *testing.T) {
 	}
 
 	data, err := io.ReadAll(r.Body)
-	r.Body.Close()
+	defer r.Body.Close()
 	if err != nil {
 		t.Error(err)
 	}

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -570,7 +570,7 @@ func TestProxy_LargeResponse(t *testing.T) {
 	expectCleanShutdown(t)
 
 	ctx := context.Background()
-	length := 1 << 21 // 1M
+	length := 1 << 21 // 2M
 	chunks := 10
 	server := httptest.NewServer(newSizedServer(length, chunks))
 	defer server.Close()


### PR DESCRIPTION
APIServer Network Proxy (ANP) is responsible for tunneling traffic from the Kubernetes APIServer (KAS) to the cluster and responses back. To do this traffic goes from KAS to the ANP Server. From the ANP server traffic is sent to the ANP Agent. From the ANP Agent traffic is sent to the final destination. Responses are sent from the destination to the ANP Agent. From the ANP Agent the response is sent to the ANP Server. From the ANP Server the response is sent to the KAS. When going through the ANP Server and the ANP Agent it is important that the Send method to push the traffic on the next segment does not block the receive method from the last segment. This is achieved by putting a transfer buffer or channel between these methods. This channel or transfer buffer exists in the ANP Server in both directions. However it only exists in the ANP Agent when coming from the ANP Server and headed toward the final destination. The read from the destination can be found in pkg/agent/client.go at about line 553. The send to the ANP Server can be found at about line 574. Please add a channel to stop this send from blocking the read. A declaration of such a channel or transfer buffer can be found at pkg/agent/client.go line 385. The usage of the channel can be found at pkg/agent/client.go line 606.