### PR TITLE
Use the server Mode constants instead of string literals

### DIFF
--- a/cmd/server/app/options/options.go
+++ b/cmd/server/app/options/options.go
@@ -389,7 +389,7 @@ func NewProxyRunOptions() *ProxyRunOptions {
 		ClusterCert:               "",
 		ClusterKey:                "",
 		ClusterCaCert:             "",
-		Mode:                      "grpc",
+		Mode:                      server.ModeGRPC,
 		UdsName:                   "",
 		DeleteUDSFile:             true,
 		ServerPort:                8090,

--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -352,7 +352,7 @@ func (p *Proxy) runUDSFrontendServer(ctx context.Context, o *options.ProxyRunOpt
 		}
 	}
 	var stop StopFunc
-	if o.Mode == "grpc" {
+	if o.Mode == server.ModeGRPC {
 		frontendServerOptions := []grpc.ServerOption{
 			grpc.KeepaliveParams(keepalive.ServerParameters{Time: o.FrontendKeepaliveTime}),
 		}
@@ -454,7 +454,7 @@ func (p *Proxy) runMTLSFrontendServer(_ context.Context, o *options.ProxyRunOpti
 
 	addr := net.JoinHostPort(o.ServerBindAddress, strconv.Itoa(o.ServerPort))
 
-	if o.Mode == "grpc" {
+	if o.Mode == server.ModeGRPC {
 		frontendServerOptions := []grpc.ServerOption{
 			grpc.Creds(credentials.NewTLS(tlsConfig)),
 			grpc.KeepaliveParams(keepalive.ServerParameters{Time: o.FrontendKeepaliveTime}),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -681,7 +681,7 @@ func (s *ProxyServer) serveRecvFrontend(frontend *GrpcFrontend, recvCh <-chan *c
 			s.PendingDial.Add(
 				random,
 				&ProxyClientConnection{
-					Mode:        "grpc",
+					Mode:        ModeGRPC,
 					frontend:    frontend,
 					dialID:      random,
 					connected:   make(chan struct{}),


### PR DESCRIPTION
/kind cleanup

pkg/server defines `ModeGRPC`/`ModeHTTPConnect` and most of the code already compares against them. This converts the last few `"grpc"` literals: the frontend mode checks, the option default, and the dial path in pkg/server.

```release-note
NONE
```
