### PR TITLE
fix HTTP-CONNECT head-of-line blocking

### DIFF
--- a/pkg/server/http_connect_hol_test.go
+++ b/pkg/server/http_connect_hol_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -577,5 +578,190 @@ func TestSlowHTTPFrontendDoesNotDelayOtherConnectionData(t *testing.T) {
 		case <-time.After(holTestSafetyTimeout):
 			t.Fatal("connection B did not receive DATA even after connection A was released")
 		}
+	}
+}
+
+// TestTemporarilySlowHTTPFrontendRecovers targets the risk that isolation turns
+// a temporary socket slowdown into an unnecessary connection reset.
+//
+// The test:
+//  1. Registers established connections A and B on the same agent stream.
+//  2. Blocks A's first DATA write and places one additional DATA payload behind
+//     it.
+//  3. Delivers DATA to B and requires B to progress while A remains blocked.
+//  4. Requires A to remain established and open during the temporary slowdown.
+//  5. Makes A writable and requires both accepted payloads in byte-stream order.
+//  6. Delivers normal CLOSE_RSP and requires close only after A's bytes drain.
+//
+// This deliberately freezes the minimum nonzero recovery guarantee: one small
+// pending DATA payload must not overflow-close A. It does not choose a larger
+// queue depth or sustained-overflow threshold. A time-based policy must not
+// preempt the prompt recovery exercised here, but the test does not decide
+// whether a genuinely prolonged stall may be timed out. No queue, writer
+// goroutine, or dispatcher design is required.
+func TestTemporarilySlowHTTPFrontendRecovers(t *testing.T) {
+	const (
+		agentID    = "agent-1"
+		connectIDA = int64(1001)
+		connectIDB = int64(1002)
+		payloadB   = "response for healthy connection B"
+	)
+	payloadsA := [][]byte{[]byte("first response for A"), []byte("second response for A")}
+	wantStreamA := bytes.Join(payloadsA, nil)
+
+	proxyServer := NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		2,
+	)
+	backend := &Backend{id: agentID}
+
+	frontendA := newByteStreamHTTPReadWriter()
+	connectionA := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      frontendA,
+		CloseHTTP: frontendA.close,
+		connected: make(chan struct{}),
+		connectID: connectIDA,
+		agentID:   agentID,
+		backend:   backend,
+	}
+	proxyServer.addEstablished(agentID, connectIDA, connectionA)
+
+	frontendB := newRecordingHTTPReadWriter()
+	connectionB := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      frontendB,
+		CloseHTTP: func() error { return nil },
+		connected: make(chan struct{}),
+		connectID: connectIDB,
+		agentID:   agentID,
+		backend:   backend,
+	}
+	proxyServer.addEstablished(agentID, connectIDB, connectionB)
+
+	// Once A's first DATA is dequeued and blocked, the channel can hold exactly
+	// one waiting DATA for A and the healthy DATA for B. Reaching B therefore
+	// proves A's second payload was accepted by the frontend delivery path.
+	recvCh := make(chan *client.Packet, 2)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		proxyServer.serveRecvBackend(backend, agentID, recvCh)
+	}()
+
+	var closeRecvOnce sync.Once
+	closeRecv := func() { closeRecvOnce.Do(func() { close(recvCh) }) }
+	t.Cleanup(func() {
+		frontendA.release()
+		closeRecv()
+		select {
+		case <-consumerDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("serveRecvBackend did not exit during cleanup")
+		}
+	})
+
+	recvCh <- dataPkt(connectIDA, payloadsA[0])
+	select {
+	case <-frontendA.firstWriteStarted:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("connection A did not enter the blocking HTTP Write")
+	}
+
+	recvCh <- dataPkt(connectIDA, payloadsA[1])
+	recvCh <- dataPkt(connectIDB, []byte(payloadB))
+
+	select {
+	case got := <-frontendB.writes:
+		if string(got) != payloadB {
+			t.Fatalf("connection B received payload %q, want %q", got, payloadB)
+		}
+	case <-time.After(holTestSafetyTimeout):
+		// Release A only after B's required progress timed out. If B then
+		// progresses, the failure is specifically the shared-consumer HOL stall.
+		frontendA.release()
+		select {
+		case got := <-frontendB.writes:
+			if string(got) != payloadB {
+				t.Fatalf("connection B received payload %q after A recovered, want %q", got, payloadB)
+			}
+			t.Fatal("connection B received DATA only after connection A recovered")
+		case <-time.After(holTestSafetyTimeout):
+			t.Fatal("connection B did not receive DATA even after connection A recovered")
+		}
+	}
+
+	if _, err := proxyServer.getFrontend(agentID, connectIDA); err != nil {
+		t.Fatalf("connection A was removed while temporarily slow: %v", err)
+	}
+	_, _, closedBeforeRecovery, _ := frontendA.snapshot()
+	if closedBeforeRecovery {
+		t.Fatal("connection A was closed instead of isolated while temporarily slow")
+	}
+
+	frontendA.release()
+	deadline := time.NewTimer(holTestSafetyTimeout)
+	defer deadline.Stop()
+	for {
+		gotStream, _, _, _ := frontendA.snapshot()
+		if len(gotStream) >= len(wantStreamA) {
+			break
+		}
+		select {
+		case <-frontendA.streamUpdated:
+		case <-deadline.C:
+			t.Fatalf("connection A received %d bytes after recovery, want %d", len(gotStream), len(wantStreamA))
+		}
+	}
+
+	if _, err := proxyServer.getFrontend(agentID, connectIDA); err != nil {
+		t.Fatalf("connection A was removed during recovery: %v", err)
+	}
+	gotStreamA, _, closedAfterRecovery, _ := frontendA.snapshot()
+	if closedAfterRecovery {
+		t.Fatal("connection A was closed after recovering socket progress")
+	}
+	if !bytes.Equal(gotStreamA, wantStreamA) {
+		t.Fatalf("connection A byte stream after recovery = %q, want %q", gotStreamA, wantStreamA)
+	}
+
+	// Normal backend close is the terminal barrier: it must occur only after A's
+	// accepted bytes have drained and must remove A from established state.
+	recvCh <- &client.Packet{
+		Type: client.PacketType_CLOSE_RSP,
+		Payload: &client.Packet_CloseResponse{
+			CloseResponse: &client.CloseResponse{ConnectID: connectIDA},
+		},
+	}
+	select {
+	case <-frontendA.closeObserved:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("connection A did not close normally after recovery")
+	}
+	gotStreamA, violations, closed, inFlight := frontendA.snapshot()
+	if len(violations) > 0 {
+		t.Fatalf("connection A socket operations were not serialized through close: %v", violations)
+	}
+	if !closed {
+		t.Fatal("connection A did not reach a terminal closed state")
+	}
+	if inFlight != 0 {
+		t.Fatalf("connection A closed with %d socket operations still in flight", inFlight)
+	}
+	if !bytes.Equal(gotStreamA, wantStreamA) {
+		t.Fatalf("connection A final byte stream = %q, want %q", gotStreamA, wantStreamA)
+	}
+	if _, err := proxyServer.getFrontend(agentID, connectIDA); err == nil {
+		t.Fatal("connection A remained established after normal close")
+	}
+
+	closeRecv()
+	select {
+	case <-consumerDone:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("serveRecvBackend did not exit after recovery test")
 	}
 }

--- a/pkg/server/http_connect_hol_test.go
+++ b/pkg/server/http_connect_hol_test.go
@@ -1210,3 +1210,221 @@ func TestHTTPConnectResponsePrecedesTunnelData(t *testing.T) {
 		t.Fatalf("frontend byte stream = %q, want CONNECT response followed by DATA %q", gotStream, wantStream)
 	}
 }
+
+// TestConcurrentHTTPFrontendAndBackendClose targets overlapping frontend EOF
+// and backend CLOSE_RSP for the same established HTTP-CONNECT tunnel.
+//
+// The test:
+//  1. Establishes a real Tunnel and verifies the successful HTTP 200 response.
+//  2. Closes the frontend peer so Tunnel initiates backend CLOSE_REQ.
+//  3. Pauses that CLOSE_REQ in flight and delivers backend CLOSE_RSP.
+//  4. Requires CLOSE_RSP to close the frontend, then releases CLOSE_REQ.
+//  5. Requires exactly one correctly addressed CLOSE_REQ, both serving paths to
+//     exit, no socket operation in flight, and no established or pending state.
+//
+// Close ownership is not assigned to any goroutine, queue, or state-machine
+// implementation; only protocol-visible shutdown and final state are asserted.
+func TestConcurrentHTTPFrontendAndBackendClose(t *testing.T) {
+	const (
+		agentID   = "agent-1"
+		connectID = int64(1001)
+		target    = "istiod-stable.istio-system.svc:443"
+	)
+	connectResponse := []byte("HTTP/1.1 200 Connection Established\r\n\r\n")
+
+	ctrl := gomock.NewController(t)
+	backendConn := mockAgentConn(ctrl, agentID, []string{})
+	dialRequests := make(chan *client.Packet, 1)
+	closeRequestStarted := make(chan struct{})
+	releaseCloseRequest := make(chan struct{})
+	var (
+		closeRequestCount atomic.Int32
+		closeStartedOnce  sync.Once
+		closeReleaseOnce  sync.Once
+	)
+	releaseBackendClose := func() {
+		closeReleaseOnce.Do(func() { close(releaseCloseRequest) })
+	}
+	backendConn.EXPECT().Send(gomock.Any()).DoAndReturn(func(pkt *client.Packet) error {
+		switch pkt.Type {
+		case client.PacketType_DIAL_REQ:
+			select {
+			case dialRequests <- pkt:
+			default:
+				t.Errorf("received duplicate backend DIAL_REQ")
+			}
+		case client.PacketType_CLOSE_REQ:
+			if count := closeRequestCount.Add(1); count != 1 {
+				t.Errorf("backend received %d CLOSE_REQ packets, want exactly one", count)
+			}
+			closePayload := pkt.GetCloseRequest()
+			if closePayload == nil {
+				t.Errorf("backend CLOSE_REQ did not contain a close request payload")
+			} else if closePayload.ConnectID != connectID {
+				t.Errorf("backend CLOSE_REQ connectID = %d, want %d", closePayload.ConnectID, connectID)
+			}
+			closeStartedOnce.Do(func() { close(closeRequestStarted) })
+			<-releaseCloseRequest
+		default:
+			t.Errorf("backend Send packet type = %v, want DIAL_REQ or CLOSE_REQ", pkt.Type)
+		}
+		return nil
+	}).AnyTimes()
+
+	backend, err := NewBackend(backendConn)
+	if err != nil {
+		t.Fatalf("NewBackend: %v", err)
+	}
+	backendCtx, cancelBackend := context.WithCancel(backend.Context())
+	backend.conn = &backendConnWithContext{
+		AgentService_ConnectServer: backendConn,
+		ctx:                        backendCtx,
+	}
+	proxyServer := NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		1,
+	)
+	proxyServer.addBackend(backend)
+
+	recvCh := make(chan *client.Packet)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		proxyServer.serveRecvBackend(backend, agentID, recvCh)
+	}()
+
+	frontendConn := newObservedHTTPConn()
+	// This test does not exercise a slow socket. Let the CONNECT response write
+	// complete normally before initiating either close path.
+	frontendConn.sink.release()
+	responseWriter := newHijackingResponseWriter(frontendConn)
+	request := httptest.NewRequest(http.MethodConnect, "http://example.invalid", nil)
+	request.Host = target
+	tunnelDone := make(chan struct{})
+	go func() {
+		defer close(tunnelDone)
+		(&Tunnel{Server: proxyServer}).ServeHTTP(responseWriter, request)
+	}()
+
+	var (
+		closeRecvOnce sync.Once
+		dialID        int64
+		dialCaptured  bool
+	)
+	closeRecv := func() { closeRecvOnce.Do(func() { close(recvCh) }) }
+	t.Cleanup(func() {
+		releaseBackendClose()
+		frontendConn.sink.release()
+		if dialCaptured {
+			if pending := proxyServer.PendingDial.Remove(dialID); pending != nil {
+				_ = pending.CloseHTTP()
+			}
+		}
+		_ = frontendConn.peer.Close()
+		_ = frontendConn.Close()
+		cancelBackend()
+		closeRecv()
+		select {
+		case <-consumerDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("serveRecvBackend did not exit during cleanup")
+		}
+		select {
+		case <-tunnelDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("HTTP tunnel did not exit during cleanup")
+		}
+	})
+
+	var dialRequest *client.Packet
+	select {
+	case dialRequest = <-dialRequests:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("HTTP tunnel did not send DIAL_REQ to the backend")
+	}
+	dial := dialRequest.GetDialRequest()
+	if dial == nil {
+		t.Fatal("backend DIAL_REQ did not contain a dial request payload")
+	}
+	dialID = dial.Random
+	dialCaptured = true
+	if dial.Address != target {
+		t.Fatalf("backend DIAL_REQ = %v, want address %q", dial, target)
+	}
+
+	recvCh <- &client.Packet{
+		Type: client.PacketType_DIAL_RSP,
+		Payload: &client.Packet_DialResponse{
+			DialResponse: &client.DialResponse{Random: dialID, ConnectID: connectID},
+		},
+	}
+	select {
+	case <-frontendConn.sink.streamUpdated:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("frontend did not receive the successful CONNECT response")
+	}
+	gotResponse, _, _, _ := frontendConn.sink.snapshot()
+	if !bytes.Equal(gotResponse, connectResponse) {
+		t.Fatalf("frontend byte stream before close = %q, want %q", gotResponse, connectResponse)
+	}
+
+	// Closing the peer supplies frontend EOF. Tunnel begins CLOSE_REQ and the
+	// mock pauses it in flight, creating a deterministic overlap window for the
+	// backend CLOSE_RSP path.
+	if err := frontendConn.peer.Close(); err != nil {
+		t.Fatalf("closing frontend peer: %v", err)
+	}
+	select {
+	case <-closeRequestStarted:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("frontend EOF did not initiate backend CLOSE_REQ")
+	}
+
+	recvCh <- &client.Packet{
+		Type: client.PacketType_CLOSE_RSP,
+		Payload: &client.Packet_CloseResponse{
+			CloseResponse: &client.CloseResponse{ConnectID: connectID},
+		},
+	}
+	select {
+	case <-frontendConn.sink.closeObserved:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("backend CLOSE_RSP did not close the frontend socket")
+	}
+
+	releaseBackendClose()
+	select {
+	case <-tunnelDone:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("HTTP tunnel did not exit after concurrent frontend/backend close")
+	}
+	closeRecv()
+	select {
+	case <-consumerDone:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("serveRecvBackend did not exit after concurrent close")
+	}
+
+	if got := closeRequestCount.Load(); got != 1 {
+		t.Fatalf("backend CLOSE_REQ count = %d, want 1", got)
+	}
+	_, _, closed, inFlight := frontendConn.sink.snapshot()
+	if !closed {
+		t.Fatal("frontend socket did not reach a terminal closed state")
+	}
+	if inFlight != 0 {
+		t.Fatalf("frontend closed with %d socket operations still in flight", inFlight)
+	}
+	if _, err := proxyServer.getFrontend(agentID, connectID); err == nil {
+		t.Fatal("connection remained or was recreated in established state after concurrent close")
+	}
+	proxyServer.PendingDial.mu.RLock()
+	_, stillPending := proxyServer.PendingDial.pendingDial[dialID]
+	proxyServer.PendingDial.mu.RUnlock()
+	if stillPending {
+		t.Fatal("connection reappeared in pending state after concurrent close")
+	}
+}

--- a/pkg/server/http_connect_hol_test.go
+++ b/pkg/server/http_connect_hol_test.go
@@ -1,0 +1,479 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+
+	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
+	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
+)
+
+// holTestSafetyTimeout is a failure-safety bound for local test synchronization,
+// not a production latency requirement or SLO.
+const holTestSafetyTimeout = time.Second
+
+type blockingHTTPReadWriter struct {
+	writeStarted chan struct{}
+	releaseWrite chan struct{}
+
+	startOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+// closeUnblocksHTTPReadWriter models the relevant net.Conn close behavior for
+// backend-shutdown tests: CloseHTTP terminates a blocked Write. A test-only
+// release exists solely to make failure cleanup safe; it does not mark the
+// frontend closed.
+type closeUnblocksHTTPReadWriter struct {
+	writeStarted  chan struct{}
+	writeDone     chan struct{}
+	closeObserved chan struct{}
+	releaseWrite  chan struct{}
+
+	mu       sync.Mutex
+	closed   bool
+	writeErr error
+
+	startOnce   sync.Once
+	doneOnce    sync.Once
+	closeOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newCloseUnblocksHTTPReadWriter() *closeUnblocksHTTPReadWriter {
+	return &closeUnblocksHTTPReadWriter{
+		writeStarted:  make(chan struct{}),
+		writeDone:     make(chan struct{}),
+		closeObserved: make(chan struct{}),
+		releaseWrite:  make(chan struct{}),
+	}
+}
+
+func (w *closeUnblocksHTTPReadWriter) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (w *closeUnblocksHTTPReadWriter) Write(p []byte) (int, error) {
+	w.startOnce.Do(func() { close(w.writeStarted) })
+	<-w.releaseWrite
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	defer w.doneOnce.Do(func() { close(w.writeDone) })
+	if w.closed {
+		w.writeErr = io.ErrClosedPipe
+		return 0, w.writeErr
+	}
+	return len(p), nil
+}
+
+func (w *closeUnblocksHTTPReadWriter) close() error {
+	w.closeOnce.Do(func() {
+		w.mu.Lock()
+		w.closed = true
+		w.mu.Unlock()
+		close(w.closeObserved)
+		w.release()
+	})
+	return nil
+}
+
+func (w *closeUnblocksHTTPReadWriter) release() {
+	w.releaseOnce.Do(func() { close(w.releaseWrite) })
+}
+
+func (w *closeUnblocksHTTPReadWriter) snapshot() (bool, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closed, w.writeErr
+}
+
+func newBlockingHTTPReadWriter() *blockingHTTPReadWriter {
+	return &blockingHTTPReadWriter{
+		writeStarted: make(chan struct{}),
+		releaseWrite: make(chan struct{}),
+	}
+}
+
+func (w *blockingHTTPReadWriter) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (w *blockingHTTPReadWriter) Write(p []byte) (int, error) {
+	w.startOnce.Do(func() {
+		close(w.writeStarted)
+	})
+	<-w.releaseWrite
+	return len(p), nil
+}
+
+func (w *blockingHTTPReadWriter) release() {
+	w.releaseOnce.Do(func() {
+		close(w.releaseWrite)
+	})
+}
+
+// released reports whether the blocking write has been released (e.g. by
+// CloseHTTP overflow-closing the connection). It is a non-blocking check.
+func (w *blockingHTTPReadWriter) released() bool {
+	select {
+	case <-w.releaseWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+// recordingHTTPReadWriter intentionally buffers one write. It is suitable only
+// for tests that send a single DATA packet before reading from writes.
+type recordingHTTPReadWriter struct {
+	writes chan []byte
+}
+
+func newRecordingHTTPReadWriter() *recordingHTTPReadWriter {
+	return &recordingHTTPReadWriter{
+		writes: make(chan []byte, 1),
+	}
+}
+
+func (w *recordingHTTPReadWriter) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (w *recordingHTTPReadWriter) Write(p []byte) (int, error) {
+	payload := append([]byte(nil), p...)
+	w.writes <- payload
+	return len(p), nil
+}
+
+// byteStreamHTTPReadWriter verifies the socket-level contract for one tunnel:
+// writes and close are serialized, and writes preserve one continuous byte
+// stream. It intentionally does not assume that protocol DATA packet boundaries
+// correspond to calls to Write.
+type byteStreamHTTPReadWriter struct {
+	firstWriteStarted chan struct{}
+	releaseFirstWrite chan struct{}
+	streamUpdated     chan struct{}
+	closeObserved     chan struct{}
+
+	inFlight atomic.Int32
+
+	mu          sync.Mutex
+	stream      []byte
+	closed      bool
+	violations  []string
+	firstOnce   sync.Once
+	releaseOnce sync.Once
+	closeOnce   sync.Once
+}
+
+func newByteStreamHTTPReadWriter() *byteStreamHTTPReadWriter {
+	return &byteStreamHTTPReadWriter{
+		firstWriteStarted: make(chan struct{}),
+		releaseFirstWrite: make(chan struct{}),
+		streamUpdated:     make(chan struct{}, 1),
+		closeObserved:     make(chan struct{}),
+	}
+}
+
+func (w *byteStreamHTTPReadWriter) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (w *byteStreamHTTPReadWriter) Write(p []byte) (int, error) {
+	w.enter("Write")
+	defer w.leave()
+
+	isFirst := false
+	w.firstOnce.Do(func() {
+		isFirst = true
+		close(w.firstWriteStarted)
+	})
+	if isFirst {
+		<-w.releaseFirstWrite
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		w.recordViolationLocked("Write completed after CloseHTTP")
+		return 0, io.ErrClosedPipe
+	}
+	// This test exercises ordering only. Short writes have a separate contract
+	// and must be covered by a dedicated test.
+	w.stream = append(w.stream, p...)
+	select {
+	case w.streamUpdated <- struct{}{}:
+	default:
+	}
+	return len(p), nil
+}
+
+func (w *byteStreamHTTPReadWriter) enter(operation string) {
+	if inFlight := w.inFlight.Add(1); inFlight > 1 {
+		w.recordViolation(fmt.Sprintf("%s overlapped another socket operation", operation))
+	}
+}
+
+func (w *byteStreamHTTPReadWriter) leave() {
+	w.inFlight.Add(-1)
+}
+
+func (w *byteStreamHTTPReadWriter) release() {
+	w.releaseOnce.Do(func() { close(w.releaseFirstWrite) })
+}
+
+func (w *byteStreamHTTPReadWriter) close() error {
+	w.enter("CloseHTTP")
+
+	w.mu.Lock()
+	if w.closed {
+		w.recordViolationLocked("CloseHTTP called more than once")
+	} else {
+		w.closed = true
+	}
+	w.mu.Unlock()
+	w.leave()
+	w.closeOnce.Do(func() { close(w.closeObserved) })
+	return nil
+}
+
+func (w *byteStreamHTTPReadWriter) recordViolation(violation string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.recordViolationLocked(violation)
+}
+
+func (w *byteStreamHTTPReadWriter) recordViolationLocked(violation string) {
+	w.violations = append(w.violations, violation)
+}
+
+func (w *byteStreamHTTPReadWriter) snapshot() ([]byte, []string, bool, int32) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]byte(nil), w.stream...), append([]string(nil), w.violations...), w.closed, w.inFlight.Load()
+}
+
+// observedHTTPConn adapts byteStreamHTTPReadWriter to the net.Conn returned by
+// an HTTP hijack. Reads block on a pipe until Close, while writes remain fully
+// controlled and observable by the test.
+type observedHTTPConn struct {
+	net.Conn
+	peer net.Conn
+	sink *byteStreamHTTPReadWriter
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func newObservedHTTPConn() *observedHTTPConn {
+	conn, peer := net.Pipe()
+	return &observedHTTPConn{
+		Conn: conn,
+		peer: peer,
+		sink: newByteStreamHTTPReadWriter(),
+	}
+}
+
+func (c *observedHTTPConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) {
+		return n, io.EOF
+	}
+	return n, err
+}
+
+func (c *observedHTTPConn) Write(p []byte) (int, error) {
+	return c.sink.Write(p)
+}
+
+func (c *observedHTTPConn) Close() error {
+	c.closeOnce.Do(func() {
+		if err := c.sink.close(); err != nil {
+			c.closeErr = err
+		}
+		if err := c.Conn.Close(); c.closeErr == nil {
+			c.closeErr = err
+		}
+		// The peer is test-side plumbing. It may already be closed to simulate
+		// frontend EOF, so its cleanup error is not a server-socket close error.
+		_ = c.peer.Close()
+	})
+	return c.closeErr
+}
+
+type hijackingResponseWriter struct {
+	header http.Header
+	conn   net.Conn
+	bufrw  *bufio.ReadWriter
+}
+
+func newHijackingResponseWriter(conn net.Conn) *hijackingResponseWriter {
+	return &hijackingResponseWriter{
+		header: make(http.Header),
+		conn:   conn,
+		bufrw:  bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn)),
+	}
+}
+
+func (w *hijackingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *hijackingResponseWriter) Write(p []byte) (int, error) {
+	return w.conn.Write(p)
+}
+
+func (w *hijackingResponseWriter) WriteHeader(int) {}
+
+func (w *hijackingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.conn, w.bufrw, nil
+}
+
+// backendConnWithContext keeps the mock stream behavior while allowing a test
+// to cancel Backend.Context independently of the mock's metadata-bearing
+// context. Cancellation unblocks a Tunnel still waiting for DIAL_RSP.
+type backendConnWithContext struct {
+	agent.AgentService_ConnectServer
+	ctx context.Context
+}
+
+func (c *backendConnWithContext) Context() context.Context {
+	return c.ctx
+}
+
+// TestSlowHTTPFrontendDoesNotDelayDialResponse targets the incident's control-
+// packet head-of-line blocking in serveRecvBackend.
+//
+// The test:
+//  1. Registers established HTTP-CONNECT connection A and pending connection B
+//     on the same agent stream.
+//  2. Blocks A inside its hijacked-socket Write.
+//  3. Delivers B's DIAL_RSP while A remains blocked.
+//  4. Requires B to establish without releasing or closing A.
+//
+// This proves that lack of socket progress for one frontend cannot park the
+// shared backend consumer or delay an unrelated connection's establishment.
+func TestSlowHTTPFrontendDoesNotDelayDialResponse(t *testing.T) {
+	const (
+		agentID    = "agent-1"
+		connectIDA = int64(1001)
+		connectIDB = int64(1002)
+		dialIDB    = int64(2002)
+	)
+
+	proxyServer := NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		1,
+	)
+	backend := &Backend{id: agentID}
+
+	slowHTTP := newBlockingHTTPReadWriter()
+	connectionA := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      slowHTTP,
+		CloseHTTP: func() error { slowHTTP.release(); return nil },
+		connected: make(chan struct{}),
+		connectID: connectIDA,
+		agentID:   agentID,
+		backend:   backend,
+	}
+	proxyServer.addEstablished(agentID, connectIDA, connectionA)
+
+	connectionB := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		CloseHTTP: func() error { return nil },
+		connected: make(chan struct{}),
+		dialID:    dialIDB,
+		agentID:   agentID,
+		start:     time.Now(),
+		backend:   backend,
+	}
+	proxyServer.PendingDial.Add(dialIDB, connectionB)
+
+	recvCh := make(chan *client.Packet, 1)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		proxyServer.serveRecvBackend(backend, agentID, recvCh)
+	}()
+
+	t.Cleanup(func() {
+		slowHTTP.release()
+		close(recvCh)
+		select {
+		case <-consumerDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("serveRecvBackend did not exit during test cleanup")
+		}
+	})
+
+	recvCh <- dataPkt(connectIDA, []byte("response for connection A"))
+
+	select {
+	case <-slowHTTP.writeStarted:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("connection A did not enter the blocking HTTP Write")
+	}
+
+	recvCh <- &client.Packet{
+		Type: client.PacketType_DIAL_RSP,
+		Payload: &client.Packet_DialResponse{
+			DialResponse: &client.DialResponse{
+				Random:    dialIDB,
+				ConnectID: connectIDB,
+			},
+		},
+	}
+
+	select {
+	case <-connectionB.connected:
+		// Desired behavior: B establishes while A remains blocked. There are no
+		// packets after B's DIAL_RSP, so A cannot be legitimately overflow-closed
+		// here; A's write must still be blocked. This deterministically proves B
+		// was rescued by isolating the consumer from A's write, not by killing A.
+		if slowHTTP.released() {
+			t.Fatal("connection A was released/closed before B established; B must establish via isolation, not by killing A")
+		}
+	case <-time.After(holTestSafetyTimeout):
+		// Release A only after the required progress timed out, both to clean up
+		// and to prove that A's Write was the operation preventing B's progress.
+		slowHTTP.release()
+		select {
+		case <-connectionB.connected:
+			t.Fatal("connection B established only after connection A's blocked HTTP Write was released")
+		case <-time.After(holTestSafetyTimeout):
+			t.Fatal("connection B did not establish even after connection A was released")
+		}
+	}
+}

--- a/pkg/server/http_connect_hol_test.go
+++ b/pkg/server/http_connect_hol_test.go
@@ -1428,3 +1428,158 @@ func TestConcurrentHTTPFrontendAndBackendClose(t *testing.T) {
 		t.Fatal("connection reappeared in pending state after concurrent close")
 	}
 }
+
+// TestManySlowHTTPFrontendsDoNotDelayDialResponse targets a fix that isolates
+// only one slow frontend but still stalls behind several slow connections.
+//
+// For slow-frontend counts 2 and 10, the test:
+//  1. Registers each slow connection on one agent stream.
+//  2. Blocks the connections in deterministic stream order.
+//  3. Delivers DIAL_RSP and DATA for healthy connection B after all slow DATA.
+//  4. Requires B to establish and receive its exact DATA before any slow
+//     frontend is released or closed.
+//  5. Requires all slow connections to remain alive through B's progress.
+//
+// The contract is observable multi-connection isolation; it does not require a
+// per-connection worker, queue, or other dispatch architecture.
+func TestManySlowHTTPFrontendsDoNotDelayDialResponse(t *testing.T) {
+	for _, slowFrontendCount := range []int{2, 10} {
+		slowFrontendCount := slowFrontendCount
+		t.Run(fmt.Sprintf("slow_frontends=%d", slowFrontendCount), func(t *testing.T) {
+			runManySlowHTTPFrontendsDialResponseCase(t, slowFrontendCount)
+		})
+	}
+}
+
+func runManySlowHTTPFrontendsDialResponseCase(t *testing.T, slowFrontendCount int) {
+	const (
+		agentID    = "agent-1"
+		dialIDB    = int64(2001)
+		connectIDB = int64(3001)
+		payloadB   = "response for healthy connection B"
+	)
+
+	proxyServer := NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		slowFrontendCount,
+	)
+	backend := &Backend{id: agentID}
+
+	slowHTTPs := make([]*blockingHTTPReadWriter, 0, slowFrontendCount)
+	connectIDs := make([]int64, 0, slowFrontendCount)
+	for i := 0; i < slowFrontendCount; i++ {
+		slowHTTP := newBlockingHTTPReadWriter()
+		connectID := int64(1001 + i)
+		connection := &ProxyClientConnection{
+			Mode:      ModeHTTPConnect,
+			HTTP:      slowHTTP,
+			CloseHTTP: func() error { slowHTTP.release(); return nil },
+			connected: make(chan struct{}),
+			connectID: connectID,
+			agentID:   agentID,
+			backend:   backend,
+		}
+		proxyServer.addEstablished(agentID, connectID, connection)
+		slowHTTPs = append(slowHTTPs, slowHTTP)
+		connectIDs = append(connectIDs, connectID)
+	}
+
+	recordingHTTP := newRecordingHTTPReadWriter()
+	connectionB := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      recordingHTTP,
+		CloseHTTP: func() error { return nil },
+		connected: make(chan struct{}),
+		dialID:    dialIDB,
+		agentID:   agentID,
+		start:     time.Now(),
+		backend:   backend,
+	}
+	proxyServer.PendingDial.Add(dialIDB, connectionB)
+
+	// Writer 0's DATA is dequeued before the remaining packets are staged.
+	// Capacity N therefore holds exactly the remaining N-1 DATA packets plus
+	// B's final DIAL_RSP, so the producer cannot become the source of the stall.
+	recvCh := make(chan *client.Packet, slowFrontendCount)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		proxyServer.serveRecvBackend(backend, agentID, recvCh)
+	}()
+
+	releaseAll := func() {
+		for _, slowHTTP := range slowHTTPs {
+			slowHTTP.release()
+		}
+	}
+	t.Cleanup(func() {
+		releaseAll()
+		close(recvCh)
+		select {
+		case <-consumerDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("serveRecvBackend did not exit during test cleanup")
+		}
+	})
+
+	// Establish one actually blocked frontend before staging the remaining slow
+	// connections and B. The test does not require the implementation to start a
+	// Write for every other slow connection; only healthy B's progress matters.
+	recvCh <- dataPkt(connectIDs[0], []byte("response for slow connection 0"))
+	select {
+	case <-slowHTTPs[0].writeStarted:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("first slow connection did not enter the blocking HTTP Write")
+	}
+
+	for i := 1; i < slowFrontendCount; i++ {
+		recvCh <- dataPkt(connectIDs[i], []byte(fmt.Sprintf("response for slow connection %d", i)))
+	}
+	recvCh <- &client.Packet{
+		Type: client.PacketType_DIAL_RSP,
+		Payload: &client.Packet_DialResponse{
+			DialResponse: &client.DialResponse{
+				Random:    dialIDB,
+				ConnectID: connectIDB,
+			},
+		},
+	}
+
+	select {
+	case <-connectionB.connected:
+		// A DIAL_RSP-only priority mechanism is insufficient: after B establishes,
+		// exact DATA for B must also traverse the same loaded backend path.
+		recvCh <- dataPkt(connectIDB, []byte(payloadB))
+		select {
+		case got := <-recordingHTTP.writes:
+			if string(got) != payloadB {
+				t.Fatalf("connection B received payload %q, want %q", got, payloadB)
+			}
+		case <-time.After(holTestSafetyTimeout):
+			t.Fatal("connection B established but its DATA was delayed by the slow HTTP frontends")
+		}
+
+		// Each slow connection has only one DATA packet, so closing one is not a
+		// legitimate overflow response. The monotonic release signal catches a
+		// connection killed at any point before healthy B's DATA was delivered.
+		for i, slowHTTP := range slowHTTPs {
+			if slowHTTP.released() {
+				t.Fatalf("slow connection %d was released/closed to make healthy B progress", i)
+			}
+		}
+	case <-time.After(holTestSafetyTimeout):
+		// Release the slow frontends only after B failed to progress. If B then
+		// establishes, their blocked writes caused the failure without constraining
+		// how a correct implementation must dispatch writes.
+		releaseAll()
+		select {
+		case <-connectionB.connected:
+			t.Fatal("connection B established only after the slow HTTP frontends were released")
+		case <-time.After(holTestSafetyTimeout):
+			t.Fatal("connection B did not establish even after the slow HTTP frontends were released")
+		}
+	}
+}

--- a/pkg/server/http_connect_hol_test.go
+++ b/pkg/server/http_connect_hol_test.go
@@ -477,3 +477,105 @@ func TestSlowHTTPFrontendDoesNotDelayDialResponse(t *testing.T) {
 		}
 	}
 }
+
+// TestSlowHTTPFrontendDoesNotDelayOtherConnectionData targets DATA-path head-of-
+// line blocking between established HTTP-CONNECT connections.
+//
+// The test:
+//  1. Registers established connections A and B on the same agent stream.
+//  2. Blocks A inside its hijacked-socket Write.
+//  3. Delivers DATA for B while A remains blocked.
+//  4. Requires B to receive its exact payload without releasing or closing A.
+//
+// This prevents a control-packet-only fix that prioritizes DIAL_RSP while
+// leaving unrelated DATA on the same blocking shared-consumer path.
+func TestSlowHTTPFrontendDoesNotDelayOtherConnectionData(t *testing.T) {
+	const (
+		agentID    = "agent-1"
+		connectIDA = int64(1001)
+		connectIDB = int64(1002)
+		payloadB   = "response for connection B"
+	)
+
+	proxyServer := NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		1,
+	)
+	backend := &Backend{id: agentID}
+
+	slowHTTP := newBlockingHTTPReadWriter()
+	connectionA := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      slowHTTP,
+		CloseHTTP: func() error { slowHTTP.release(); return nil },
+		connected: make(chan struct{}),
+		connectID: connectIDA,
+		agentID:   agentID,
+		backend:   backend,
+	}
+	proxyServer.addEstablished(agentID, connectIDA, connectionA)
+
+	recordingHTTP := newRecordingHTTPReadWriter()
+	connectionB := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      recordingHTTP,
+		CloseHTTP: func() error { return nil },
+		connected: make(chan struct{}),
+		connectID: connectIDB,
+		agentID:   agentID,
+		backend:   backend,
+	}
+	proxyServer.addEstablished(agentID, connectIDB, connectionB)
+
+	recvCh := make(chan *client.Packet, 1)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		proxyServer.serveRecvBackend(backend, agentID, recvCh)
+	}()
+
+	t.Cleanup(func() {
+		slowHTTP.release()
+		close(recvCh)
+		select {
+		case <-consumerDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("serveRecvBackend did not exit during test cleanup")
+		}
+	})
+
+	recvCh <- dataPkt(connectIDA, []byte("response for connection A"))
+	select {
+	case <-slowHTTP.writeStarted:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("connection A did not enter the blocking HTTP Write")
+	}
+
+	recvCh <- dataPkt(connectIDB, []byte(payloadB))
+
+	select {
+	case got := <-recordingHTTP.writes:
+		if string(got) != payloadB {
+			t.Fatalf("connection B received payload %q, want %q", got, payloadB)
+		}
+		if slowHTTP.released() {
+			t.Fatal("connection A was released/closed before B received DATA; B must progress via isolation, not by killing A")
+		}
+	case <-time.After(holTestSafetyTimeout):
+		// Release A only to prove that its blocked write was preventing B's DATA
+		// from being processed and to allow deterministic cleanup.
+		slowHTTP.release()
+		select {
+		case got := <-recordingHTTP.writes:
+			if string(got) != payloadB {
+				t.Fatalf("connection B received payload %q after A was released, want %q", got, payloadB)
+			}
+			t.Fatal("connection B received DATA only after connection A's blocked HTTP Write was released")
+		case <-time.After(holTestSafetyTimeout):
+			t.Fatal("connection B did not receive DATA even after connection A was released")
+		}
+	}
+}

--- a/pkg/server/http_connect_hol_test.go
+++ b/pkg/server/http_connect_hol_test.go
@@ -25,11 +25,13 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"go.uber.org/mock/gomock"
 
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
@@ -976,5 +978,235 @@ func TestPerConnectionDataOrdering(t *testing.T) {
 	}
 	if !bytes.Equal(gotStream, wantStream) {
 		t.Fatalf("frontend byte stream = %q, want %q", gotStream, wantStream)
+	}
+}
+
+// TestHTTPConnectResponsePrecedesTunnelData targets ordering at the boundary
+// between Tunnel establishment and backend DATA delivery.
+//
+// The test:
+//  1. Starts a real Tunnel.ServeHTTP path with a hijacked test connection.
+//  2. Completes DIAL_REQ/DIAL_RSP and blocks the successful HTTP 200 Write.
+//  3. Delivers backend DATA, then uses DRAIN as a deterministic shared-consumer
+//     progress marker while the HTTP response remains blocked.
+//  4. Releases the HTTP response and completes CLOSE_RSP/CLOSE_REQ shutdown.
+//  5. Requires the client-visible bytes to be the complete HTTP 200 response
+//     followed by the exact tunneled DATA.
+//
+// Only wire order is asserted; no dispatch or buffering design is required.
+func TestHTTPConnectResponsePrecedesTunnelData(t *testing.T) {
+	const (
+		agentID   = "agent-1"
+		connectID = int64(1001)
+		target    = "istiod-stable.istio-system.svc:443"
+	)
+	connectResponse := []byte("HTTP/1.1 200 Connection Established\r\n\r\n")
+	payload := []byte("tunneled response bytes")
+	wantStream := append(append([]byte(nil), connectResponse...), payload...)
+
+	ctrl := gomock.NewController(t)
+	backendConn := mockAgentConn(ctrl, agentID, []string{})
+	dialRequests := make(chan *client.Packet, 1)
+	closeRequests := make(chan *client.Packet, 1)
+	backendConn.EXPECT().Send(gomock.Any()).DoAndReturn(func(pkt *client.Packet) error {
+		switch pkt.Type {
+		case client.PacketType_DIAL_REQ:
+			select {
+			case dialRequests <- pkt:
+			default:
+				t.Errorf("received duplicate backend DIAL_REQ")
+			}
+		case client.PacketType_CLOSE_REQ:
+			select {
+			case closeRequests <- pkt:
+			default:
+				t.Errorf("received duplicate backend CLOSE_REQ")
+			}
+		default:
+			t.Errorf("backend Send packet type = %v, want DIAL_REQ or CLOSE_REQ", pkt.Type)
+		}
+		return nil
+	}).AnyTimes()
+
+	backend, err := NewBackend(backendConn)
+	if err != nil {
+		t.Fatalf("NewBackend: %v", err)
+	}
+	backendCtx, cancelBackend := context.WithCancel(backend.Context())
+	backend.conn = &backendConnWithContext{
+		AgentService_ConnectServer: backendConn,
+		ctx:                        backendCtx,
+	}
+	proxyServer := NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		1,
+	)
+	proxyServer.addBackend(backend)
+
+	recvCh := make(chan *client.Packet)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		proxyServer.serveRecvBackend(backend, agentID, recvCh)
+	}()
+
+	frontendConn := newObservedHTTPConn()
+	responseWriter := newHijackingResponseWriter(frontendConn)
+	request := httptest.NewRequest(http.MethodConnect, "http://example.invalid", nil)
+	request.Host = target
+	tunnelDone := make(chan struct{})
+	go func() {
+		defer close(tunnelDone)
+		(&Tunnel{Server: proxyServer}).ServeHTTP(responseWriter, request)
+	}()
+
+	var (
+		closeRecvOnce sync.Once
+		feederDone    chan struct{}
+		dialID        int64
+		dialCaptured  bool
+	)
+	closeRecv := func() { closeRecvOnce.Do(func() { close(recvCh) }) }
+	t.Cleanup(func() {
+		// Teardown order is load-bearing:
+		//  1. Release the socket write and stop the feeder before closing recvCh,
+		//     otherwise the feeder could panic by sending to a closed channel.
+		//  2. Close the frontend and cancel the backend context so Tunnel exits
+		//     whether it is blocked in the established read loop or still waiting
+		//     for DIAL_RSP.
+		//  3. Only then close recvCh and wait for the consumer and Tunnel.
+		frontendConn.sink.release()
+		safeToCloseRecv := true
+		if feederDone != nil {
+			select {
+			case <-feederDone:
+			case <-time.After(holTestSafetyTimeout):
+				t.Errorf("backend packet feeder did not exit during cleanup")
+				safeToCloseRecv = false
+			}
+		}
+		if dialCaptured {
+			if pending := proxyServer.PendingDial.Remove(dialID); pending != nil {
+				_ = pending.CloseHTTP()
+			}
+		}
+		_ = frontendConn.Close()
+		cancelBackend()
+		if safeToCloseRecv {
+			closeRecv()
+			select {
+			case <-consumerDone:
+			case <-time.After(holTestSafetyTimeout):
+				t.Errorf("serveRecvBackend did not exit during cleanup")
+			}
+		}
+		select {
+		case <-tunnelDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("HTTP tunnel did not exit during cleanup")
+		}
+	})
+
+	var dialRequest *client.Packet
+	select {
+	case dialRequest = <-dialRequests:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("HTTP tunnel did not send DIAL_REQ to the backend")
+	}
+	dial := dialRequest.GetDialRequest()
+	if dial == nil {
+		t.Fatal("backend DIAL_REQ did not contain a dial request payload")
+	}
+	dialID = dial.Random
+	dialCaptured = true
+	if dial.Address != target {
+		t.Fatalf("backend DIAL_REQ = %v, want address %q", dial, target)
+	}
+
+	recvCh <- &client.Packet{
+		Type: client.PacketType_DIAL_RSP,
+		Payload: &client.Packet_DialResponse{
+			DialResponse: &client.DialResponse{Random: dialID, ConnectID: connectID},
+		},
+	}
+	select {
+	case <-frontendConn.sink.firstWriteStarted:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("HTTP tunnel did not begin writing the successful CONNECT response")
+	}
+
+	// DRAIN is a test-side backend-consumer progress marker. Handing it to the
+	// consumer proves the preceding DATA left the shared consumer and was accepted
+	// by the frontend delivery path while the CONNECT response remained blocked.
+	// This makes the ordering check deterministic without sleeps.
+	feederDone = make(chan struct{})
+	go func() {
+		defer close(feederDone)
+		recvCh <- dataPkt(connectID, payload)
+		recvCh <- &client.Packet{Type: client.PacketType_DRAIN}
+	}()
+	select {
+	case <-feederDone:
+	case <-time.After(holTestSafetyTimeout):
+		frontendConn.sink.release()
+		t.Fatal("backend consumer did not accept DATA while the CONNECT response write was blocked")
+	}
+
+	frontendConn.sink.release()
+	deadline := time.NewTimer(holTestSafetyTimeout)
+	defer deadline.Stop()
+	for {
+		gotStream, _, _, _ := frontendConn.sink.snapshot()
+		if len(gotStream) >= len(wantStream) {
+			break
+		}
+		select {
+		case <-frontendConn.sink.streamUpdated:
+		case <-deadline.C:
+			t.Fatalf("frontend received %d bytes, want %d before close", len(gotStream), len(wantStream))
+		}
+	}
+
+	recvCh <- &client.Packet{
+		Type: client.PacketType_CLOSE_RSP,
+		Payload: &client.Packet_CloseResponse{
+			CloseResponse: &client.CloseResponse{ConnectID: connectID},
+		},
+	}
+	select {
+	case <-frontendConn.sink.closeObserved:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("frontend connection did not close after CLOSE_RSP")
+	}
+	closeRecv()
+	select {
+	case <-consumerDone:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("serveRecvBackend did not exit")
+	}
+	select {
+	case <-tunnelDone:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("HTTP tunnel did not exit after frontend close")
+	}
+	select {
+	case closeRequest := <-closeRequests:
+		closePayload := closeRequest.GetCloseRequest()
+		if closePayload == nil {
+			t.Fatal("backend CLOSE_REQ did not contain a close request payload")
+		}
+		if closePayload.ConnectID != connectID {
+			t.Fatalf("backend CLOSE_REQ connectID = %d, want %d", closePayload.ConnectID, connectID)
+		}
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("HTTP tunnel did not send CLOSE_REQ after frontend close")
+	}
+
+	gotStream, _, _, _ := frontendConn.sink.snapshot()
+	if !bytes.Equal(gotStream, wantStream) {
+		t.Fatalf("frontend byte stream = %q, want CONNECT response followed by DATA %q", gotStream, wantStream)
 	}
 }

--- a/pkg/server/http_connect_hol_test.go
+++ b/pkg/server/http_connect_hol_test.go
@@ -878,3 +878,103 @@ func TestBackendShutdownUnblocksSlowHTTPFrontend(t *testing.T) {
 		t.Fatal("connection remained established after backend shutdown")
 	}
 }
+
+// TestPerConnectionDataOrdering targets reordering, omission, duplication, and
+// close overtaking within one isolated HTTP-CONNECT connection.
+//
+// The test:
+//  1. Registers one established connection and blocks its first socket Write.
+//  2. Delivers three more DATA packets followed by CLOSE_RSP.
+//  3. Releases the first Write.
+//  4. Requires the concatenated DATA byte stream exactly once and in source
+//     order, followed by terminal close with no socket operation in flight.
+//
+// DATA packet boundaries need not map one-to-one to socket Write calls; the
+// observable contract is the byte stream and close ordering.
+func TestPerConnectionDataOrdering(t *testing.T) {
+	const (
+		agentID   = "agent-1"
+		connectID = int64(1001)
+	)
+	payloads := [][]byte{[]byte("first"), []byte("second"), []byte("third"), []byte("fourth")}
+	wantStream := bytes.Join(payloads, nil)
+
+	proxyServer := NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		len(payloads),
+	)
+	backend := &Backend{id: agentID}
+
+	frontendHTTP := newByteStreamHTTPReadWriter()
+	connection := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      frontendHTTP,
+		CloseHTTP: frontendHTTP.close,
+		connected: make(chan struct{}),
+		connectID: connectID,
+		agentID:   agentID,
+		backend:   backend,
+	}
+	proxyServer.addEstablished(agentID, connectID, connection)
+
+	// Once the first DATA is dequeued, the channel has exactly enough capacity
+	// for the remaining DATA packets and the terminal CLOSE_RSP. Test-side sends
+	// therefore cannot become the source of the stall.
+	recvCh := make(chan *client.Packet, len(payloads))
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		proxyServer.serveRecvBackend(backend, agentID, recvCh)
+	}()
+
+	t.Cleanup(func() {
+		frontendHTTP.release()
+		close(recvCh)
+		select {
+		case <-consumerDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("serveRecvBackend did not exit during test cleanup")
+		}
+	})
+
+	recvCh <- dataPkt(connectID, payloads[0])
+	select {
+	case <-frontendHTTP.firstWriteStarted:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("first DATA did not enter the blocking HTTP Write")
+	}
+
+	for _, payload := range payloads[1:] {
+		recvCh <- dataPkt(connectID, payload)
+	}
+	recvCh <- &client.Packet{
+		Type: client.PacketType_CLOSE_RSP,
+		Payload: &client.Packet_CloseResponse{
+			CloseResponse: &client.CloseResponse{ConnectID: connectID},
+		},
+	}
+
+	frontendHTTP.release()
+	select {
+	case <-frontendHTTP.closeObserved:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("timed out waiting for frontend close after ordered DATA")
+	}
+
+	gotStream, violations, closed, inFlight := frontendHTTP.snapshot()
+	if len(violations) > 0 {
+		t.Fatalf("frontend socket operations were not serialized: %v", violations)
+	}
+	if inFlight != 0 {
+		t.Fatalf("frontend close was observed with %d socket operations still in flight", inFlight)
+	}
+	if !closed {
+		t.Fatal("frontend did not observe the terminal close")
+	}
+	if !bytes.Equal(gotStream, wantStream) {
+		t.Fatalf("frontend byte stream = %q, want %q", gotStream, wantStream)
+	}
+}

--- a/pkg/server/http_connect_hol_test.go
+++ b/pkg/server/http_connect_hol_test.go
@@ -765,3 +765,116 @@ func TestTemporarilySlowHTTPFrontendRecovers(t *testing.T) {
 		t.Fatal("serveRecvBackend did not exit after recovery test")
 	}
 }
+
+// TestBackendShutdownUnblocksSlowHTTPFrontend targets cleanup after the agent
+// stream ends while an HTTP-CONNECT frontend socket Write is blocked.
+// ProxyServer.Connect closes recvCh when the agent stream terminates.
+//
+// The test:
+//  1. Registers established HTTP-CONNECT connection A.
+//  2. Blocks A inside its frontend socket Write.
+//  3. Closes recvCh, representing agent-stream termination.
+//  4. Does not release the write on the success path.
+//  5. Requires production cleanup to call CloseHTTP, unblock the pending Write
+//     with io.ErrClosedPipe, remove A from established state, and exit
+//     serveRecvBackend.
+//
+// The required outcome is independent of any writer goroutine, queue, or
+// cancellation implementation.
+func TestBackendShutdownUnblocksSlowHTTPFrontend(t *testing.T) {
+	const (
+		agentID   = "agent-1"
+		connectID = int64(1001)
+	)
+
+	proxyServer := NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		1,
+	)
+	backend := &Backend{id: agentID}
+	frontend := newCloseUnblocksHTTPReadWriter()
+	connection := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      frontend,
+		CloseHTTP: frontend.close,
+		connected: make(chan struct{}),
+		connectID: connectID,
+		agentID:   agentID,
+		backend:   backend,
+	}
+	proxyServer.addEstablished(agentID, connectID, connection)
+
+	recvCh := make(chan *client.Packet)
+	consumerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		proxyServer.serveRecvBackend(backend, agentID, recvCh)
+	}()
+
+	var closeRecvOnce sync.Once
+	closeRecv := func() { closeRecvOnce.Do(func() { close(recvCh) }) }
+	t.Cleanup(func() {
+		// A release here is failure cleanup only. The success path must be
+		// released by production calling CloseHTTP after backend shutdown.
+		frontend.release()
+		closeRecv()
+		select {
+		case <-frontend.writeDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("blocked frontend Write did not exit during cleanup")
+		}
+		select {
+		case <-consumerDone:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("serveRecvBackend did not exit during cleanup")
+		}
+	})
+
+	recvCh <- dataPkt(connectID, []byte("response blocked on frontend socket"))
+	select {
+	case <-frontend.writeStarted:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("frontend DATA did not enter the blocking HTTP Write")
+	}
+
+	// Closing recvCh models readBackendToChannel ending when the agent stream is
+	// lost. No test-side release follows: backend cleanup must close the frontend
+	// and thereby unblock its Write.
+	closeRecv()
+	select {
+	case <-frontend.closeObserved:
+	case <-time.After(holTestSafetyTimeout):
+		frontend.release()
+		select {
+		case <-frontend.closeObserved:
+			t.Fatal("backend shutdown closed the frontend only after its blocked Write was released by the test")
+		case <-time.After(holTestSafetyTimeout):
+			t.Fatal("backend shutdown did not close the blocked HTTP frontend")
+		}
+	}
+
+	select {
+	case <-frontend.writeDone:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("closing the frontend did not unblock its pending Write")
+	}
+	select {
+	case <-consumerDone:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("serveRecvBackend did not exit after backend shutdown")
+	}
+
+	closed, writeErr := frontend.snapshot()
+	if !closed {
+		t.Fatal("frontend did not reach a terminal closed state")
+	}
+	if !errors.Is(writeErr, io.ErrClosedPipe) {
+		t.Fatalf("blocked frontend Write error = %v, want %v", writeErr, io.ErrClosedPipe)
+	}
+	if _, err := proxyServer.getFrontend(agentID, connectID); err == nil {
+		t.Fatal("connection remained established after backend shutdown")
+	}
+}

--- a/pkg/server/http_connect_hol_test.go
+++ b/pkg/server/http_connect_hol_test.go
@@ -31,9 +31,11 @@ import (
 	"testing"
 	"time"
 
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/mock/gomock"
 
 	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
 	"sigs.k8s.io/apiserver-network-proxy/proto/agent"
 )
@@ -1581,5 +1583,254 @@ func runManySlowHTTPFrontendsDialResponseCase(t *testing.T, slowFrontendCount in
 		case <-time.After(holTestSafetyTimeout):
 			t.Fatal("connection B did not establish even after the slow HTTP frontends were released")
 		}
+	}
+}
+
+// TestSlowHTTPFrontendDoesNotSaturateBackendReceiveChannel targets the incident's
+// propagated ingress symptom: "Receive channel from agent is full" and a stuck
+// FullRecvChannel("Connect") gauge. It drives readBackendToChannel -> recvCh ->
+// serveRecvBackend, but not the outer Connect RPC wrapper.
+//
+// For capacities 1 and 10, the test:
+//  1. Blocks established connection A in its HTTP socket Write.
+//  2. Delivers B's DIAL_RSP, then N+1 filler DATA packets for A so the backlog
+//     exceeds a capacity-N backend receive channel.
+//  3. Delivers terminal DATA for healthy B after the filler traffic.
+//  4. Confirms the FullRecvChannel gauge rises while current code is stalled.
+//  5. Requires B to establish and receive its exact DATA without test-releasing
+//     A, then requires the shared receive-channel gauge to settle to zero.
+//
+// Capacity 1 is the minimal reproduction; capacity 10 matches the default
+// konnectivity-server backend Connect receive channel (agent -> server), not the
+// HTTP-CONNECT frontend path. A transient gauge increase is acceptable. A may
+// also be overflow-closed under the frozen sustained-backpressure policy; the
+// required outcome is that healthy traffic and shared ingress do not remain
+// stuck. No frontend dispatch architecture is prescribed.
+func TestSlowHTTPFrontendDoesNotSaturateBackendReceiveChannel(t *testing.T) {
+	for _, capacity := range []int{1, 10} {
+		capacity := capacity
+		t.Run(fmt.Sprintf("capacity=%d", capacity), func(t *testing.T) {
+			runSlowHTTPFrontendSaturationCase(t, capacity)
+		})
+	}
+}
+
+func runSlowHTTPFrontendSaturationCase(t *testing.T, capacity int) {
+	const (
+		agentID    = "agent-1"
+		connectIDA = int64(1001)
+		connectIDB = int64(1002)
+		dialIDB    = int64(2002)
+		payloadB   = "terminal response for healthy connection B"
+	)
+
+	metrics.Metrics.Reset()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proxyServer := NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		capacity,
+	)
+
+	dialRSPFor := func(random, connID int64) *client.Packet {
+		return &client.Packet{
+			Type: client.PacketType_DIAL_RSP,
+			Payload: &client.Packet_DialResponse{
+				DialResponse: &client.DialResponse{
+					Random:    random,
+					ConnectID: connID,
+				},
+			},
+		}
+	}
+
+	// Packets are released to the mock reader in stages, not preloaded, so the
+	// sustained saturation is provably caused by A's parked write rather than by
+	// the reader outrunning the consumer. The gate is opened only after A is
+	// confirmed blocked. gateOnce lets cleanup reopen it safely if the test
+	// fails before the main path does.
+	gateOpen := make(chan struct{})
+	var gateOnce sync.Once
+	openGate := func() { gateOnce.Do(func() { close(gateOpen) }) }
+
+	packets := make(chan *client.Packet)
+	fillerCount := capacity + 1
+
+	conn := mockAgentConn(ctrl, agentID, []string{})
+	// A bounded backpressure policy may legitimately close A after sustained
+	// overload. Later DATA for the now-missing frontend may repeat the close
+	// request, so accept any number of CLOSE_REQ packets for A while rejecting
+	// every other send.
+	conn.EXPECT().Send(gomock.Any()).DoAndReturn(func(pkt *client.Packet) error {
+		if pkt.Type != client.PacketType_CLOSE_REQ {
+			t.Errorf("backend Send packet type = %v, want CLOSE_REQ", pkt.Type)
+			return nil
+		}
+		closeReq := pkt.GetCloseRequest()
+		if closeReq == nil || closeReq.ConnectID != connectIDA {
+			t.Errorf("backend CLOSE_REQ = %v, want connectID %d", closeReq, connectIDA)
+		}
+		return nil
+	}).AnyTimes()
+	conn.EXPECT().Recv().DoAndReturn(func() (*client.Packet, error) {
+		if pkt, ok := <-packets; ok {
+			return pkt, nil
+		}
+		return nil, io.EOF
+	}).AnyTimes()
+	backend, err := NewBackend(conn)
+	if err != nil {
+		t.Fatalf("NewBackend: %v", err)
+	}
+
+	slowHTTP := newBlockingHTTPReadWriter()
+	connectionA := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      slowHTTP,
+		CloseHTTP: func() error { slowHTTP.release(); return nil },
+		connected: make(chan struct{}),
+		connectID: connectIDA,
+		agentID:   agentID,
+		backend:   backend,
+	}
+	proxyServer.addEstablished(agentID, connectIDA, connectionA)
+
+	recordingHTTP := newRecordingHTTPReadWriter()
+	connectionB := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      recordingHTTP,
+		CloseHTTP: func() error { return nil },
+		connected: make(chan struct{}),
+		dialID:    dialIDB,
+		agentID:   agentID,
+		start:     time.Now(),
+		backend:   backend,
+	}
+	proxyServer.PendingDial.Add(dialIDB, connectionB)
+
+	recvCh := make(chan *client.Packet, capacity)
+	stopCh := make(chan error, 1)
+	consumerDone := make(chan struct{})
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(consumerDone)
+		proxyServer.serveRecvBackend(backend, agentID, recvCh)
+	}()
+	go func() {
+		defer close(readerDone)
+		proxyServer.readBackendToChannel(backend, recvCh, stopCh)
+	}()
+
+	// The feeder owns the packets channel: it delivers A's DATA, then (after the
+	// gate opens) B's DIAL_RSP, N+1 A fillers, and finally DATA for healthy B, then
+	// closes packets so the reader sees EOF. allPacketsPulled reports that the
+	// mock stream yielded every packet; it does NOT by itself prove those
+	// packets were inserted into recvCh or consumed. Delivery to B is the
+	// end-to-end progress proof.
+	allPacketsPulled := make(chan struct{})
+	go func() {
+		defer close(allPacketsPulled)
+		packets <- dataPkt(connectIDA, []byte("response for connection A"))
+		<-gateOpen
+		packets <- dialRSPFor(dialIDB, connectIDB)
+		for i := 0; i < fillerCount; i++ {
+			packets <- dataPkt(connectIDA, []byte("filler to saturate recvCh"))
+		}
+		packets <- dataPkt(connectIDB, []byte(payloadB))
+		close(packets)
+	}()
+
+	t.Cleanup(func() {
+		openGate()         // unblock the feeder if we failed before opening it.
+		slowHTTP.release() // unblock A so the consumer and reader can drain.
+		select {
+		case <-allPacketsPulled:
+		case <-time.After(holTestSafetyTimeout):
+			t.Errorf("feeder did not finish delivering packets during cleanup")
+		}
+		select {
+		case <-readerDone:
+			// Only safe to close recvCh once the reader has stopped sending.
+			close(recvCh) // mirrors production defer; lets the consumer loop end.
+			select {
+			case <-consumerDone:
+			case <-time.After(holTestSafetyTimeout):
+				t.Errorf("serveRecvBackend did not exit during test cleanup")
+			}
+		case <-time.After(holTestSafetyTimeout):
+			// Do not close recvCh while readBackendToChannel may still send to
+			// it; that would panic and mask the real failure.
+			t.Errorf("readBackendToChannel did not exit during test cleanup; leaving recvCh open to avoid send-on-closed")
+		}
+	})
+
+	// Wait until A is provably blocked inside its HTTP Write, then open the gate
+	// so any saturation is attributable to A.
+	select {
+	case <-slowHTTP.writeStarted:
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("connection A did not enter the blocking HTTP Write")
+	}
+	openGate()
+
+	// Desired behavior: B establishes without the test releasing A.
+	select {
+	case <-connectionB.connected:
+	case <-time.After(holTestSafetyTimeout):
+		// Failure diagnosis: prove that the receive channel remained saturated.
+		// Poll rather than sampling once so scheduling does not hide the symptom;
+		// an implementation that keeps draining may never raise the gauge.
+		saturated := false
+		for i := 0; i < 100; i++ {
+			if promtest.ToFloat64(metrics.Metrics.FullRecvChannel(metrics.Connect)) >= 1 {
+				saturated = true
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if !saturated {
+			t.Errorf("expected FullRecvChannel gauge >= 1 while consumer is stalled")
+		}
+		t.Fatal("connection B did not establish while connection A's HTTP Write was blocked; receive channel saturated")
+	}
+
+	// Note: we deliberately do NOT assert here that A is still blocked. A valid
+	// bounded backpressure policy may close A while handling the fillers, and the
+	// implementation can reach that point before this goroutine runs. The "B was not
+	// rescued by killing A" invariant is proven deterministically in
+	// TestSlowHTTPFrontendDoesNotDelayDialResponse, which feeds no packets after
+	// B and therefore cannot legitimately close A at that point.
+
+	// Terminal end-to-end progress proof: healthy B receives its exact DATA even
+	// though A's filler traffic was staged first. This rejects control-only
+	// prioritization and a shared writer pool that remains blocked behind A,
+	// without requiring A's writes to use any particular dispatch mechanism.
+	select {
+	case got := <-recordingHTTP.writes:
+		if string(got) != payloadB {
+			t.Fatalf("connection B received payload %q, want %q", got, payloadB)
+		}
+	case <-time.After(holTestSafetyTimeout):
+		t.Fatal("connection B established but terminal DATA did not progress through the saturated backend receive path")
+	}
+
+	// A transient gauge blip is acceptable; require it to settle to zero once
+	// the consumer has drained the backlog. The shared backend receive channel
+	// must no longer be stuck.
+	settled := false
+	for i := 0; i < 100; i++ {
+		if promtest.ToFloat64(metrics.Metrics.FullRecvChannel(metrics.Connect)) == 0 {
+			settled = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !settled {
+		t.Errorf("FullRecvChannel gauge did not return to 0; backend ingress is still stalled")
 	}
 }

--- a/pkg/server/http_connect_lifecycle_test.go
+++ b/pkg/server/http_connect_lifecycle_test.go
@@ -1,0 +1,544 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
+)
+
+type writerTestBackendConsumer struct {
+	recvCh chan *client.Packet
+	done   chan struct{}
+
+	stopOnce sync.Once
+}
+
+func startWriterTestBackendConsumer(t *testing.T, server *ProxyServer, backend *Backend, agentID string, buffer int) *writerTestBackendConsumer {
+	t.Helper()
+	consumer := &writerTestBackendConsumer{
+		recvCh: make(chan *client.Packet, buffer),
+		done:   make(chan struct{}),
+	}
+	go func() {
+		defer close(consumer.done)
+		server.serveRecvBackend(backend, agentID, consumer.recvCh)
+	}()
+	t.Cleanup(func() { consumer.stop(t) })
+	return consumer
+}
+
+func (c *writerTestBackendConsumer) stop(t *testing.T) {
+	t.Helper()
+	c.stopOnce.Do(func() { close(c.recvCh) })
+	select {
+	case <-c.done:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Errorf("serveRecvBackend did not stop")
+	}
+}
+
+func writerTestDrainPacket() *client.Packet {
+	return &client.Packet{Type: client.PacketType_DRAIN}
+}
+
+func writerTestDialResponse(dialID, connectID int64) *client.Packet {
+	return &client.Packet{
+		Type: client.PacketType_DIAL_RSP,
+		Payload: &client.Packet_DialResponse{
+			DialResponse: &client.DialResponse{Random: dialID, ConnectID: connectID},
+		},
+	}
+}
+
+func TestHTTPConnectLateDataCloseRequestPolicy(t *testing.T) {
+	t.Run("before close response", func(t *testing.T) {
+		const (
+			agentID   = "late-before-agent"
+			connectID = int64(501)
+		)
+		server := newWriterTestServer(2)
+		backend, stream := newWriterTestBackend(context.Background(), agentID)
+		httpWriter := newWriterTestImmediateHTTP()
+		connection := &ProxyClientConnection{
+			Mode:      ModeHTTPConnect,
+			HTTP:      httpWriter,
+			CloseHTTP: httpWriter.close,
+			closed:    make(chan struct{}),
+			agentID:   agentID,
+			connectID: connectID,
+			backend:   backend,
+		}
+		server.addEstablished(agentID, connectID, connection)
+		writer, _ := connection.attachHTTPWriter(server, nil, false)
+		writer.start()
+		consumer := startWriterTestBackendConsumer(t, server, backend, agentID, 8)
+
+		writer.abort(httpConnectAbortFrontendClose)
+		writerTestEventually(t, "initial connection-owned close request", func() bool {
+			return stream.count(client.PacketType_CLOSE_REQ) == 1
+		})
+		consumer.recvCh <- dataPkt(connectID, []byte("late before acknowledgement"))
+		consumer.recvCh <- writerTestDrainPacket()
+		writerTestEventually(t, "late DATA processing marker", backend.IsDraining)
+		if got := stream.count(client.PacketType_CLOSE_REQ); got != 1 {
+			t.Fatalf("CLOSE_REQ count after pre-acknowledgement DATA = %d, want unchanged count 1", got)
+		}
+		got, err := server.getFrontend(agentID, connectID)
+		if err != nil || got != connection {
+			t.Fatalf("terminal connection before acknowledgement = %p, %v; want retained %p", got, err, connection)
+		}
+
+		consumer.recvCh <- closeRspPkt(connectID, "")
+		writerTestEventually(t, "terminal entry removal after close response", func() bool {
+			_, err := server.getFrontend(agentID, connectID)
+			return err != nil
+		})
+	})
+
+	t.Run("after close response", func(t *testing.T) {
+		const (
+			agentID   = "late-after-agent"
+			connectID = int64(502)
+		)
+		server := newWriterTestServer(2)
+		backend, stream := newWriterTestBackend(context.Background(), agentID)
+		httpWriter := newWriterTestImmediateHTTP()
+		connection := &ProxyClientConnection{
+			Mode:      ModeHTTPConnect,
+			HTTP:      httpWriter,
+			CloseHTTP: httpWriter.close,
+			closed:    make(chan struct{}),
+			agentID:   agentID,
+			connectID: connectID,
+			backend:   backend,
+		}
+		server.addEstablished(agentID, connectID, connection)
+		writer, _ := connection.attachHTTPWriter(server, nil, false)
+		writer.start()
+		consumer := startWriterTestBackendConsumer(t, server, backend, agentID, 8)
+
+		consumer.recvCh <- closeRspPkt(connectID, "")
+		writerTestEventually(t, "graceful removal before late DATA", func() bool {
+			_, err := server.getFrontend(agentID, connectID)
+			return err != nil
+		})
+		// Model the Tunnel's terminal convergence after CLOSE_RSP closed its
+		// socket. This is the one legitimate connection-owned request.
+		writer.abort(httpConnectAbortFrontendClose)
+		writerTestEventually(t, "connection-owned close request", func() bool {
+			return stream.count(client.PacketType_CLOSE_REQ) == 1
+		})
+
+		consumer.recvCh <- dataPkt(connectID, []byte("late after acknowledgement"))
+		consumer.recvCh <- writerTestDrainPacket()
+		writerTestEventually(t, "post-acknowledgement DATA processing marker", backend.IsDraining)
+		if got := stream.count(client.PacketType_CLOSE_REQ); got != 2 {
+			t.Fatalf("CLOSE_REQ count after post-acknowledgement DATA = %d, want 2 (one additional missing-frontend request)", got)
+		}
+		for _, id := range stream.closeRequestIDs() {
+			if id != connectID {
+				t.Fatalf("CLOSE_REQ connection ID = %d, want %d", id, connectID)
+			}
+		}
+	})
+}
+
+func TestHTTPConnectQueueOverflowIsolationAndRetention(t *testing.T) {
+	const (
+		agentID = "overflow-agent"
+		slowID  = int64(601)
+		fastID  = int64(602)
+	)
+	server := newWriterTestServer(1)
+	backend, stream := newWriterTestBackend(context.Background(), agentID)
+	slowHTTP := newWriterTestBlockingHTTP()
+	fastHTTP := newWriterTestImmediateHTTP()
+	slowConnection := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      slowHTTP,
+		CloseHTTP: slowHTTP.close,
+		closed:    make(chan struct{}),
+		agentID:   agentID,
+		connectID: slowID,
+		backend:   backend,
+	}
+	fastConnection := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      fastHTTP,
+		CloseHTTP: fastHTTP.close,
+		closed:    make(chan struct{}),
+		agentID:   agentID,
+		connectID: fastID,
+		backend:   backend,
+	}
+	server.addEstablished(agentID, slowID, slowConnection)
+	server.addEstablished(agentID, fastID, fastConnection)
+	consumer := startWriterTestBackendConsumer(t, server, backend, agentID, 16)
+
+	consumer.recvCh <- dataPkt(slowID, []byte("in flight"))
+	select {
+	case <-slowHTTP.writeStarted:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("slow connection did not enter its blocked write")
+	}
+	consumer.recvCh <- dataPkt(slowID, []byte("queued"))
+	consumer.recvCh <- dataPkt(slowID, []byte("overflow"))
+	select {
+	case <-slowHTTP.closeCh:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("queue overflow did not close the slow connection")
+	}
+	writerTestEventually(t, "overflow CLOSE_REQ", func() bool {
+		return stream.count(client.PacketType_CLOSE_REQ) == 1
+	})
+
+	consumer.recvCh <- dataPkt(fastID, []byte("healthy"))
+	writerTestEventually(t, "healthy connection DATA", func() bool {
+		got, _, _ := fastHTTP.snapshot()
+		return bytes.Equal(got, []byte("healthy"))
+	})
+	got, err := server.getFrontend(agentID, slowID)
+	if err != nil || got != slowConnection {
+		t.Fatalf("overflowed terminal entry = %p, %v; want retained %p", got, err, slowConnection)
+	}
+	if got, err := server.getFrontend(agentID, fastID); err != nil || got != fastConnection {
+		t.Fatalf("healthy connection = %p, %v; want %p", got, err, fastConnection)
+	}
+
+	consumer.recvCh <- dataPkt(slowID, []byte("late while terminal"))
+	consumer.recvCh <- writerTestDrainPacket()
+	writerTestEventually(t, "terminal late-DATA marker", backend.IsDraining)
+	if got := stream.count(client.PacketType_CLOSE_REQ); got != 1 {
+		t.Fatalf("terminal late DATA changed CLOSE_REQ count to %d, want 1", got)
+	}
+	consumer.recvCh <- closeRspPkt(slowID, "")
+	writerTestEventually(t, "overflow entry removal after acknowledgement", func() bool {
+		_, err := server.getFrontend(agentID, slowID)
+		return err != nil
+	})
+	if got, err := server.getFrontend(agentID, fastID); err != nil || got != fastConnection {
+		t.Fatalf("healthy connection was affected by overflow acknowledgement: %p, %v", got, err)
+	}
+}
+
+func TestBackendShutdownAbortsOnlyMatchingHTTPConnections(t *testing.T) {
+	const agentID = "shared-agent-id"
+	server := newWriterTestServer(2)
+	backendA, streamA := newWriterTestBackend(context.Background(), agentID)
+	backendB, _ := newWriterTestBackend(context.Background(), agentID)
+
+	activeHTTP := newWriterTestBlockingHTTP()
+	drainingHTTP := newWriterTestBlockingHTTP()
+	otherHTTP := newWriterTestBlockingHTTP()
+	active := &ProxyClientConnection{Mode: ModeHTTPConnect, HTTP: activeHTTP, CloseHTTP: activeHTTP.close, closed: make(chan struct{}), agentID: agentID, connectID: 701, backend: backendA}
+	draining := &ProxyClientConnection{Mode: ModeHTTPConnect, HTTP: drainingHTTP, CloseHTTP: drainingHTTP.close, closed: make(chan struct{}), agentID: agentID, connectID: 702, backend: backendA}
+	other := &ProxyClientConnection{Mode: ModeHTTPConnect, HTTP: otherHTTP, CloseHTTP: otherHTTP.close, closed: make(chan struct{}), agentID: agentID, connectID: 703, backend: backendB}
+	server.addEstablished(agentID, active.connectID, active)
+	server.addEstablished(agentID, draining.connectID, draining)
+	server.addEstablished(agentID, other.connectID, other)
+
+	activeWriter, _ := active.attachHTTPWriter(server, nil, false)
+	drainingWriter, _ := draining.attachHTTPWriter(server, nil, false)
+	otherWriter, _ := other.attachHTTPWriter(server, nil, false)
+	activeWriter.start()
+	drainingWriter.start()
+	otherWriter.start()
+	activeWriter.enqueueData([]byte("active"))
+	drainingWriter.enqueueData([]byte("draining"))
+	otherWriter.enqueueData([]byte("other backend"))
+	for name, started := range map[string]<-chan struct{}{
+		"active": activeHTTP.writeStarted, "draining": drainingHTTP.writeStarted, "other": otherHTTP.writeStarted,
+	} {
+		select {
+		case <-started:
+		case <-time.After(writerTestSafetyTimeout):
+			t.Fatalf("%s writer did not block", name)
+		}
+	}
+	drainingWriter.beginGracefulClose()
+
+	consumer := startWriterTestBackendConsumer(t, server, backendA, agentID, 0)
+	consumer.stop(t)
+	for name, closed := range map[string]<-chan struct{}{
+		"active": activeHTTP.closeCh, "draining": drainingHTTP.closeCh,
+	} {
+		select {
+		case <-closed:
+		case <-time.After(writerTestSafetyTimeout):
+			t.Fatalf("backend shutdown did not close %s writer", name)
+		}
+	}
+	if _, err := server.getFrontend(agentID, active.connectID); err == nil {
+		t.Fatal("active matching connection remained established after backend shutdown")
+	}
+	if _, err := server.getFrontend(agentID, draining.connectID); err == nil {
+		t.Fatal("gracefully draining matching connection remained established after backend shutdown")
+	}
+	if got, err := server.getFrontend(agentID, other.connectID); err != nil || got != other {
+		t.Fatalf("different backend connection = %p, %v; want untouched %p", got, err, other)
+	}
+	select {
+	case <-otherHTTP.closeCh:
+		t.Fatal("backend shutdown closed a connection owned by a different backend pointer")
+	default:
+	}
+	if got := streamA.count(client.PacketType_CLOSE_REQ); got != 0 {
+		t.Fatalf("dead backend received %d CLOSE_REQ packets", got)
+	}
+
+	// Release the intentionally untouched writer using its own backend lifecycle.
+	server.removeEstablishedIf(agentID, other.connectID, other)
+	other.suppressBackendCloseRequest()
+	other.abortHTTP(server, httpConnectAbortBackendShutdown)
+	select {
+	case <-otherHTTP.closeCh:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("cleanup did not close the different-backend writer")
+	}
+}
+
+func TestHTTPConnectGracefulDrainMapLifecycle(t *testing.T) {
+	const (
+		agentID   = "drain-agent"
+		connectID = int64(801)
+	)
+	server := newWriterTestServer(2)
+	httpWriter := newWriterTestBlockingHTTP()
+	removedAtClose := make(chan bool, 1)
+	connection := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      httpWriter,
+		closed:    make(chan struct{}),
+		agentID:   agentID,
+		connectID: connectID,
+	}
+	connection.CloseHTTP = func() error {
+		_, err := server.getFrontend(agentID, connectID)
+		removedAtClose <- err != nil
+		return httpWriter.close()
+	}
+	server.addEstablished(agentID, connectID, connection)
+	writer, _ := connection.attachHTTPWriter(server, nil, false)
+	writer.start()
+	writer.enqueueData([]byte("first"))
+	select {
+	case <-httpWriter.writeStarted:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("graceful writer did not enter its blocked first write")
+	}
+	writer.enqueueData([]byte("second"))
+	writer.beginGracefulClose()
+	if got, err := server.getFrontend(agentID, connectID); err != nil || got != connection {
+		t.Fatalf("draining connection = %p, %v; want discoverable %p", got, err, connection)
+	}
+
+	httpWriter.release()
+	select {
+	case removed := <-removedAtClose:
+		if !removed {
+			t.Fatal("connection was still established when terminal CloseHTTP began")
+		}
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("graceful writer did not reach terminal CloseHTTP")
+	}
+	stream, closes, _ := httpWriter.snapshot()
+	if !bytes.Equal(stream, []byte("firstsecond")) {
+		t.Fatalf("gracefully drained stream = %q, want %q", stream, "firstsecond")
+	}
+	if closes != 1 {
+		t.Fatalf("CloseHTTP calls = %d, want 1", closes)
+	}
+}
+
+func TestHTTPConnectWedgedGracefulCloseIsConnectionLocal(t *testing.T) {
+	const (
+		agentID   = "wedged-graceful-agent"
+		wedgedID  = int64(901)
+		healthyID = int64(902)
+	)
+	server := newWriterTestServer(2)
+	backend, stream := newWriterTestBackend(context.Background(), agentID)
+	wedgedHTTP := newWriterTestBlockingHTTP()
+	healthyHTTP := newWriterTestImmediateHTTP()
+	wedged := &ProxyClientConnection{Mode: ModeHTTPConnect, HTTP: wedgedHTTP, CloseHTTP: wedgedHTTP.close, closed: make(chan struct{}), agentID: agentID, connectID: wedgedID, backend: backend}
+	healthy := &ProxyClientConnection{Mode: ModeHTTPConnect, HTTP: healthyHTTP, CloseHTTP: healthyHTTP.close, closed: make(chan struct{}), agentID: agentID, connectID: healthyID, backend: backend}
+	server.addEstablished(agentID, wedgedID, wedged)
+	server.addEstablished(agentID, healthyID, healthy)
+	wedgedWriter, _ := wedged.attachHTTPWriter(server, nil, false)
+	wedgedWriter.start()
+	consumer := startWriterTestBackendConsumer(t, server, backend, agentID, 8)
+
+	consumer.recvCh <- dataPkt(wedgedID, []byte("final blocked DATA"))
+	select {
+	case <-wedgedHTTP.writeStarted:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("wedged graceful writer did not block")
+	}
+	consumer.recvCh <- closeRspPkt(wedgedID, "")
+	consumer.recvCh <- writerTestDrainPacket()
+	writerTestEventually(t, "graceful close processing marker", backend.IsDraining)
+	if got, err := server.getFrontend(agentID, wedgedID); err != nil || got != wedged {
+		t.Fatalf("wedged graceful connection = %p, %v; want retained %p", got, err, wedged)
+	}
+
+	consumer.recvCh <- dataPkt(healthyID, []byte("healthy progress"))
+	writerTestEventually(t, "healthy progress beside wedged graceful writer", func() bool {
+		got, _, _ := healthyHTTP.snapshot()
+		return bytes.Equal(got, []byte("healthy progress"))
+	})
+	select {
+	case <-wedgedHTTP.closeCh:
+		t.Fatal("graceful close acquired an implicit timeout before backend shutdown")
+	default:
+	}
+
+	consumer.stop(t)
+	select {
+	case <-wedgedHTTP.closeCh:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("backend shutdown did not reap the wedged graceful writer")
+	}
+	if _, err := server.getFrontend(agentID, wedgedID); err == nil {
+		t.Fatal("wedged graceful connection remained established after backend shutdown")
+	}
+	if got := stream.count(client.PacketType_CLOSE_REQ); got != 0 {
+		t.Fatalf("backend shutdown emitted %d CLOSE_REQ packets on the dead stream", got)
+	}
+}
+
+// This test races the real DIAL_RSP routing path against the Tunnel teardown
+// ownership operation. It asserts publication and side-effect semantics, not
+// the current implementation's number or placement of terminal checks.
+func TestHTTPConnectDialResponseTeardownRace(t *testing.T) {
+	const iterations = 80
+	for i := 0; i < iterations; i++ {
+		agentID := "attachment-race-agent"
+		dialID := int64(10000 + i)
+		connectID := int64(11000 + i)
+		server := newWriterTestServer(2)
+		backend, stream := newWriterTestBackend(context.Background(), agentID)
+		httpWriter := newWriterTestImmediateHTTP()
+		connected := make(chan struct{})
+		connection := &ProxyClientConnection{
+			Mode:                ModeHTTPConnect,
+			HTTP:                httpWriter,
+			CloseHTTP:           httpWriter.close,
+			closed:              make(chan struct{}),
+			connected:           connected,
+			httpInitialResponse: []byte(httpConnectSuccessResponse),
+			start:               time.Now(),
+			backend:             backend,
+			dialID:              dialID,
+			agentID:             agentID,
+		}
+		server.PendingDial.Add(dialID, connection)
+		consumer := startWriterTestBackendConsumer(t, server, backend, agentID, 0)
+
+		start := make(chan struct{})
+		var teardownOwned atomic.Bool
+		var racers sync.WaitGroup
+		racers.Add(2)
+		go func() {
+			defer racers.Done()
+			<-start
+			consumer.recvCh <- writerTestDialResponse(dialID, connectID)
+		}()
+		go func() {
+			defer racers.Done()
+			<-start
+			if server.PendingDial.Remove(dialID) != nil {
+				teardownOwned.Store(true)
+			}
+			connection.abortHTTP(server, httpConnectAbortFrontendClose)
+		}()
+		close(start)
+		racers.Wait()
+		consumer.recvCh <- writerTestDrainPacket()
+		writerTestEventually(t, "DIAL_RSP/teardown processing marker", backend.IsDraining)
+		writerTestEventually(t, "one close request from DIAL_RSP/teardown convergence", func() bool {
+			return stream.count(client.PacketType_CLOSE_REQ) == 1
+		})
+
+		connection.httpMu.Lock()
+		writerBefore := connection.httpWriter
+		terminal := connection.httpTerminal
+		connection.httpMu.Unlock()
+		if !terminal {
+			t.Fatal("teardown race did not leave the connection terminal")
+		}
+		writerAfter, attached := connection.attachHTTPWriter(server, nil, false)
+		if writerBefore == nil {
+			if attached || writerAfter != nil {
+				t.Fatal("terminal teardown permitted a fresh writer attachment")
+			}
+		} else if !attached || writerAfter != writerBefore {
+			t.Fatalf("terminal lookup replaced writer %p with %p (attached=%t)", writerBefore, writerAfter, attached)
+		}
+
+		if teardownOwned.Load() {
+			select {
+			case <-connected:
+				t.Fatal("connected was signaled after pending teardown won ownership")
+			default:
+			}
+			if _, err := server.getFrontend(agentID, connectID); err == nil {
+				t.Fatal("connection was published after pending teardown won ownership")
+			}
+		}
+
+		if got, err := server.getFrontend(agentID, connectID); err == nil {
+			if got != connection {
+				t.Fatalf("established pointer = %p, want %p", got, connection)
+			}
+			consumer.recvCh <- dataPkt(connectID, []byte("late terminal DATA"))
+			consumer.recvCh <- closeRspPkt(connectID, "")
+			writerTestEventually(t, "terminal entry acknowledgement", func() bool {
+				_, err := server.getFrontend(agentID, connectID)
+				return err != nil
+			})
+		}
+		consumer.stop(t)
+		if got := stream.count(client.PacketType_CLOSE_REQ); got != 1 {
+			t.Fatalf("DIAL_RSP/teardown CLOSE_REQ count = %d, want 1", got)
+		}
+		ids := stream.closeRequestIDs()
+		if len(ids) != 1 || ids[0] != connectID {
+			t.Fatalf("DIAL_RSP/teardown CLOSE_REQ IDs = %v, want [%d]", ids, connectID)
+		}
+		writerTestEventually(t, "DIAL_RSP/teardown HTTP close", func() bool {
+			_, closes, _ := httpWriter.snapshot()
+			return closes == 1
+		})
+		written, closes, _ := httpWriter.snapshot()
+		if len(written) > 0 && !bytes.Equal(written, []byte(httpConnectSuccessResponse)) {
+			t.Fatalf("DIAL_RSP/teardown wrote %q, want at most one complete CONNECT response", written)
+		}
+		if closes != 1 {
+			t.Fatalf("DIAL_RSP/teardown CloseHTTP calls = %d, want 1", closes)
+		}
+		if _, err := server.getFrontend(agentID, connectID); err == nil {
+			t.Fatal("connection reappeared after terminal acknowledgement")
+		}
+	}
+}

--- a/pkg/server/http_connect_response_failure_test.go
+++ b/pkg/server/http_connect_response_failure_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
+)
+
+// A blocked or failing CONNECT response is connection-local. The shared
+// backend consumer must continue processing control packets while that socket
+// write is unresolved, and a failed response must never signal establishment.
+func TestHTTPConnectInitialResponseFailureDoesNotBlockBackendConsumer(t *testing.T) {
+	const (
+		agentID   = "response-progress-agent"
+		dialID    = int64(1201)
+		connectID = int64(1202)
+	)
+	server := newWriterTestServer(2)
+	backend, stream := newWriterTestBackend(context.Background(), agentID)
+	httpWriter := newWriterTestGateFailHTTP(errors.New("CONNECT response failed"))
+	connected := make(chan struct{})
+	var closeCalls atomic.Int32
+	connection := &ProxyClientConnection{
+		Mode:                ModeHTTPConnect,
+		HTTP:                httpWriter,
+		CloseHTTP:           func() error { closeCalls.Add(1); return nil },
+		closed:              make(chan struct{}),
+		connected:           connected,
+		httpInitialResponse: []byte(httpConnectSuccessResponse),
+		start:               time.Now(),
+		backend:             backend,
+		dialID:              dialID,
+		agentID:             agentID,
+	}
+	server.PendingDial.Add(dialID, connection)
+	consumer := startWriterTestBackendConsumer(t, server, backend, agentID, 4)
+
+	consumer.recvCh <- writerTestDialResponse(dialID, connectID)
+	select {
+	case <-httpWriter.started:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("CONNECT response write did not start")
+	}
+	consumer.recvCh <- writerTestDrainPacket()
+	writerTestEventually(t, "backend consumer progress during blocked CONNECT response", backend.IsDraining)
+	select {
+	case <-connected:
+		t.Fatal("connected was signaled before the CONNECT response completed")
+	default:
+	}
+
+	httpWriter.unblock()
+	writerTestEventually(t, "failed CONNECT response cleanup", func() bool {
+		return closeCalls.Load() == 1 && stream.count(client.PacketType_CLOSE_REQ) == 1
+	})
+	select {
+	case <-connected:
+		t.Fatal("connected was signaled after the CONNECT response failed")
+	default:
+	}
+	if got, err := server.getFrontend(agentID, connectID); err != nil || got != connection {
+		t.Fatalf("failed-response terminal entry = %p, %v; want retained %p", got, err, connection)
+	}
+
+	consumer.recvCh <- closeRspPkt(connectID, "")
+	writerTestEventually(t, "failed-response acknowledgement removal", func() bool {
+		_, err := server.getFrontend(agentID, connectID)
+		return err != nil
+	})
+}

--- a/pkg/server/http_connect_writer.go
+++ b/pkg/server/http_connect_writer.go
@@ -1,0 +1,506 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
+)
+
+const (
+	maxHTTPConnectErrorBodyBytes = 4 << 10
+	httpConnectSuccessResponse   = "HTTP/1.1 200 Connection Established\r\n\r\n"
+	httpConnectTruncationMarker  = "\n[error response truncated]\n"
+)
+
+type httpConnectEnqueueResult uint8
+
+const (
+	httpConnectEnqueueAccepted httpConnectEnqueueResult = iota
+	httpConnectEnqueueClosed
+	httpConnectEnqueueOverflow
+)
+
+type httpConnectCloseDisposition uint8
+
+const (
+	httpConnectCloseDraining httpConnectCloseDisposition = iota
+	httpConnectCloseAlreadyForced
+)
+
+type httpConnectAbortReason string
+
+const (
+	httpConnectAbortBackendShutdown httpConnectAbortReason = "backend_shutdown"
+	httpConnectAbortDialClosed      httpConnectAbortReason = "dial_closed"
+	httpConnectAbortFrontendClose   httpConnectAbortReason = "frontend_close"
+	httpConnectAbortQueueOverflow   httpConnectAbortReason = "queue_overflow"
+	httpConnectAbortSetupRace       httpConnectAbortReason = "setup_race"
+	httpConnectAbortWriteFailure    httpConnectAbortReason = "write_failure"
+)
+
+// httpConnectWriter is the sole owner of normal writes to one HTTP-CONNECT
+// frontend. Its private bounded FIFO keeps a blocked socket from parking the
+// shared agent-stream consumer.
+type httpConnectWriter struct {
+	server   *ProxyServer
+	frontend *ProxyClientConnection
+
+	// initialResponse is optional. Real Tunnels supply the successful CONNECT
+	// response; already-established lower-level connections leave it empty.
+	initialResponse []byte
+	notifyConnected bool
+
+	dataCh  chan []byte
+	abortCh chan struct{}
+
+	// mu linearizes enqueue with graceful and forced terminal transitions. It
+	// is never held during HTTP or backend I/O.
+	mu                sync.Mutex
+	accepting         bool
+	closeResponseSeen bool
+	aborted           bool
+
+	startOnce    sync.Once
+	gracefulOnce sync.Once
+	abortOnce    sync.Once
+}
+
+func newHTTPConnectWriter(
+	server *ProxyServer,
+	frontend *ProxyClientConnection,
+	initialResponse []byte,
+	notifyConnected bool,
+) *httpConnectWriter {
+	queueDepth := max(1, server.httpConnectQueueSize)
+	return &httpConnectWriter{
+		server:          server,
+		frontend:        frontend,
+		initialResponse: initialResponse,
+		notifyConnected: notifyConnected,
+		dataCh:          make(chan []byte, queueDepth),
+		abortCh:         make(chan struct{}),
+		accepting:       true,
+	}
+}
+
+func (w *httpConnectWriter) start() {
+	w.startOnce.Do(func() {
+		go w.run()
+	})
+}
+
+func (w *httpConnectWriter) run() {
+	if !w.writeInitialResponse() {
+		return
+	}
+
+	for {
+		select {
+		case <-w.abortCh:
+			return
+		default:
+		}
+
+		select {
+		case <-w.abortCh:
+			return
+		case data, ok := <-w.dataCh:
+			if !ok {
+				w.finishGracefulClose()
+				return
+			}
+
+			// Abort may have won at the same time as the dequeue. Do not write a
+			// queued payload after observing that terminal transition.
+			if w.isAborted() {
+				return
+			}
+			if err := w.write(data); err != nil {
+				agentID, connectID, _ := w.frontend.httpConnectionDetails()
+				klog.ErrorS(err, "HTTP-CONNECT DATA write failed", "agentID", agentID, "connectionID", connectID)
+				w.abort(httpConnectAbortWriteFailure)
+				return
+			}
+		}
+	}
+}
+
+func (w *httpConnectWriter) writeInitialResponse() bool {
+	w.mu.Lock()
+	if w.aborted {
+		w.initialResponse = nil
+		w.mu.Unlock()
+		return false
+	}
+	response := w.initialResponse
+	w.mu.Unlock()
+
+	if len(response) > 0 {
+		err := w.write(response)
+		w.mu.Lock()
+		w.initialResponse = nil
+		w.mu.Unlock()
+		if err != nil {
+			agentID, connectID, _ := w.frontend.httpConnectionDetails()
+			klog.ErrorS(err, "HTTP-CONNECT initial response write failed", "agentID", agentID, "connectionID", connectID)
+			w.abort(httpConnectAbortWriteFailure)
+			return false
+		}
+	}
+
+	// Successful establishment and a concurrent abort are linearized by the
+	// same writer-state mutex. An abort that wins must wake Tunnel only through
+	// the closed notification, never through connected.
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.aborted {
+		return false
+	}
+	if w.notifyConnected && w.frontend.connected != nil {
+		close(w.frontend.connected)
+		w.notifyConnected = false
+	}
+	return true
+}
+
+func (w *httpConnectWriter) write(data []byte) error {
+	start := time.Now()
+	defer func() {
+		metrics.Metrics.ObserveFrontendWriteLatency(time.Since(start))
+	}()
+	if w.frontend.HTTP == nil {
+		return fmt.Errorf("HTTP-CONNECT frontend has no writer")
+	}
+	return writeAll(w.frontend.HTTP, data)
+}
+
+// enqueueData transfers ownership of data to the writer when accepted. It
+// never waits for queue space.
+func (w *httpConnectWriter) enqueueData(data []byte) httpConnectEnqueueResult {
+	w.mu.Lock()
+	if !w.accepting {
+		w.mu.Unlock()
+		return httpConnectEnqueueClosed
+	}
+
+	select {
+	case w.dataCh <- data:
+		w.mu.Unlock()
+		return httpConnectEnqueueAccepted
+	default:
+		// Reaching overflow requires accepting to still be true. Because
+		// beginGracefulClose records closeResponseSeen and clears accepting in
+		// this same critical section, a backend close response cannot already
+		// have been observed here.
+		firstAbort, _ := w.abortLocked()
+		w.mu.Unlock()
+
+		if firstAbort {
+			w.frontend.markHTTPWriterTerminal(w)
+			metrics.Metrics.ObserveHTTPConnectDisconnect(metrics.HTTPConnectDisconnectQueueOverflow)
+			agentID, connectID, _ := w.frontend.httpConnectionDetails()
+			klog.V(2).InfoS("Closing overloaded HTTP-CONNECT frontend", "reason", httpConnectAbortQueueOverflow, "agentID", agentID, "connectionID", connectID)
+			w.frontend.startHTTPForcedCleanup(w.server, w, httpConnectAbortQueueOverflow)
+		}
+		return httpConnectEnqueueOverflow
+	}
+}
+
+func (w *httpConnectWriter) beginGracefulClose() httpConnectCloseDisposition {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.closeResponseSeen = true
+	if w.aborted {
+		return httpConnectCloseAlreadyForced
+	}
+	w.accepting = false
+	w.gracefulOnce.Do(func() {
+		close(w.dataCh)
+	})
+	return httpConnectCloseDraining
+}
+
+func (w *httpConnectWriter) abort(reason httpConnectAbortReason) {
+	w.mu.Lock()
+	firstAbort, closeResponseSeen := w.abortLocked()
+	w.mu.Unlock()
+	if !firstAbort {
+		return
+	}
+
+	w.frontend.markHTTPWriterTerminal(w)
+	if closeResponseSeen {
+		agentID, connectID, _ := w.frontend.httpConnectionDetails()
+		w.server.removeEstablishedIf(agentID, connectID, w.frontend)
+	}
+	w.frontend.startHTTPForcedCleanup(w.server, w, reason)
+}
+
+// abortLocked performs only the non-blocking state transition. The caller
+// must hold w.mu and start cleanup after releasing it.
+func (w *httpConnectWriter) abortLocked() (firstAbort, closeResponseSeen bool) {
+	if w.aborted {
+		return false, w.closeResponseSeen
+	}
+	w.aborted = true
+	w.accepting = false
+	w.abortOnce.Do(func() {
+		close(w.abortCh)
+	})
+	return true, w.closeResponseSeen
+}
+
+func (w *httpConnectWriter) isAborted() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.aborted
+}
+
+func (w *httpConnectWriter) finishGracefulClose() {
+	w.mu.Lock()
+	aborted := w.aborted
+	w.mu.Unlock()
+	if aborted {
+		return
+	}
+
+	w.frontend.markHTTPWriterTerminal(w)
+	agentID, connectID, _ := w.frontend.httpConnectionDetails()
+	w.server.removeEstablishedIf(agentID, connectID, w.frontend)
+	if err := w.frontend.closeHTTP(); err != nil {
+		klog.ErrorS(err, "HTTP-CONNECT frontend close failed", "agentID", agentID, "connectionID", connectID)
+	}
+}
+
+// discardQueuedData releases references to DATA that cannot be delivered
+// after a forced abort. accepting is already false, so the queue cannot grow.
+func (w *httpConnectWriter) discardQueuedData() {
+	w.mu.Lock()
+	w.initialResponse = nil
+	w.mu.Unlock()
+
+	for {
+		select {
+		case _, ok := <-w.dataCh:
+			if !ok {
+				return
+			}
+		default:
+			return
+		}
+	}
+}
+
+func (c *ProxyClientConnection) attachHTTPWriter(
+	server *ProxyServer,
+	initialResponse []byte,
+	notifyConnected bool,
+) (*httpConnectWriter, bool) {
+	c.httpMu.Lock()
+	defer c.httpMu.Unlock()
+	if c.httpWriter != nil {
+		return c.httpWriter, true
+	}
+	if c.httpTerminal {
+		return nil, false
+	}
+	w := newHTTPConnectWriter(server, c, initialResponse, notifyConnected)
+	if len(initialResponse) > 0 {
+		c.httpInitialResponse = nil
+	}
+	c.httpWriter = w
+	return w, true
+}
+
+func (c *ProxyClientConnection) configuredHTTPWriter(server *ProxyServer, notifyConnected bool) (*httpConnectWriter, bool) {
+	c.httpMu.Lock()
+	defer c.httpMu.Unlock()
+	if c.httpWriter != nil {
+		return c.httpWriter, true
+	}
+	if c.httpTerminal {
+		return nil, false
+	}
+	w := newHTTPConnectWriter(server, c, c.httpInitialResponse, notifyConnected)
+	c.httpInitialResponse = nil
+	c.httpWriter = w
+	return w, true
+}
+
+func (c *ProxyClientConnection) markHTTPWriterTerminal(expected *httpConnectWriter) {
+	c.httpMu.Lock()
+	defer c.httpMu.Unlock()
+	if expected == nil || c.httpWriter == expected {
+		c.httpTerminal = true
+	}
+}
+
+func (c *ProxyClientConnection) httpWriterIsTerminal(expected *httpConnectWriter) bool {
+	c.httpMu.Lock()
+	defer c.httpMu.Unlock()
+	return c.httpTerminal || c.httpWriter != expected
+}
+
+func (c *ProxyClientConnection) abortHTTP(server *ProxyServer, reason httpConnectAbortReason) {
+	c.httpMu.Lock()
+	c.httpTerminal = true
+	w := c.httpWriter
+	c.httpMu.Unlock()
+
+	if w != nil {
+		w.abort(reason)
+		return
+	}
+	c.startHTTPForcedCleanup(server, nil, reason)
+}
+
+func (c *ProxyClientConnection) startHTTPForcedCleanup(
+	server *ProxyServer,
+	w *httpConnectWriter,
+	reason httpConnectAbortReason,
+) {
+	c.httpCleanupOnce.Do(func() {
+		go func() {
+			if w != nil {
+				w.discardQueuedData()
+			}
+			if err := c.closeHTTP(); err != nil {
+				agentID, connectID, _ := c.httpConnectionDetails()
+				klog.ErrorS(err, "HTTP-CONNECT frontend close failed", "reason", reason, "agentID", agentID, "connectionID", connectID)
+			}
+			c.sendBackendCloseRequest(server, string(reason))
+		}()
+	})
+}
+
+func (c *ProxyClientConnection) closeHTTP() error {
+	c.closeHTTPOnce.Do(func() {
+		if c.closed != nil {
+			close(c.closed)
+		}
+		if c.CloseHTTP != nil {
+			c.closeHTTPErr = c.CloseHTTP()
+		}
+	})
+	return c.closeHTTPErr
+}
+
+func (c *ProxyClientConnection) setHTTPConnectionDetails(agentID string, connectID int64) {
+	c.httpMu.Lock()
+	c.agentID = agentID
+	c.connectID = connectID
+	c.httpMu.Unlock()
+}
+
+func (c *ProxyClientConnection) httpConnectionDetails() (agentID string, connectID int64, backend *Backend) {
+	c.httpMu.Lock()
+	defer c.httpMu.Unlock()
+	return c.agentID, c.connectID, c.backend
+}
+
+func (c *ProxyClientConnection) suppressBackendCloseRequest() {
+	c.httpMu.Lock()
+	c.httpSuppressCloseRequest = true
+	c.httpMu.Unlock()
+}
+
+func (c *ProxyClientConnection) sendBackendCloseRequestAsync(server *ProxyServer, reason string) {
+	go c.sendBackendCloseRequest(server, reason)
+}
+
+func (c *ProxyClientConnection) sendBackendCloseRequest(server *ProxyServer, reason string) {
+	_, connectID, backend := c.httpConnectionDetails()
+	if connectID == 0 || backend == nil || backend.conn == nil {
+		// In particular, a pre-establishment terminal path must not consume the
+		// once guard. A concurrent successful DIAL_RSP may assign a real ID and
+		// still needs to close that backend connection.
+		return
+	}
+
+	c.closeRequestOnce.Do(func() {
+		c.httpMu.Lock()
+		suppressed := c.httpSuppressCloseRequest
+		connectID = c.connectID
+		backend = c.backend
+		dialID := c.dialID
+		c.httpMu.Unlock()
+		if suppressed || connectID == 0 || backend == nil || backend.conn == nil {
+			return
+		}
+		if backend.Context().Err() != nil {
+			return
+		}
+		server.sendBackendClose(backend, connectID, dialID, reason)
+	})
+}
+
+func serializeHTTPConnectDialError(dialErr string) []byte {
+	body := []byte(dialErr)
+	if len(body) > maxHTTPConnectErrorBodyBytes {
+		marker := []byte(httpConnectTruncationMarker)
+		prefixLen := maxHTTPConnectErrorBodyBytes - len(marker)
+		body = append(append([]byte(nil), body[:prefixLen]...), marker...)
+	}
+
+	statusCode := mapDialErrorToHTTPStatus(dialErr)
+	response := http.Response{
+		StatusCode:    statusCode,
+		Status:        fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Header: http.Header{
+			"Content-Type": []string{"text/plain; charset=utf-8"},
+		},
+		Proto:      "HTTP/1.1",
+		ProtoMinor: 1,
+		ProtoMajor: 1,
+	}
+	var serialized bytes.Buffer
+	// bytes.Buffer writes cannot fail.
+	_ = response.Write(&serialized)
+	return serialized.Bytes()
+}
+
+// writeAll preserves stream semantics for writers that make partial progress.
+func writeAll(dst io.Writer, data []byte) error {
+	for len(data) > 0 {
+		n, err := dst.Write(data)
+		if n < 0 || n > len(data) {
+			return io.ErrShortWrite
+		}
+		if n > 0 {
+			data = data[n:]
+		}
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+	}
+	return nil
+}

--- a/pkg/server/http_connect_writer_test.go
+++ b/pkg/server/http_connect_writer_test.go
@@ -1,0 +1,784 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/metadata"
+
+	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/metrics"
+	"sigs.k8s.io/apiserver-network-proxy/pkg/server/proxystrategies"
+)
+
+const writerTestSafetyTimeout = time.Second
+
+type writerTestSentPacket struct {
+	typeID    client.PacketType
+	connectID int64
+}
+
+type writerTestAgentStream struct {
+	ctx context.Context
+
+	mu   sync.Mutex
+	sent []writerTestSentPacket
+}
+
+func newWriterTestBackend(ctx context.Context, agentID string) (*Backend, *writerTestAgentStream) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	stream := &writerTestAgentStream{ctx: ctx}
+	return &Backend{id: agentID, conn: stream}, stream
+}
+
+func (s *writerTestAgentStream) Send(pkt *client.Packet) error {
+	entry := writerTestSentPacket{typeID: pkt.Type}
+	if closeReq := pkt.GetCloseRequest(); closeReq != nil {
+		entry.connectID = closeReq.ConnectID
+	}
+	s.mu.Lock()
+	s.sent = append(s.sent, entry)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *writerTestAgentStream) Recv() (*client.Packet, error) { return nil, io.EOF }
+func (s *writerTestAgentStream) SetHeader(metadata.MD) error   { return nil }
+func (s *writerTestAgentStream) SendHeader(metadata.MD) error  { return nil }
+func (s *writerTestAgentStream) SetTrailer(metadata.MD)        {}
+func (s *writerTestAgentStream) Context() context.Context      { return s.ctx }
+func (s *writerTestAgentStream) SendMsg(any) error             { return nil }
+func (s *writerTestAgentStream) RecvMsg(any) error             { return io.EOF }
+
+func (s *writerTestAgentStream) count(packetType client.PacketType) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	count := 0
+	for _, pkt := range s.sent {
+		if pkt.typeID == packetType {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *writerTestAgentStream) closeRequestIDs() []int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var ids []int64
+	for _, pkt := range s.sent {
+		if pkt.typeID == client.PacketType_CLOSE_REQ {
+			ids = append(ids, pkt.connectID)
+		}
+	}
+	return ids
+}
+
+func newWriterTestServer(queueDepth int) *ProxyServer {
+	return NewProxyServer(
+		"",
+		[]proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault},
+		1,
+		nil,
+		queueDepth,
+	)
+}
+
+func writerTestEventually(t *testing.T, description string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(writerTestSafetyTimeout)
+	for {
+		if condition() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", description)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+type writerTestImmediateHTTP struct {
+	mu      sync.Mutex
+	stream  []byte
+	closed  bool
+	closes  int
+	updated chan struct{}
+	closeCh chan struct{}
+
+	closeOnce sync.Once
+}
+
+func newWriterTestImmediateHTTP() *writerTestImmediateHTTP {
+	return &writerTestImmediateHTTP{
+		updated: make(chan struct{}, 1),
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (w *writerTestImmediateHTTP) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (w *writerTestImmediateHTTP) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, io.ErrClosedPipe
+	}
+	w.stream = append(w.stream, p...)
+	select {
+	case w.updated <- struct{}{}:
+	default:
+	}
+	return len(p), nil
+}
+
+func (w *writerTestImmediateHTTP) close() error {
+	w.mu.Lock()
+	w.closes++
+	w.closed = true
+	w.mu.Unlock()
+	w.closeOnce.Do(func() { close(w.closeCh) })
+	return nil
+}
+
+func (w *writerTestImmediateHTTP) snapshot() ([]byte, int, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]byte(nil), w.stream...), w.closes, w.closed
+}
+
+type writerTestBlockingHTTP struct {
+	writeStarted chan struct{}
+	writeDone    chan struct{}
+	releaseWrite chan struct{}
+	closeCh      chan struct{}
+	updated      chan struct{}
+
+	mu     sync.Mutex
+	stream []byte
+	closed bool
+	closes int
+
+	startOnce   sync.Once
+	doneOnce    sync.Once
+	releaseOnce sync.Once
+	closeOnce   sync.Once
+}
+
+func newWriterTestBlockingHTTP() *writerTestBlockingHTTP {
+	return &writerTestBlockingHTTP{
+		writeStarted: make(chan struct{}),
+		writeDone:    make(chan struct{}),
+		releaseWrite: make(chan struct{}),
+		closeCh:      make(chan struct{}),
+		updated:      make(chan struct{}, 1),
+	}
+}
+
+func (w *writerTestBlockingHTTP) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (w *writerTestBlockingHTTP) Write(p []byte) (int, error) {
+	w.startOnce.Do(func() { close(w.writeStarted) })
+	<-w.releaseWrite
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	defer w.doneOnce.Do(func() { close(w.writeDone) })
+	if w.closed {
+		return 0, io.ErrClosedPipe
+	}
+	w.stream = append(w.stream, p...)
+	select {
+	case w.updated <- struct{}{}:
+	default:
+	}
+	return len(p), nil
+}
+
+func (w *writerTestBlockingHTTP) release() {
+	w.releaseOnce.Do(func() { close(w.releaseWrite) })
+}
+
+func (w *writerTestBlockingHTTP) close() error {
+	w.mu.Lock()
+	w.closes++
+	w.closed = true
+	w.mu.Unlock()
+	w.closeOnce.Do(func() { close(w.closeCh) })
+	w.release()
+	return nil
+}
+
+func (w *writerTestBlockingHTTP) snapshot() ([]byte, int, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]byte(nil), w.stream...), w.closes, w.closed
+}
+
+type writerTestGateFailHTTP struct {
+	started chan struct{}
+	release chan struct{}
+	err     error
+
+	startOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newWriterTestGateFailHTTP(err error) *writerTestGateFailHTTP {
+	return &writerTestGateFailHTTP{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+		err:     err,
+	}
+}
+
+func (w *writerTestGateFailHTTP) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (w *writerTestGateFailHTTP) Write([]byte) (int, error) {
+	w.startOnce.Do(func() { close(w.started) })
+	<-w.release
+	return 0, w.err
+}
+
+func (w *writerTestGateFailHTTP) unblock() {
+	w.releaseOnce.Do(func() { close(w.release) })
+}
+
+type writerTestOneByteHTTP struct {
+	mu     sync.Mutex
+	stream []byte
+}
+
+func (w *writerTestOneByteHTTP) Read([]byte) (int, error) { return 0, io.EOF }
+
+func (w *writerTestOneByteHTTP) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	w.mu.Lock()
+	w.stream = append(w.stream, p[0])
+	w.mu.Unlock()
+	return 1, nil
+}
+
+func (w *writerTestOneByteHTTP) bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]byte(nil), w.stream...)
+}
+
+type writerTestZeroWriter struct {
+	calls atomic.Int32
+}
+
+func (w *writerTestZeroWriter) Write([]byte) (int, error) {
+	w.calls.Add(1)
+	return 0, nil
+}
+
+// This test protects the writer's load-bearing synchronization contract. It is
+// intentionally run under the package race job: enqueue publication and both
+// terminal transitions must remain panic-free and idempotent under overlap.
+func TestHTTPConnectWriterConcurrentTerminalTransitions(t *testing.T) {
+	const iterations = 300
+	for i := 0; i < iterations; i++ {
+		server := newWriterTestServer(8)
+		var closeCalls atomic.Int32
+		connection := &ProxyClientConnection{
+			Mode:      ModeHTTPConnect,
+			HTTP:      newWriterTestImmediateHTTP(),
+			CloseHTTP: func() error { closeCalls.Add(1); return nil },
+			closed:    make(chan struct{}),
+			agentID:   "race-agent",
+			connectID: int64(i + 1),
+		}
+		writer, attached := connection.attachHTTPWriter(server, nil, false)
+		if !attached {
+			t.Fatal("failed to attach writer to a live connection")
+		}
+
+		start := make(chan struct{})
+		var workers sync.WaitGroup
+		for worker := 0; worker < 8; worker++ {
+			workers.Add(1)
+			go func(worker int) {
+				defer workers.Done()
+				<-start
+				for packet := 0; packet < 8; packet++ {
+					writer.enqueueData([]byte{byte(worker), byte(packet)})
+				}
+			}(worker)
+		}
+		workers.Add(2)
+		go func() {
+			defer workers.Done()
+			<-start
+			writer.beginGracefulClose()
+		}()
+		go func() {
+			defer workers.Done()
+			<-start
+			writer.abort(httpConnectAbortFrontendClose)
+		}()
+
+		close(start)
+		workers.Wait()
+		// Replay both transitions after the raced calls return to verify that the
+		// terminal APIs remain idempotent.
+		writer.abort(httpConnectAbortWriteFailure)
+		writer.beginGracefulClose()
+
+		writerTestEventually(t, "exactly one terminal HTTP close", func() bool {
+			return closeCalls.Load() == 1
+		})
+		writer.mu.Lock()
+		accepting, aborted, closeSeen := writer.accepting, writer.aborted, writer.closeResponseSeen
+		writer.mu.Unlock()
+		if accepting || !aborted || !closeSeen {
+			t.Fatalf("terminal writer state = accepting:%t aborted:%t closeResponseSeen:%t", accepting, aborted, closeSeen)
+		}
+		if got := closeCalls.Load(); got != 1 {
+			t.Fatalf("CloseHTTP calls = %d, want 1", got)
+		}
+	}
+}
+
+// A stale asynchronous graceful completion must not evict a replacement that
+// reused the same protocol IDs.
+func TestHTTPConnectStaleWriterCannotRemoveReplacement(t *testing.T) {
+	const (
+		agentID   = "reuse-agent"
+		connectID = int64(73)
+	)
+	server := newWriterTestServer(2)
+	oldHTTP := newWriterTestBlockingHTTP()
+	oldConnection := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      oldHTTP,
+		CloseHTTP: oldHTTP.close,
+		closed:    make(chan struct{}),
+		agentID:   agentID,
+		connectID: connectID,
+	}
+	server.addEstablished(agentID, connectID, oldConnection)
+	oldWriter, _ := oldConnection.attachHTTPWriter(server, nil, false)
+	oldWriter.start()
+	if got := oldWriter.enqueueData([]byte("old payload")); got != httpConnectEnqueueAccepted {
+		t.Fatalf("enqueue result = %v, want accepted", got)
+	}
+	select {
+	case <-oldHTTP.writeStarted:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("old writer did not enter its blocked write")
+	}
+	oldWriter.beginGracefulClose()
+
+	replacement := &ProxyClientConnection{Mode: ModeHTTPConnect, agentID: agentID, connectID: connectID}
+	server.addEstablished(agentID, connectID, replacement)
+	oldHTTP.release()
+	select {
+	case <-oldHTTP.closeCh:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("stale writer did not finish graceful cleanup")
+	}
+
+	got, err := server.getFrontend(agentID, connectID)
+	if err != nil {
+		t.Fatalf("replacement was removed by stale completion: %v", err)
+	}
+	if got != replacement {
+		t.Fatalf("established pointer = %p, want replacement %p", got, replacement)
+	}
+}
+
+func TestHTTPConnectWriterPreservesBytesAcrossPartialWrites(t *testing.T) {
+	const (
+		agentID   = "partial-agent"
+		connectID = int64(91)
+	)
+	payloads := [][]byte{[]byte("alpha"), []byte("-"), []byte("beta"), []byte("-gamma")}
+	want := bytes.Join(payloads, nil)
+	server := newWriterTestServer(len(payloads))
+	httpWriter := &writerTestOneByteHTTP{}
+	connection := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      httpWriter,
+		closed:    make(chan struct{}),
+		agentID:   agentID,
+		connectID: connectID,
+	}
+	server.addEstablished(agentID, connectID, connection)
+	writer, _ := connection.attachHTTPWriter(server, nil, false)
+	writer.start()
+	for _, payload := range payloads {
+		if got := writer.enqueueData(payload); got != httpConnectEnqueueAccepted {
+			t.Fatalf("enqueue result = %v, want accepted", got)
+		}
+	}
+	writer.beginGracefulClose()
+	select {
+	case <-connection.closed:
+	case <-time.After(writerTestSafetyTimeout):
+		t.Fatal("partial-write stream did not close after draining")
+	}
+	if got := httpWriter.bytes(); !bytes.Equal(got, want) {
+		t.Fatalf("reassembled stream = %q, want %q", got, want)
+	}
+
+	zeroWriter := &writerTestZeroWriter{}
+	if err := writeAll(zeroWriter, []byte("no progress")); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("zero-progress write error = %v, want %v", err, io.ErrShortWrite)
+	}
+	if got := zeroWriter.calls.Load(); got != 1 {
+		t.Fatalf("zero-progress writer calls = %d, want 1", got)
+	}
+}
+
+func TestHTTPConnectInitialResponseFailures(t *testing.T) {
+	t.Run("successful dial response", func(t *testing.T) {
+		const (
+			agentID   = "response-agent"
+			connectID = int64(101)
+		)
+		server := newWriterTestServer(1)
+		backend, stream := newWriterTestBackend(context.Background(), agentID)
+		writeErr := errors.New("response write failed")
+		httpWriter := newWriterTestGateFailHTTP(writeErr)
+		connected := make(chan struct{})
+		var closeCalls atomic.Int32
+		connection := &ProxyClientConnection{
+			Mode:                ModeHTTPConnect,
+			HTTP:                httpWriter,
+			CloseHTTP:           func() error { closeCalls.Add(1); return nil },
+			closed:              make(chan struct{}),
+			connected:           connected,
+			httpInitialResponse: []byte(httpConnectSuccessResponse),
+			agentID:             agentID,
+			connectID:           connectID,
+			backend:             backend,
+		}
+		server.addEstablished(agentID, connectID, connection)
+		writer, attached := connection.configuredHTTPWriter(server, true)
+		if !attached {
+			t.Fatal("successful response writer was not attached")
+		}
+		writer.start()
+		select {
+		case <-httpWriter.started:
+		case <-time.After(writerTestSafetyTimeout):
+			t.Fatal("successful response write did not start")
+		}
+		httpWriter.unblock()
+		writerTestEventually(t, "failed response cleanup", func() bool {
+			return closeCalls.Load() == 1 && stream.count(client.PacketType_CLOSE_REQ) == 1
+		})
+		select {
+		case <-connected:
+			t.Fatal("connected was signaled after the successful response write failed")
+		default:
+		}
+		if got, err := server.getFrontend(agentID, connectID); err != nil || got != connection {
+			t.Fatalf("failed response terminal entry = %p, %v; want retained %p", got, err, connection)
+		}
+		if writer.beginGracefulClose() != httpConnectCloseAlreadyForced {
+			t.Fatal("backend acknowledgement did not observe the forced response failure")
+		}
+		server.removeEstablishedIf(agentID, connectID, connection)
+	})
+
+	t.Run("failed dial response with zero connection ID", func(t *testing.T) {
+		const agentID = "failed-dial-agent"
+		server := newWriterTestServer(1)
+		backend, stream := newWriterTestBackend(context.Background(), agentID)
+		replacement := &ProxyClientConnection{Mode: ModeHTTPConnect, agentID: agentID}
+		server.addEstablished(agentID, 0, replacement)
+
+		writeErr := errors.New("error response write failed")
+		httpWriter := newWriterTestGateFailHTTP(writeErr)
+		var closeCalls atomic.Int32
+		connected := make(chan struct{})
+		failedDial := &ProxyClientConnection{
+			Mode:      ModeHTTPConnect,
+			HTTP:      httpWriter,
+			CloseHTTP: func() error { closeCalls.Add(1); return nil },
+			closed:    make(chan struct{}),
+			connected: connected,
+			agentID:   agentID,
+			backend:   backend,
+		}
+		writer, attached := failedDial.attachHTTPWriter(server, serializeHTTPConnectDialError("dial failed"), false)
+		if !attached {
+			t.Fatal("failed-dial writer was not attached")
+		}
+		writer.start()
+		select {
+		case <-httpWriter.started:
+		case <-time.After(writerTestSafetyTimeout):
+			t.Fatal("failed-dial error response write did not start")
+		}
+		writer.beginGracefulClose()
+		httpWriter.unblock()
+		writerTestEventually(t, "failed-dial response cleanup", func() bool {
+			return closeCalls.Load() == 1
+		})
+		select {
+		case <-connected:
+			t.Fatal("failed dial signaled connected")
+		default:
+		}
+		failedDial.sendBackendCloseRequest(server, "test completion")
+		if got := stream.count(client.PacketType_CLOSE_REQ); got != 0 {
+			t.Fatalf("failed dial sent %d CLOSE_REQ packets with connection ID zero", got)
+		}
+		got, err := server.getFrontend(agentID, 0)
+		if err != nil || got != replacement {
+			t.Fatalf("zero-ID replacement = %p, %v; want %p", got, err, replacement)
+		}
+
+		serialized := serializeHTTPConnectDialError(strings.Repeat("x", maxHTTPConnectErrorBodyBytes+512))
+		response, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(serialized)), nil)
+		if err != nil {
+			t.Fatalf("parse serialized error response: %v", err)
+		}
+		body, err := io.ReadAll(response.Body)
+		_ = response.Body.Close()
+		if err != nil {
+			t.Fatalf("read serialized error body: %v", err)
+		}
+		if len(body) != maxHTTPConnectErrorBodyBytes {
+			t.Fatalf("error response body length = %d, want %d", len(body), maxHTTPConnectErrorBodyBytes)
+		}
+		if !bytes.HasSuffix(body, []byte(httpConnectTruncationMarker)) {
+			t.Fatalf("truncated error body does not end with marker: %q", body[len(body)-64:])
+		}
+	})
+}
+
+func TestHTTPConnectDeadBackendSendGuards(t *testing.T) {
+	t.Run("overflow cleanup outlives backend shutdown", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		server := newWriterTestServer(1)
+		backend, stream := newWriterTestBackend(ctx, "dead-agent")
+		closeStarted := make(chan struct{})
+		closeRelease := make(chan struct{})
+		closeReturned := make(chan struct{})
+		connection := &ProxyClientConnection{
+			Mode:      ModeHTTPConnect,
+			HTTP:      newWriterTestImmediateHTTP(),
+			closed:    make(chan struct{}),
+			agentID:   "dead-agent",
+			connectID: 201,
+			backend:   backend,
+			CloseHTTP: func() error {
+				close(closeStarted)
+				<-closeRelease
+				close(closeReturned)
+				return nil
+			},
+		}
+		writer, _ := connection.attachHTTPWriter(server, nil, false)
+		if got := writer.enqueueData([]byte("queued")); got != httpConnectEnqueueAccepted {
+			t.Fatalf("first enqueue = %v, want accepted", got)
+		}
+		if got := writer.enqueueData([]byte("overflow")); got != httpConnectEnqueueOverflow {
+			t.Fatalf("second enqueue = %v, want overflow", got)
+		}
+		select {
+		case <-closeStarted:
+		case <-time.After(writerTestSafetyTimeout):
+			t.Fatal("overflow cleanup did not enter CloseHTTP")
+		}
+		connection.suppressBackendCloseRequest()
+		cancel()
+		close(closeRelease)
+		select {
+		case <-closeReturned:
+		case <-time.After(writerTestSafetyTimeout):
+			t.Fatal("overflow CloseHTTP did not return")
+		}
+		// Settle the once guard synchronously if the cleanup goroutine has not yet
+		// reached it. Either caller must observe suppression.
+		connection.sendBackendCloseRequest(server, "backend shutdown")
+		if got := stream.count(client.PacketType_CLOSE_REQ); got != 0 {
+			t.Fatalf("dead backend received %d CLOSE_REQ packets", got)
+		}
+	})
+
+	t.Run("nonzero pre-publication ID with canceled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		server := newWriterTestServer(1)
+		backend, stream := newWriterTestBackend(ctx, "canceled-agent")
+		connection := &ProxyClientConnection{
+			Mode:      ModeHTTPConnect,
+			agentID:   "canceled-agent",
+			connectID: 202,
+			backend:   backend,
+		}
+		connection.sendBackendCloseRequest(server, "setup race")
+		if got := stream.count(client.PacketType_CLOSE_REQ); got != 0 {
+			t.Fatalf("canceled pre-publication backend received %d CLOSE_REQ packets", got)
+		}
+	})
+}
+
+func TestHTTPConnectTerminalSideEffectsConvergeExactlyOnce(t *testing.T) {
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		server := newWriterTestServer(1)
+		backend, stream := newWriterTestBackend(context.Background(), "terminal-agent")
+		var closeCalls atomic.Int32
+		connection := &ProxyClientConnection{
+			Mode:      ModeHTTPConnect,
+			HTTP:      newWriterTestImmediateHTTP(),
+			CloseHTTP: func() error { closeCalls.Add(1); return nil },
+			closed:    make(chan struct{}),
+			agentID:   "terminal-agent",
+			connectID: int64(300 + i),
+			backend:   backend,
+		}
+		server.addEstablished(connection.agentID, connection.connectID, connection)
+		writer, _ := connection.attachHTTPWriter(server, nil, false)
+		if got := writer.enqueueData([]byte("queued")); got != httpConnectEnqueueAccepted {
+			t.Fatalf("initial enqueue = %v, want accepted", got)
+		}
+
+		start := make(chan struct{})
+		result := make(chan httpConnectCloseDisposition, 1)
+		var workers sync.WaitGroup
+		workers.Add(4)
+		go func() {
+			defer workers.Done()
+			<-start
+			result <- writer.beginGracefulClose()
+		}()
+		go func() {
+			defer workers.Done()
+			<-start
+			writer.abort(httpConnectAbortWriteFailure)
+		}()
+		go func() {
+			defer workers.Done()
+			<-start
+			connection.abortHTTP(server, httpConnectAbortFrontendClose)
+		}()
+		go func() {
+			defer workers.Done()
+			<-start
+			writer.enqueueData([]byte("racing enqueue"))
+		}()
+		close(start)
+		workers.Wait()
+		// Mirror CLOSE_RSP routing: if forced cleanup won first, the response
+		// path owns removal of the terminal map entry.
+		if <-result == httpConnectCloseAlreadyForced {
+			server.removeEstablishedIf(connection.agentID, connection.connectID, connection)
+		}
+
+		writerTestEventually(t, "converged terminal side effects", func() bool {
+			return closeCalls.Load() == 1 && stream.count(client.PacketType_CLOSE_REQ) == 1
+		})
+		// With convergence observed, replay every terminal API to prove that none
+		// can duplicate a side effect or resurrect map state.
+		connection.abortHTTP(server, httpConnectAbortFrontendClose)
+		writer.abort(httpConnectAbortWriteFailure)
+		_ = connection.closeHTTP()
+		connection.sendBackendCloseRequest(server, "duplicate terminal call")
+		if got := closeCalls.Load(); got != 1 {
+			t.Fatalf("CloseHTTP calls = %d, want 1", got)
+		}
+		if got := stream.count(client.PacketType_CLOSE_REQ); got != 1 {
+			t.Fatalf("connection-owned CLOSE_REQ count = %d, want 1", got)
+		}
+		if _, err := server.getFrontend(connection.agentID, connection.connectID); err == nil {
+			t.Fatal("terminal connection remained or was resurrected in established state")
+		}
+	}
+}
+
+func TestHTTPConnectQueueOverflowMetricCardinalityAndReset(t *testing.T) {
+	metrics.Metrics.Reset()
+	t.Cleanup(metrics.Metrics.Reset)
+
+	server := newWriterTestServer(1)
+	connection := &ProxyClientConnection{
+		Mode:      ModeHTTPConnect,
+		HTTP:      newWriterTestImmediateHTTP(),
+		closed:    make(chan struct{}),
+		agentID:   "metric-agent",
+		connectID: 401,
+	}
+	writer, _ := connection.attachHTTPWriter(server, nil, false)
+	if got := writer.enqueueData([]byte("queued")); got != httpConnectEnqueueAccepted {
+		t.Fatalf("first enqueue = %v, want accepted", got)
+	}
+	if got := writer.enqueueData([]byte("overflow")); got != httpConnectEnqueueOverflow {
+		t.Fatalf("second enqueue = %v, want overflow", got)
+	}
+
+	const metricName = metrics.Namespace + "_" + metrics.Subsystem + "_http_connect_disconnect_count"
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	found := false
+	for _, family := range families {
+		if family.GetName() != metricName {
+			continue
+		}
+		found = true
+		if len(family.Metric) != 1 {
+			t.Fatalf("overflow metric series = %d, want 1", len(family.Metric))
+		}
+		metric := family.Metric[0]
+		if len(metric.Label) != 1 || metric.Label[0].GetName() != "reason" || metric.Label[0].GetValue() != "queue_overflow" {
+			t.Fatalf("overflow metric labels = %v, want only reason=queue_overflow", metric.Label)
+		}
+		if got := metric.GetCounter().GetValue(); got != 1 {
+			t.Fatalf("overflow metric value = %v, want 1", got)
+		}
+	}
+	if !found {
+		t.Fatalf("metric family %q was not gathered", metricName)
+	}
+
+	metrics.Metrics.Reset()
+	metrics.Metrics.Reset()
+	families, err = prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather reset metrics: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() == metricName && len(family.Metric) != 0 {
+			t.Fatalf("overflow metric retained %d series after reset", len(family.Metric))
+		}
+	}
+}

--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -47,23 +47,24 @@ var (
 
 // ServerMetrics includes all the metrics of the proxy server.
 type ServerMetrics struct {
-	endpointLatencies    *prometheus.HistogramVec
-	frontendLatencies    *prometheus.HistogramVec
-	grpcConnections      *prometheus.GaugeVec
-	httpConnections      prometheus.Gauge
-	backend              *prometheus.GaugeVec
-	totalBackendCount    *prometheus.GaugeVec
-	pendingDials         *prometheus.GaugeVec
-	establishedConns     *prometheus.GaugeVec
-	fullRecvChannels     *prometheus.GaugeVec
-	dialFailures         *prometheus.CounterVec
-	streamPackets        *prometheus.CounterVec
-	streamErrors         *prometheus.CounterVec
-	culledLeases         prometheus.Counter
-	leaseDeleteLatencies *prometheus.HistogramVec
-	leaseDeletes         *prometheus.CounterVec
-	leaseListLatencies   *prometheus.HistogramVec
-	leaseLists           *prometheus.CounterVec
+	endpointLatencies      *prometheus.HistogramVec
+	frontendLatencies      *prometheus.HistogramVec
+	grpcConnections        *prometheus.GaugeVec
+	httpConnections        prometheus.Gauge
+	backend                *prometheus.GaugeVec
+	totalBackendCount      *prometheus.GaugeVec
+	pendingDials           *prometheus.GaugeVec
+	establishedConns       *prometheus.GaugeVec
+	fullRecvChannels       *prometheus.GaugeVec
+	dialFailures           *prometheus.CounterVec
+	httpConnectDisconnects *prometheus.CounterVec
+	streamPackets          *prometheus.CounterVec
+	streamErrors           *prometheus.CounterVec
+	culledLeases           prometheus.Counter
+	leaseDeleteLatencies   *prometheus.HistogramVec
+	leaseDeletes           *prometheus.CounterVec
+	leaseListLatencies     *prometheus.HistogramVec
+	leaseLists             *prometheus.CounterVec
 }
 
 // newServerMetrics create a new ServerMetrics, configured with default metric names.
@@ -167,6 +168,17 @@ func newServerMetrics() *ServerMetrics {
 			"reason",
 		},
 	)
+	httpConnectDisconnects := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "http_connect_disconnect_count",
+			Help:      "Number of HTTP CONNECT frontends disconnected by the server, partitioned by reason.",
+		},
+		[]string{
+			"reason",
+		},
+	)
 	culledLeases := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: Namespace,
 		Subsystem: Subsystem,
@@ -221,6 +233,7 @@ func newServerMetrics() *ServerMetrics {
 	prometheus.MustRegister(establishedConns)
 	prometheus.MustRegister(fullRecvChannels)
 	prometheus.MustRegister(dialFailures)
+	prometheus.MustRegister(httpConnectDisconnects)
 	prometheus.MustRegister(streamPackets)
 	prometheus.MustRegister(streamErrors)
 	prometheus.MustRegister(culledLeases)
@@ -229,23 +242,24 @@ func newServerMetrics() *ServerMetrics {
 	prometheus.MustRegister(leaseListLatencies)
 	prometheus.MustRegister(leaseLists)
 	return &ServerMetrics{
-		endpointLatencies:    endpointLatencies,
-		frontendLatencies:    frontendLatencies,
-		grpcConnections:      grpcConnections,
-		httpConnections:      httpConnections,
-		backend:              backend,
-		totalBackendCount:    totalBackendCount,
-		pendingDials:         pendingDials,
-		establishedConns:     establishedConns,
-		fullRecvChannels:     fullRecvChannels,
-		dialFailures:         dialFailures,
-		streamPackets:        streamPackets,
-		streamErrors:         streamErrors,
-		culledLeases:         culledLeases,
-		leaseDeleteLatencies: leaseDeleteLatencies,
-		leaseDeletes:         leaseDeletes,
-		leaseListLatencies:   leaseListLatencies,
-		leaseLists:           leaseLists,
+		endpointLatencies:      endpointLatencies,
+		frontendLatencies:      frontendLatencies,
+		grpcConnections:        grpcConnections,
+		httpConnections:        httpConnections,
+		backend:                backend,
+		totalBackendCount:      totalBackendCount,
+		pendingDials:           pendingDials,
+		establishedConns:       establishedConns,
+		fullRecvChannels:       fullRecvChannels,
+		dialFailures:           dialFailures,
+		httpConnectDisconnects: httpConnectDisconnects,
+		streamPackets:          streamPackets,
+		streamErrors:           streamErrors,
+		culledLeases:           culledLeases,
+		leaseDeleteLatencies:   leaseDeleteLatencies,
+		leaseDeletes:           leaseDeletes,
+		leaseListLatencies:     leaseListLatencies,
+		leaseLists:             leaseLists,
 	}
 }
 
@@ -260,6 +274,7 @@ func (s *ServerMetrics) Reset() {
 	s.establishedConns.Reset()
 	s.fullRecvChannels.Reset()
 	s.dialFailures.Reset()
+	s.httpConnectDisconnects.Reset()
 	s.streamPackets.Reset()
 	s.streamErrors.Reset()
 }
@@ -333,6 +348,16 @@ const (
 
 func (s *ServerMetrics) ObserveDialFailure(reason DialFailureReason) {
 	s.dialFailures.With(prometheus.Labels{"reason": string(reason)}).Inc()
+}
+
+type HTTPConnectDisconnectReason string
+
+const (
+	HTTPConnectDisconnectQueueOverflow HTTPConnectDisconnectReason = "queue_overflow"
+)
+
+func (s *ServerMetrics) ObserveHTTPConnectDisconnect(reason HTTPConnectDisconnectReason) {
+	s.httpConnectDisconnects.With(prometheus.Labels{"reason": string(reason)}).Inc()
 }
 
 func (s *ServerMetrics) ObservePacket(segment commonmetrics.Segment, packetType client.PacketType) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,12 +17,10 @@ limitations under the License.
 package server
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	runpprof "runtime/pprof"
 	"strconv"
 	"strings"
@@ -102,6 +100,22 @@ type ProxyClientConnection struct {
 	start       time.Time
 	backend     *Backend
 	dialAddress string // cached for logging
+
+	// HTTP-CONNECT output and terminal state. httpMu protects writer
+	// attachment, terminal-before-attachment, connection identifiers used by
+	// asynchronous cleanup, and CLOSE_REQ suppression. It is never held during
+	// HTTP or backend I/O.
+	httpMu                   sync.Mutex
+	httpWriter               *httpConnectWriter
+	httpTerminal             bool
+	httpInitialResponse      []byte
+	httpSuppressCloseRequest bool
+	closed                   chan struct{}
+
+	closeHTTPOnce    sync.Once
+	closeHTTPErr     error
+	closeRequestOnce sync.Once
+	httpCleanupOnce  sync.Once
 }
 
 const (
@@ -161,38 +175,7 @@ func (c *ProxyClientConnection) send(pkt *client.Packet) error {
 		return c.frontend.Send(pkt)
 	}
 	if c.Mode == ModeHTTPConnect {
-		if pkt.Type == client.PacketType_CLOSE_RSP {
-			return c.CloseHTTP()
-		} else if pkt.Type == client.PacketType_DIAL_CLS {
-			return c.CloseHTTP()
-		} else if pkt.Type == client.PacketType_DATA {
-			_, err := c.HTTP.Write(pkt.GetData().Data)
-			return err
-		} else if pkt.Type == client.PacketType_DIAL_RSP {
-			dialErr := pkt.GetDialResponse().Error
-			if dialErr != "" {
-				// // Map the error to appropriate HTTP status code
-				statusCode := mapDialErrorToHTTPStatus(dialErr)
-				statusText := http.StatusText(statusCode)
-				body := bytes.NewBufferString(dialErr)
-				t := http.Response{
-					StatusCode: statusCode,
-					Status:     fmt.Sprintf("%d %s", statusCode, statusText),
-					Body:       io.NopCloser(body),
-					Header: http.Header{
-						"Content-Type": []string{"text/plain; charset=utf-8"},
-					},
-					Proto:      "HTTP/1.1",
-					ProtoMinor: 1,
-					ProtoMajor: 1,
-				}
-
-				t.Write(c.HTTP)
-				return c.CloseHTTP()
-			}
-			return nil
-		}
-		return fmt.Errorf("attempt to send via unrecognized connection type %v", pkt.Type)
+		return fmt.Errorf("HTTP-CONNECT packet %v must be routed through its connection writer", pkt.Type)
 	}
 	return fmt.Errorf("attempt to send via unrecognized connection mode %q", c.Mode)
 }
@@ -272,8 +255,9 @@ type ProxyServer struct {
 	AgentAuthenticationOptions *AgentTokenAuthenticationOptions
 
 	// TODO: move strategies into BackendStorage
-	proxyStrategies []proxystrategies.ProxyStrategy
-	xfrChannelSize  int
+	proxyStrategies      []proxystrategies.ProxyStrategy
+	xfrChannelSize       int
+	httpConnectQueueSize int
 }
 
 // AgentTokenAuthenticationOptions contains list of parameters required for agent token based authentication
@@ -360,6 +344,24 @@ func (s *ProxyServer) removeEstablished(agentID string, connID int64) *ProxyClie
 	return ret
 }
 
+// removeEstablishedIf removes a connection only if expected is still the
+// registered pointer. Asynchronous completion from an old HTTP writer must not
+// remove a replacement that reused the same agent and connection IDs.
+func (s *ProxyServer) removeEstablishedIf(agentID string, connID int64, expected *ProxyClientConnection) *ProxyClientConnection {
+	s.fmu.Lock()
+	defer s.fmu.Unlock()
+	conns, ok := s.established[agentID]
+	if !ok || conns[connID] != expected {
+		return nil
+	}
+	delete(conns, connID)
+	if len(conns) == 0 {
+		delete(s.established, agentID)
+	}
+	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.established))
+	return expected
+}
+
 func (s *ProxyServer) getFrontend(agentID string, connID int64) (*ProxyClientConnection, error) {
 	s.fmu.RLock()
 	defer s.fmu.RUnlock()
@@ -385,11 +387,14 @@ func (s *ProxyServer) removeEstablishedForBackendConn(agentID string, backend *B
 	if !ok {
 		return nil, fmt.Errorf("can't find agentID %s in the established", agentID)
 	}
-	for _, frontend := range established {
+	for connID, frontend := range established {
 		if frontend.backend == backend {
-			delete(s.established, agentID)
+			delete(established, connID)
 			ret = append(ret, frontend)
 		}
+	}
+	if len(established) == 0 {
+		delete(s.established, agentID)
 	}
 
 	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.established))
@@ -458,6 +463,10 @@ func NewProxyServer(serverID string, proxyStrategies []proxystrategies.ProxyStra
 		Readiness:       bms[0],
 		proxyStrategies: proxyStrategies,
 		xfrChannelSize:  channelSize,
+		// V1 intentionally seeds each private HTTP write queue from the existing
+		// transfer-channel setting. Until a separate option exists, increasing
+		// xfr-channel-size also increases every HTTP connection memory allowance.
+		httpConnectQueueSize: max(1, channelSize),
 	}
 }
 
@@ -863,8 +872,9 @@ func (s *ProxyServer) serveRecvBackend(backend *Backend, agentID string, recvCh 
 	}()
 
 	defer func() {
-		// Close all established connections when the agent connection is closed
-		// TODO(#126): connections in PendingDial state should also be closed.
+		// Remove all connections owned by this backend before asynchronously
+		// aborting HTTP writers. The backend stream is dead, so suppress every
+		// connection-owned CLOSE_REQ.
 		established, err := s.removeEstablishedForBackendConn(agentID, backend)
 		if err != nil {
 			return
@@ -875,13 +885,18 @@ func (s *ProxyServer) serveRecvBackend(backend *Backend, agentID string, recvCh 
 		}
 
 		for _, frontend := range established {
+			if frontend.Mode == ModeHTTPConnect {
+				frontend.suppressBackendCloseRequest()
+				frontend.abortHTTP(s, httpConnectAbortBackendShutdown)
+				continue
+			}
+
 			pkt := &client.Packet{
 				Type: client.PacketType_CLOSE_RSP,
 				Payload: &client.Packet_CloseResponse{
-					CloseResponse: &client.CloseResponse{},
+					CloseResponse: &client.CloseResponse{ConnectID: frontend.connectID},
 				},
 			}
-			pkt.GetCloseResponse().ConnectID = frontend.connectID
 			if err := frontend.send(pkt); err != nil {
 				klog.ErrorS(err, "CLOSE_RSP to frontend failed", "agentID", agentID)
 			}
@@ -901,34 +916,40 @@ func (s *ProxyServer) serveRecvBackend(backend *Backend, agentID string, recvCh 
 				if resp.ConnectID != 0 {
 					s.sendBackendClose(backend, resp.ConnectID, resp.Random, "unknown dial id")
 				}
-			} else {
-				dialErr := false
-				if resp.Error != "" {
-					// Dial response with error should not contain a valid ConnID.
-					klog.ErrorS(errors.New(resp.Error), "DIAL_RSP contains failure", "dialID", resp.Random, "agentID", agentID)
-					metrics.Metrics.ObserveDialFailure(metrics.DialFailureErrorResponse)
-					dialErr = true
+				break
+			}
+
+			if resp.Error != "" {
+				klog.ErrorS(errors.New(resp.Error), "DIAL_RSP contains failure", "dialID", resp.Random, "agentID", agentID)
+				metrics.Metrics.ObserveDialFailure(metrics.DialFailureErrorResponse)
+				if frontend.Mode == ModeHTTPConnect {
+					writer, attached := frontend.attachHTTPWriter(s, serializeHTTPConnectDialError(resp.Error), false)
+					if !attached {
+						frontend.abortHTTP(s, httpConnectAbortDialClosed)
+						break
+					}
+					writer.start()
+					writer.beginGracefulClose()
+					break
 				}
-				err := frontend.send(pkt)
-				if err != nil {
+				if err := frontend.send(pkt); err != nil {
 					klog.ErrorS(err, "DIAL_RSP send to frontend stream failure",
 						"dialID", resp.Random, "agentID", agentID, "connectionID", resp.ConnectID)
-					if !dialErr { // Avoid double-counting.
-						metrics.Metrics.ObserveDialFailure(metrics.DialFailureSendResponse)
-					}
-					// If we never finish setting up the tunnel for ConnectID, then the connection is dead.
-					// Currently, the agent will no resend DIAL_RSP, so connection is dead.
-					// We already attempted to tell the frontend that. We should ensure we tell the backend.
 					s.sendBackendClose(backend, resp.ConnectID, resp.Random, "dial error")
-					dialErr = true
 				}
-				// Avoid adding the frontend if there was an error dialing the destination
-				if dialErr {
+				break
+			}
+
+			if frontend.Mode != ModeHTTPConnect {
+				if err := frontend.send(pkt); err != nil {
+					klog.ErrorS(err, "DIAL_RSP send to frontend stream failure",
+						"dialID", resp.Random, "agentID", agentID, "connectionID", resp.ConnectID)
+					metrics.Metrics.ObserveDialFailure(metrics.DialFailureSendResponse)
+					s.sendBackendClose(backend, resp.ConnectID, resp.Random, "dial error")
 					break
 				}
 				frontend.connectID = resp.ConnectID
 				frontend.agentID = agentID
-				// TODO: this connection may be cleaned on serveRecvFrontend exit, make it independent.
 				s.addEstablished(agentID, resp.ConnectID, frontend)
 				close(frontend.connected)
 				metrics.Metrics.ObserveDialLatency(time.Since(frontend.start))
@@ -939,7 +960,43 @@ func (s *ProxyServer) serveRecvBackend(backend *Backend, agentID string, recvCh 
 					"dialAddress", frontend.dialAddress,
 					"dialDuration", time.Since(frontend.start),
 				)
+				break
 			}
+
+			frontend.setHTTPConnectionDetails(agentID, resp.ConnectID)
+			writer, attached := frontend.configuredHTTPWriter(s, true)
+			if !attached {
+				// Teardown won before writer attachment. The backend has still
+				// created a real connection, so close it without blocking this
+				// shared consumer.
+				frontend.sendBackendCloseRequestAsync(s, string(httpConnectAbortSetupRace))
+				break
+			}
+			if frontend.httpWriterIsTerminal(writer) {
+				frontend.sendBackendCloseRequestAsync(s, string(httpConnectAbortSetupRace))
+				break
+			}
+
+			// Publish the exact connection before the writer starts so DATA can
+			// never observe an established HTTP connection without its writer.
+			s.addEstablished(agentID, resp.ConnectID, frontend)
+			if frontend.httpWriterIsTerminal(writer) {
+				// Teardown raced publication and won before establishment. Do
+				// not leave a newly published terminal entry behind.
+				s.removeEstablishedIf(agentID, resp.ConnectID, frontend)
+				writer.abort(httpConnectAbortSetupRace)
+				frontend.sendBackendCloseRequestAsync(s, string(httpConnectAbortSetupRace))
+				break
+			}
+			writer.start()
+			metrics.Metrics.ObserveDialLatency(time.Since(frontend.start))
+			klog.V(3).InfoS("Proxy connection established",
+				"dialID", resp.Random,
+				"connectionID", resp.ConnectID,
+				"agentID", agentID,
+				"dialAddress", frontend.dialAddress,
+				"dialDuration", time.Since(frontend.start),
+			)
 
 		case client.PacketType_DIAL_CLS:
 			resp := pkt.GetCloseDial()
@@ -947,20 +1004,22 @@ func (s *ProxyServer) serveRecvBackend(backend *Backend, agentID string, recvCh 
 			frontend := s.PendingDial.Remove(resp.Random)
 			if frontend == nil {
 				klog.V(2).InfoS("DIAL_CLS not recognized; dropped", "dialID", resp.Random, "agentID", agentID)
-			} else {
-				if err := frontend.send(pkt); err != nil {
-					klog.ErrorS(err, "DIAL_CLS send to client stream error", "agentID", agentID, "dialID", resp.Random)
-				} else {
-					klog.V(5).InfoS("DIAL_CLS sent to frontend", "dialID", resp.Random)
-				}
-				klog.ErrorS(nil, "Dial terminated (DIAL_CLS) by backend",
-					"dialID", resp.Random,
-					"agentID", agentID,
-					"dialAddress", frontend.dialAddress,
-					"dialDuration", time.Since(frontend.start),
-				)
-				metrics.Metrics.ObserveDialFailure(metrics.DialFailureBackendClose)
+				break
 			}
+			if frontend.Mode == ModeHTTPConnect {
+				frontend.abortHTTP(s, httpConnectAbortDialClosed)
+			} else if err := frontend.send(pkt); err != nil {
+				klog.ErrorS(err, "DIAL_CLS send to client stream error", "agentID", agentID, "dialID", resp.Random)
+			} else {
+				klog.V(5).InfoS("DIAL_CLS sent to frontend", "dialID", resp.Random)
+			}
+			klog.ErrorS(nil, "Dial terminated (DIAL_CLS) by backend",
+				"dialID", resp.Random,
+				"agentID", agentID,
+				"dialAddress", frontend.dialAddress,
+				"dialDuration", time.Since(frontend.start),
+			)
+			metrics.Metrics.ObserveDialFailure(metrics.DialFailureBackendClose)
 
 		case client.PacketType_DATA:
 			resp := pkt.GetData()
@@ -976,26 +1035,62 @@ func (s *ProxyServer) serveRecvBackend(backend *Backend, agentID string, recvCh 
 				s.sendBackendClose(backend, resp.ConnectID, 0, "missing frontend")
 				break
 			}
-			if err := frontend.send(pkt); err != nil {
-				klog.ErrorS(err, "send to client stream failure", "agentID", agentID, "connectionID", resp.ConnectID)
-			} else {
-				klog.V(5).InfoS("DATA sent to frontend")
+			if frontend.Mode != ModeHTTPConnect {
+				if err := frontend.send(pkt); err != nil {
+					klog.ErrorS(err, "send to client stream failure", "agentID", agentID, "connectionID", resp.ConnectID)
+				} else {
+					klog.V(5).InfoS("DATA sent to frontend")
+				}
+				break
+			}
+
+			writer, attached := frontend.attachHTTPWriter(s, nil, false)
+			if !attached {
+				// A still-registered terminal connection absorbs late DATA
+				// until CLOSE_RSP without generating repeated CLOSE_REQ packets.
+				break
+			}
+			writer.start()
+			switch writer.enqueueData(resp.Data) {
+			case httpConnectEnqueueAccepted:
+				klog.V(5).InfoS("HTTP-CONNECT DATA queued to frontend", "agentID", agentID, "connectionID", resp.ConnectID)
+			case httpConnectEnqueueClosed:
+				// The terminal entry deliberately remains registered until the
+				// backend acknowledges closure.
+			case httpConnectEnqueueOverflow:
+				// enqueueData already initiated connection-local forced cleanup.
 			}
 
 		case client.PacketType_CLOSE_RSP:
 			resp := pkt.GetCloseResponse()
 			klog.V(5).InfoS("Received CLOSE_RSP", "agentID", agentID, "connectionID", resp.ConnectID)
-			frontend := s.removeEstablished(agentID, resp.ConnectID)
-			if frontend == nil {
-				// assuming it is already closed, just log it
+			frontend, err := s.getFrontend(agentID, resp.ConnectID)
+			if err != nil {
 				klog.V(2).InfoS("could not get frontend client for closing", "agentID", agentID, "connectionID", resp.ConnectID)
 				break
 			}
-			if err := frontend.send(pkt); err != nil {
-				// Normal when frontend closes it.
-				klog.ErrorS(err, "CLOSE_RSP send to client stream error", "agentID", agentID, "connectionID", resp.ConnectID)
-			} else {
-				klog.V(5).InfoS("CLOSE_RSP sent to frontend", "connectionID", resp.ConnectID)
+			if frontend.Mode != ModeHTTPConnect {
+				frontend = s.removeEstablished(agentID, resp.ConnectID)
+				if frontend == nil {
+					break
+				}
+				if err := frontend.send(pkt); err != nil {
+					// Normal when frontend closes it.
+					klog.ErrorS(err, "CLOSE_RSP send to client stream error", "agentID", agentID, "connectionID", resp.ConnectID)
+				} else {
+					klog.V(5).InfoS("CLOSE_RSP sent to frontend", "connectionID", resp.ConnectID)
+				}
+				break
+			}
+
+			writer, attached := frontend.attachHTTPWriter(s, nil, false)
+			if !attached {
+				s.removeEstablishedIf(agentID, resp.ConnectID, frontend)
+				break
+			}
+			writer.start()
+			if writer.beginGracefulClose() == httpConnectCloseAlreadyForced {
+				s.removeEstablishedIf(agentID, resp.ConnectID, frontend)
 			}
 
 		case client.PacketType_DRAIN:

--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -76,9 +76,6 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var closeOnce sync.Once
-	defer closeOnce.Do(func() { conn.Close() })
-
 	random := rand.Int63() /* #nosec G404 */
 	dialRequest := &client.Packet{
 		Type: client.PacketType_DIAL_REQ,
@@ -95,122 +92,90 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	backend, err := t.Server.getBackend(r.Host)
 	if err != nil {
 		klog.ErrorS(err, "no tunnels available")
-		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\ncurrently no tunnels available: %v", err)))
-		// The hijacked connection will be closed by the closeOnce defer.
+		_ = writeAll(conn, []byte(fmt.Sprintf("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\ncurrently no tunnels available: %v", err)))
+		_ = conn.Close()
 		return
 	}
+
 	closed := make(chan struct{})
 	connected := make(chan struct{})
+	initialAgentID := backend.GetAgentID()
 	connection := &ProxyClientConnection{
-		Mode: ModeHTTPConnect,
-		HTTP: io.ReadWriter(conn), // pass as ReadWriter so the caller must close with CloseHTTP
-		CloseHTTP: func() error {
-			closeOnce.Do(func() { conn.Close() })
-			close(closed)
-			return nil
-		},
-		connected: connected,
-		start:     time.Now(),
-		backend:   backend,
-		dialID:    random,
-		agentID:   backend.GetAgentID(),
+		Mode:                ModeHTTPConnect,
+		HTTP:                io.ReadWriter(conn),
+		CloseHTTP:           conn.Close,
+		connected:           connected,
+		closed:              closed,
+		httpInitialResponse: []byte(httpConnectSuccessResponse),
+		start:               time.Now(),
+		backend:             backend,
+		dialID:              random,
+		agentID:             initialAgentID,
 	}
 	t.Server.PendingDial.Add(random, connection)
 
-	// This defer acts as a safeguard to ensure we clean up the pending dial
-	// if the connection is never successfully established.
-	established := false
+	// Every Tunnel exit owns teardown of any attached writer. Removing the
+	// pending entry is also the ownership token for pre-establishment cleanup.
 	defer func() {
-		if !established {
-			if t.Server.PendingDial.Remove(random) != nil {
-				// This metric is observed only when the frontend closes the connection.
-				// Other failure reasons are observed elsewhere.
-				metrics.Metrics.ObserveDialFailure(metrics.DialFailureFrontendClose)
-			}
+		if t.Server.PendingDial.Remove(random) != nil {
+			metrics.Metrics.ObserveDialFailure(metrics.DialFailureFrontendClose)
 		}
+		connection.abortHTTP(t.Server, httpConnectAbortFrontendClose)
 	}()
 
 	if err := backend.Send(dialRequest); err != nil {
-		klog.ErrorS(err, "failed to tunnel dial request", "host", r.Host, "dialID", connection.dialID, "agentID", connection.agentID)
+		klog.ErrorS(err, "failed to tunnel dial request", "host", r.Host, "dialID", connection.dialID, "agentID", initialAgentID)
 		metrics.Metrics.ObserveDialFailure(metrics.DialFailureBackendClose)
-		// Send proper HTTP error response
-		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nFailed to tunnel dial request: %v\r\n", err)))
-		// The deferred cleanup will run when we return here.
+		_ = writeAll(conn, []byte(fmt.Sprintf("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nFailed to tunnel dial request: %v\r\n", err)))
 		return
 	}
 
 	ctxt := backend.Context()
-
 	select {
-	case <-connection.connected: // Waiting for response before we begin full communication.
-		// The connection is successful. Mark it as established so the deferred
-		// cleanup function knows not to remove it from PendingDial.
-		established = true
+	case <-connection.connected:
+		// The per-connection writer has completed the entire successful CONNECT
+		// response before signaling establishment.
+		agentID, connectID, _ := connection.httpConnectionDetails()
+		klog.V(3).InfoS("Connection established, sent 200 OK", "host", r.Host, "agentID", agentID, "connectionID", connectID)
 
-		// Now that connection is established, send 200 OK to switch to tunnel mode
-		_, err = conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
-		if err != nil {
-			klog.ErrorS(err, "failed to send 200 connection established", "host", r.Host, "agentID", connection.agentID)
-			// We return here, but since `established` is true, the deferred
-			// function will not remove the pending dial. The agent-side goroutine
-			// is responsible for the established connection now.
-			return
-		}
-		klog.V(3).InfoS("Connection established, sent 200 OK", "host", r.Host, "agentID", connection.agentID, "connectionID", connection.connectID)
-
-	case <-closed: // Connection was closed by the client before being established
-		klog.V(2).InfoS("Frontend connection closed before being established", "host", r.Host, "dialID", connection.dialID, "agentID", connection.agentID)
-		// The deferred cleanup will run when we return here.
+	case <-closed:
+		klog.V(2).InfoS("Frontend connection closed before being established", "host", r.Host, "dialID", connection.dialID, "agentID", initialAgentID)
 		return
 
-	case <-ctxt.Done(): // Backend connection died before being established
-		klog.ErrorS(ctxt.Err(), "backend context closed before connection was established", "host", r.Host, "dialID", connection.dialID, "agentID", connection.agentID)
+	case <-ctxt.Done():
+		klog.ErrorS(ctxt.Err(), "backend context closed before connection was established", "host", r.Host, "dialID", connection.dialID, "agentID", initialAgentID)
 		metrics.Metrics.ObserveDialFailure(metrics.DialFailureBackendClose)
-		// Send proper HTTP error response
-		conn.Write([]byte(fmt.Sprintf("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nBackend context error: %v\r\n", ctxt.Err())))
-		// The deferred cleanup will run when we return here.
+
+		if t.Server.PendingDial.Remove(random) != nil {
+			// Tunnel still owns the pending dial, so it is the only path allowed
+			// to serialize this pre-establishment error to the socket.
+			_ = writeAll(conn, serializeHTTPConnectDialError(fmt.Sprintf("Backend context error: %v", ctxt.Err())))
+		} else {
+			// DIAL_RSP already claimed the connection. Marking terminal prevents
+			// a racing response path from attaching and starting a fresh writer.
+			connection.abortHTTP(t.Server, httpConnectAbortBackendShutdown)
+		}
 		return
 	}
 
-	defer func() {
-		packet := &client.Packet{
-			Type: client.PacketType_CLOSE_REQ,
-			Payload: &client.Packet_CloseRequest{
-				CloseRequest: &client.CloseRequest{
-					ConnectID: connection.connectID,
-				},
-			},
-		}
+	connIDAgent, connID, _ := connection.httpConnectionDetails()
+	klog.V(3).InfoS("Starting proxy to host", "host", r.Host, "agentID", connIDAgent, "connectionID", connID)
 
-		if err = backend.Send(packet); err != nil {
-			klog.V(2).InfoS("failed to send close request packet", "host", r.Host, "agentID", connection.agentID, "connectionID", connection.connectID)
-		}
-		// The top-level defer handles conn.Close()
-	}()
-
-	connID := connection.connectID
-	agentID := connection.agentID
-	klog.V(3).InfoS("Starting proxy to host", "host", r.Host, "agentID", agentID, "connectionID", connID)
-
-	// Get a buffer from the pool
+	// Get a buffer from the pool.
 	bufPtr := bufferPool.Get().(*[]byte)
 	pkt := *bufPtr
-	defer func() {
-		// Return the buffer to the pool when done
-		bufferPool.Put(bufPtr)
-	}()
+	defer bufferPool.Put(bufPtr)
 
 	var acc int
-
 	for {
 		n, err := bufrw.Read(pkt[:])
 		acc += n
 		if err == io.EOF {
-			klog.V(1).InfoS("EOF from host", "host", r.Host, "agentID", agentID, "connectionID", connID)
+			klog.V(1).InfoS("EOF from host", "host", r.Host, "agentID", connIDAgent, "connectionID", connID)
 			break
 		}
 		if err != nil {
-			klog.ErrorS(err, "Received failure on connection", "host", r.Host, "agentID", agentID, "connectionID", connID)
+			klog.ErrorS(err, "Received failure on connection", "host", r.Host, "agentID", connIDAgent, "connectionID", connID)
 			break
 		}
 
@@ -223,17 +188,16 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				},
 			},
 		}
-		err = backend.Send(packet)
-		if err != nil {
-			klog.ErrorS(err, "error sending packet", "host", r.Host, "agentID", agentID, "connectionID", connID)
+		if err := backend.Send(packet); err != nil {
+			klog.ErrorS(err, "error sending packet", "host", r.Host, "agentID", connIDAgent, "connectionID", connID)
 			break
 		}
 		klog.V(5).InfoS("Forwarding data on tunnel to agent",
 			"bytes", n,
 			"totalBytes", acc,
-			"agentID", connection.agentID,
-			"connectionID", connection.connectID)
+			"agentID", connIDAgent,
+			"connectionID", connID)
 	}
 
-	klog.V(5).InfoS("Stopping transfer to host", "host", r.Host, "agentID", agentID, "connectionID", connID)
+	klog.V(5).InfoS("Stopping transfer to host", "host", r.Host, "agentID", connIDAgent, "connectionID", connID)
 }


### PR DESCRIPTION
 Previously, HTTP CONNECT responses and DATA were written to frontend sockets directly from the shared backend receive loop. A single slow or blocked frontend could therefore stall every connection using the same agent stream.

 This change:

 - Introduces one bounded FIFO writer per HTTP CONNECT connection, moving socket writes out of the shared receive loop.
 - Preserves byte ordering and guarantees that the HTTP CONNECT response is fully written before tunnel DATA.
 - Supports concurrency-safe graceful draining and forced abort without sending on closed channels or closing resources twice.
 - Isolates queue overflow and write failures to the affected connection while allowing healthy connections to continue.
 - Adds idempotent frontend close and backend CLOSE_REQ handling across frontend EOF, backend response, overflow, and shutdown races.
 - Uses pointer-checked established-connection removal so stale writer cleanup cannot remove a replacement that reused the same connection ID.
 - Ensures backend shutdown aborts and unblocks only connections owned by that backend.
 - Adds a low-cardinality metric for HTTP CONNECT queue-overflow disconnects.
 - Adds race and lifecycle coverage for ordering, partial writes, ID reuse, late DATA, overflow isolation, teardown convergence, and backend shutdown.

