### PR TITLE
Fix drain failure structured logging

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -353,7 +353,7 @@ func (a *Client) Serve() {
 					},
 				}
 				if err := a.Send(drainPkt); err != nil {
-					klog.ErrorS(err, "drain failure", "")
+					klog.ErrorS(err, "drain failure", "serverID", a.serverID, "agentID", a.agentID)
 				}
 			})
 		default:


### PR DESCRIPTION
The existing `klog.ErrorS` call passes a lone empty string as a key without a value. klog renders that as a missing structured value, producing malformed log output and losing useful client context.
