### PR TITLE
fix: make CloseHTTP idempotent to avoid close of closed channel

### DIFF
--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -106,8 +106,10 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Mode: ModeHTTPConnect,
 		HTTP: io.ReadWriter(conn), // pass as ReadWriter so the caller must close with CloseHTTP
 		CloseHTTP: func() error {
-			closeOnce.Do(func() { conn.Close() })
-			close(closed)
+			closeOnce.Do(func() {
+				conn.Close()
+				close(closed)
+			})
 			return nil
 		},
 		connected: connected,

--- a/pkg/server/tunnel.go
+++ b/pkg/server/tunnel.go
@@ -107,8 +107,8 @@ func (t *Tunnel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		HTTP: io.ReadWriter(conn), // pass as ReadWriter so the caller must close with CloseHTTP
 		CloseHTTP: func() error {
 			closeOnce.Do(func() {
+				defer close(closed)
 				conn.Close()
-				close(closed)
 			})
 			return nil
 		},


### PR DESCRIPTION
The `CloseHTTP` callback for an HTTP-CONNECT connection wraps `conn.Close()` in `closeOnce`, but `close(closed)` sits just outside it:

```go
CloseHTTP: func() error {
    closeOnce.Do(func() { conn.Close() })
    close(closed)
    return nil
},
```

If `CloseHTTP` runs twice for the same connection, that second `close(closed)` panics with "close of closed channel" — and since it's unrecovered, it takes the whole proxy process down, not just the one tunnel. `conn.Close()` being inside `closeOnce` already shows the intent is for this cleanup to happen once; `close(closed)` just got left out of the guard. Moving it inside the same `closeOnce` makes the callback idempotent. Nothing changes on the normal single-close path.
