### PR TITLE
server: preserve frontends on other backend connections

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -456,11 +456,14 @@ func (s *ProxyServer) removeEstablishedForBackendConn(agentID string, backend *B
 	if !ok {
 		return nil, fmt.Errorf("can't find agentID %s in the established", agentID)
 	}
-	for _, frontend := range established {
+	for connID, frontend := range established {
 		if frontend.backend == backend {
-			delete(s.established, agentID)
+			delete(established, connID)
 			ret = append(ret, frontend)
 		}
+	}
+	if len(established) == 0 {
+		delete(s.established, agentID)
 	}
 
 	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.established))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -679,6 +679,34 @@ func TestRemoveEstablishedForBackendConn(t *testing.T) {
 	}
 }
 
+func TestRemoveEstablishedForBackendConnPreservesOtherBackend(t *testing.T) {
+	metrics.Metrics.Reset()
+	const agentID = "agent"
+
+	targetBackend := &Backend{}
+	otherBackend := &Backend{}
+	targetFrontend := &ProxyClientConnection{backend: targetBackend}
+	otherFrontend := &ProxyClientConnection{backend: otherBackend}
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p.addEstablished(agentID, 1, targetFrontend)
+	p.addEstablished(agentID, 2, otherFrontend)
+
+	removed, err := p.removeEstablishedForBackendConn(agentID, targetBackend)
+	if err != nil {
+		t.Fatalf("removeEstablishedForBackendConn failed: %v", err)
+	}
+	if len(removed) != 1 || removed[0] != targetFrontend {
+		t.Fatalf("removed frontends = %v, want only %p", removed, targetFrontend)
+	}
+	if frontend, err := p.getFrontend(agentID, 1); err == nil || frontend != nil {
+		t.Fatalf("target backend frontend remains tracked: got %p, err %v", frontend, err)
+	}
+	if frontend, err := p.getFrontend(agentID, 2); err != nil || frontend != otherFrontend {
+		t.Fatalf("other backend frontend was removed: got %p, err %v, want %p", frontend, err, otherFrontend)
+	}
+	assertEstablishedConnsMetric(t, 1)
+}
+
 func TestRemoveEstablishedForStream(t *testing.T) {
 	streamUID := "target-uuid"
 	backend1 := &Backend{}


### PR DESCRIPTION
When backend streams with the same agent ID overlap, cleanup of one stream deletes the entire established connection map for that agent. This can untrack connections belonging to a surviving backend stream.

Remove only connections associated with the terminating backend, and delete the agent entry only when no connections remain. Add a regression test covering the overlapping-backend case.

Fixes: #894 