### PR TITLE
Add connection_duration_seconds histogram for post-dial connection lifespan

### DIFF
--- a/pkg/server/metrics/metrics.go
+++ b/pkg/server/metrics/metrics.go
@@ -40,6 +40,8 @@ const (
 var (
 	// Use buckets ranging from 10 ns to 12.5 seconds.
 	latencyBuckets = []float64{0.000001, 0.00001, 0.0001, 0.005, 0.025, 0.1, 0.5, 2.5, 12.5}
+	// Use buckets ranging from 1 second to 24 hours.
+	connectionDurationBuckets = []float64{1, 5, 15, 30, 60, 300, 900, 1800, 3600, 14400, 43200, 86400}
 
 	// Metrics provides access to all dial metrics.
 	Metrics = newServerMetrics()
@@ -49,6 +51,7 @@ var (
 type ServerMetrics struct {
 	endpointLatencies    *prometheus.HistogramVec
 	frontendLatencies    *prometheus.HistogramVec
+	connectionDuration   *prometheus.HistogramVec
 	grpcConnections      *prometheus.GaugeVec
 	httpConnections      prometheus.Gauge
 	backend              *prometheus.GaugeVec
@@ -85,6 +88,16 @@ func newServerMetrics() *ServerMetrics {
 			Name:      "frontend_write_duration_seconds",
 			Help:      "Latency of write to the frontend in seconds",
 			Buckets:   latencyBuckets,
+		},
+		[]string{},
+	)
+	connectionDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: Subsystem,
+			Name:      "connection_duration_seconds",
+			Help:      "Duration in seconds a proxied end-to-end connection was established (post-dial) before being closed.",
+			Buckets:   connectionDurationBuckets,
 		},
 		[]string{},
 	)
@@ -213,6 +226,7 @@ func newServerMetrics() *ServerMetrics {
 	streamErrors := commonmetrics.MakeStreamErrorsTotalMetric(Namespace, Subsystem)
 	prometheus.MustRegister(endpointLatencies)
 	prometheus.MustRegister(frontendLatencies)
+	prometheus.MustRegister(connectionDuration)
 	prometheus.MustRegister(grpcConnections)
 	prometheus.MustRegister(httpConnections)
 	prometheus.MustRegister(backend)
@@ -231,6 +245,7 @@ func newServerMetrics() *ServerMetrics {
 	return &ServerMetrics{
 		endpointLatencies:    endpointLatencies,
 		frontendLatencies:    frontendLatencies,
+		connectionDuration:   connectionDuration,
 		grpcConnections:      grpcConnections,
 		httpConnections:      httpConnections,
 		backend:              backend,
@@ -253,6 +268,7 @@ func newServerMetrics() *ServerMetrics {
 func (s *ServerMetrics) Reset() {
 	s.endpointLatencies.Reset()
 	s.frontendLatencies.Reset()
+	s.connectionDuration.Reset()
 	s.grpcConnections.Reset()
 	s.backend.Reset()
 	s.totalBackendCount.Reset()
@@ -272,6 +288,11 @@ func (s *ServerMetrics) CulledLeasesInc() {
 // ObserveDialLatency records the latency of dial to the remote endpoint.
 func (s *ServerMetrics) ObserveDialLatency(elapsed time.Duration) {
 	s.endpointLatencies.WithLabelValues().Observe(elapsed.Seconds())
+}
+
+// ObserveConnectionDuration records how long an established end-to-end connection remained open.
+func (s *ServerMetrics) ObserveConnectionDuration(elapsed time.Duration) {
+	s.connectionDuration.WithLabelValues().Observe(elapsed.Seconds())
 }
 
 // ObserveFrontendWriteLatency records the latency of blocking on stream send to the client.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -95,17 +95,18 @@ const defaultBackendDialTimeout = 0
 var errBackendDialTimeout = errors.New("timed out waiting for backend dial")
 
 type ProxyClientConnection struct {
-	Mode        string
-	HTTP        io.ReadWriter
-	frontend    *GrpcFrontend
-	CloseHTTP   func() error
-	connected   chan struct{}
-	dialID      int64
-	connectID   int64
-	agentID     string
-	start       time.Time
-	backend     *Backend
-	dialAddress string // cached for logging
+	Mode          string
+	HTTP          io.ReadWriter
+	frontend      *GrpcFrontend
+	CloseHTTP     func() error
+	connected     chan struct{}
+	dialID        int64
+	connectID     int64
+	agentID       string
+	start         time.Time
+	establishedAt time.Time
+	backend       *Backend
+	dialAddress   string // cached for logging
 }
 
 const (
@@ -407,6 +408,7 @@ func (s *ProxyServer) addEstablished(agentID string, connID int64, p *ProxyClien
 	if _, ok := s.established[agentID]; !ok {
 		s.established[agentID] = make(map[int64]*ProxyClientConnection)
 	}
+	p.establishedAt = time.Now()
 	s.established[agentID][connID] = p
 
 	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.established))
@@ -428,6 +430,7 @@ func (s *ProxyServer) removeEstablished(agentID string, connID int64) *ProxyClie
 		delete(s.established, agentID)
 	}
 	metrics.Metrics.SetEstablishedConnCount(s.getCount(s.established))
+	metrics.Metrics.ObserveConnectionDuration(time.Since(ret.establishedAt))
 	return ret
 }
 
@@ -460,6 +463,7 @@ func (s *ProxyServer) removeEstablishedForBackendConn(agentID string, backend *B
 		if frontend.backend == backend {
 			delete(established, connID)
 			ret = append(ret, frontend)
+			metrics.Metrics.ObserveConnectionDuration(time.Since(frontend.establishedAt))
 		}
 	}
 	if len(established) == 0 {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/metadata"
 
@@ -647,6 +648,29 @@ func TestEstablishedConnsMetric(t *testing.T) {
 	assertEstablishedConnsMetric(t, 1)
 	p.removeEstablished("agent3", int64(1))
 	assertEstablishedConnsMetric(t, 0)
+}
+
+func TestConnectionDurationMetric(t *testing.T) {
+	metrics.Metrics.Reset()
+
+	p := NewProxyServer("", []proxystrategies.ProxyStrategy{proxystrategies.ProxyStrategyDefault}, 1, nil, xfrChannelSize)
+	p.addEstablished("agent1", int64(1), new(ProxyClientConnection))
+	p.removeEstablished("agent1", int64(1))
+
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() != "konnectivity_network_proxy_server_connection_duration_seconds" {
+			continue
+		}
+		if got := metricFamily.GetMetric()[0].GetHistogram().GetSampleCount(); got != 1 {
+			t.Fatalf("expected 1 connection duration observation, got %d", got)
+		}
+		return
+	}
+	t.Fatal("connection duration metric not found")
 }
 
 func TestRemoveEstablishedForBackendConn(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds a `connection_duration_seconds` Prometheus histogram (buckets 1s–24h) tracking how long a proxied end-to-end connection stays established (post-dial) before it closes.
- Records the establish timestamp on `ProxyClientConnection` and observes the duration on both removal paths (`removeEstablished`, `removeEstablishedForBackendConn`), mirroring the existing `dial_failure_count`/reason instrumentation style.

Addresses one item of the checklist in #410 ("Connection lifespan (histogram)").

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/server/...` (68 tests pass, includes new `TestConnectionDurationMetric`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)