### PR TITLE
fix: scope removeEstablishedForBackendConn to the retiring backend

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -456,11 +456,14 @@ func (s *ProxyServer) removeEstablishedForBackendConn(agentID string, backend *B
 	if !ok {
 		return nil, fmt.Errorf("can't find agentID %s in the established", agentID)
 	}
-	for _, frontend := range established {
+	for connID, frontend := range established {
 		if frontend.backend == backend {
-			delete(s.established, agentID)
+			delete(established, connID)
 			ret = append(ret, frontend)
 		}
+	}
+	if len(established) == 0 {
+		delete(s.established, agentID)
 	}
 
 	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.established))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -464,6 +464,8 @@ func (s *ProxyServer) removeEstablishedForBackendConn(agentID string, backend *B
 	}
 	if len(established) == 0 {
 		delete(s.established, agentID)
+	} else {
+		klog.V(2).InfoS("Frontends established over other backend connections remain after backend removal", "agentID", agentID, "remaining", len(established))
 	}
 
 	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.established))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1087,3 +1087,29 @@ func dialClosePkt(dialID int64) *client.Packet {
 		},
 	}
 }
+
+func TestRemoveEstablishedForBackendConnPreservesOtherBackends(t *testing.T) {
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+
+	backend1 := &Backend{}
+	backend2 := &Backend{}
+
+	conn1 := &ProxyClientConnection{backend: backend1}
+	conn2 := &ProxyClientConnection{backend: backend2}
+	p.addEstablished("agent1", int64(1), conn1)
+	p.addEstablished("agent1", int64(2), conn2)
+
+	ret, err := p.removeEstablishedForBackendConn("agent1", backend1)
+	if err != nil {
+		t.Fatalf("removeEstablishedForBackendConn returned error: %v", err)
+	}
+	if len(ret) != 1 || ret[0] != conn1 {
+		t.Fatalf("expected only conn1 returned, got %v", ret)
+	}
+	if got, err := p.getFrontend("agent1", int64(2)); err != nil || got != conn2 {
+		t.Errorf("conn2 on backend2 was wrongly evicted: got %v, err %v", got, err)
+	}
+	if got, err := p.getFrontend("agent1", int64(1)); err == nil && got != nil {
+		t.Errorf("conn1 on backend1 should have been removed, got %v", got)
+	}
+}


### PR DESCRIPTION
While reading through the server I noticed `removeEstablishedForBackendConn` deletes the whole per-agent `established` map on the first matching connection (`delete(s.established, agentID)`), rather than just the connections belonging to the backend that's going away.

That's fine when there's one backend per agentID, but `backends` is a slice per agentID, so with an HA agent you can have several. In that case retiring one backend also evicts the connections served by the *other* backends under the same agentID. They get dropped from the routing map and aren't added to the returned slice, so the caller never sends them a `CLOSE_RSP` and their frontend connections leak.

The two sibling functions already do this the right way — `removeEstablished` and `removeEstablishedForStream` delete per-connID and only drop the agent entry once its inner map is empty. This just brings `removeEstablishedForBackendConn` in line with them.

I also added `TestRemoveEstablishedForBackendConnPreservesOtherBackends`: two connections under one agentID on two different backends, retire one, and check the other is still routable while only the retired backend's connection comes back. It fails on the current code and passes with the change.
