### PR TITLE
Fix agent DRAIN signaling blocked by stream Recv

### DIFF
--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -151,9 +151,8 @@ type Client struct {
 	opts    []grpc.DialOption
 	conn    *grpc.ClientConn
 
-	drainCh   <-chan struct{}
-	drainOnce sync.Once
-	stopCh    chan struct{}
+	drainCh <-chan struct{}
+	stopCh  chan struct{}
 
 	// locks
 	sendLock      sync.Mutex
@@ -338,24 +337,12 @@ func (a *Client) Serve() {
 
 	klog.V(2).InfoS("Start serving", "serverID", a.serverID, "agentID", a.agentID)
 	go a.probe()
+	go a.sendDrainWhenRequested()
 	for {
 		select {
 		case <-a.stopCh:
 			klog.V(2).InfoS("stop agent client.")
 			return
-		case <-a.drainCh:
-			a.drainOnce.Do(func() {
-				klog.V(2).InfoS("drain agent client", "serverID", a.serverID, "agentID", a.agentID)
-				drainPkt := &client.Packet{
-					Type: client.PacketType_DRAIN,
-					Payload: &client.Packet_Drain{
-						Drain: &client.Drain{},
-					},
-				}
-				if err := a.Send(drainPkt); err != nil {
-					klog.ErrorS(err, "drain failure", "")
-				}
-			})
 		default:
 		}
 
@@ -573,6 +560,26 @@ func (a *Client) Serve() {
 		default:
 			klog.V(5).InfoS("unrecognized packet", "type", pkt)
 		}
+	}
+}
+
+// sendDrainWhenRequested sends DRAIN independently of the receive loop, which
+// can block indefinitely on an idle stream.
+func (a *Client) sendDrainWhenRequested() {
+	select {
+	case <-a.stopCh:
+		return
+	case <-a.drainCh:
+	}
+	klog.V(2).InfoS("drain agent client", "serverID", a.serverID, "agentID", a.agentID)
+	drainPkt := &client.Packet{
+		Type: client.PacketType_DRAIN,
+		Payload: &client.Packet_Drain{
+			Drain: &client.Drain{},
+		},
+	}
+	if err := a.Send(drainPkt); err != nil {
+		klog.ErrorS(err, "drain failure", "")
 	}
 }
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -53,18 +53,18 @@ type endpointConn struct {
 	// dataCh is a queue to decouple reads from the ANP Server
 	// to the corresponding writes to the data plane.
 	// This is for traffic coming from the KAS.
-	dataCh    chan []byte
+	dataCh chan []byte
 	// dialDone should be closed by dialChannelToRemote which is reading from the dialCh.
 	// It should only be closed when it has read to the end of the channel and sent the packets.
-	dialDone  chan struct{}
+	dialDone chan struct{}
 
 	// sendCh is a queue to decouple reads from the data plane
 	// to the corresponding writes to the ANP Server.
 	// This is for traffic going toward the KAS
-	sendCh    chan []byte
+	sendCh chan []byte
 	// sendDone should be closed by sendChannelToProxy which is reading from sendCh.
 	// It should only be closed when it has read to the end of the channel and sent the packets.
-	sendDone  chan struct{}
+	sendDone chan struct{}
 
 	cleanOnce sync.Once
 	warnChLim bool
@@ -482,11 +482,11 @@ func (a *Client) Serve() {
 						// the channel as it may not have been closed yet and we
 						// don't want to leave a goroutine hanging.
 						select {
-    						case <- eConn.sendCh:
+						case <-eConn.sendCh:
 							discardedPktCount++
-    						default:
+						default:
 							reading = false
-    						}
+						}
 					}
 					if discardedPktCount > 0 {
 						klog.V(1).InfoS("Discard packets from failed Dial", "pktCount", discardedPktCount, "dialID", dialReq.Random, "connectionID", connID)

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -344,7 +344,6 @@ func TestFailedSend_DialResp_GRPC(t *testing.T) {
 }
 
 func TestDrain(t *testing.T) {
-	var stream agent.AgentService_ConnectClient
 	drainCh := make(chan struct{})
 	stopCh := make(chan struct{})
 	cs := &ClientSet{
@@ -358,11 +357,17 @@ func TestDrain(t *testing.T) {
 		stopCh:      stopCh,
 		cs:          cs,
 	}
-	testClient.stream, stream = pipe()
+	agentStream, stream := pipe()
+	recvStarted := make(chan struct{}, 1)
+	agentStream.recvStarted = recvStarted
+	testClient.stream = agentStream
 
 	// Start agent
 	go testClient.Serve()
 	defer close(stopCh)
+
+	// Ensure Serve is blocked in Recv before requesting drain.
+	<-recvStarted
 
 	// Simulate pod first shutdown signal
 	close(drainCh)
@@ -380,11 +385,12 @@ func TestDrain(t *testing.T) {
 // fakeStream implements AgentService_ConnectClient
 type fakeStream struct {
 	grpc.ClientStream
-	r <-chan *client.Packet
-	w chan<- *client.Packet
+	r           <-chan *client.Packet
+	w           chan<- *client.Packet
+	recvStarted chan struct{}
 }
 
-func pipe() (agent.AgentService_ConnectClient, agent.AgentService_ConnectClient) {
+func pipe() (*fakeStream, *fakeStream) {
 	r, w := make(chan *client.Packet, 2), make(chan *client.Packet, 2)
 	s1, s2 := &fakeStream{}, &fakeStream{}
 	s1.r, s1.w = r, w
@@ -399,6 +405,10 @@ func (s *fakeStream) Send(packet *client.Packet) error {
 }
 
 func (s *fakeStream) Recv() (*client.Packet, error) {
+	select {
+	case s.recvStarted <- struct{}{}:
+	default:
+	}
 	select {
 	case pkt := <-s.r:
 		klog.V(4).InfoS("[DEBUG] recv", "packet", pkt)

--- a/pkg/agent/client_test.go
+++ b/pkg/agent/client_test.go
@@ -367,7 +367,11 @@ func TestDrain(t *testing.T) {
 	defer close(stopCh)
 
 	// Ensure Serve is blocked in Recv before requesting drain.
-	<-recvStarted
+	select {
+	case <-recvStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Serve to call Recv")
+	}
 
 	// Simulate pod first shutdown signal
 	close(drainCh)


### PR DESCRIPTION
When an agent starts draining while its proxy stream is idle, `Serve` is blocked in `Recv` and cannot observe `drainCh`. The DRAIN packet may never reach the proxy server, allowing new connections to be assigned to an agent that is shutting down.

This moves drain notification out of the receive loop so it can be sent as soon as `drainCh` closes.