### PR TITLE
server: prefer less congested backends in random routing

### DIFF
--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -56,6 +56,10 @@ type Backend struct {
 
 	// draining indicates if this backend is draining and should not accept new connections
 	draining atomic.Bool
+
+	// recvCh is assigned before the backend is published and is immutable
+	// afterward. It is observed only to measure receive-path pressure.
+	recvCh <-chan *client.Packet
 }
 
 // IsDraining returns true if the backend is draining
@@ -66,6 +70,17 @@ func (b *Backend) IsDraining() bool {
 // SetDraining marks the backend as draining
 func (b *Backend) SetDraining() {
 	b.draining.Store(true)
+}
+
+// RecvChannelOccupancy reports how much of the backend's receive channel is
+// occupied. Channel length is safe to sample concurrently, but the result is
+// only a point-in-time routing signal. An unavailable sample is treated as
+// neutral.
+func (b *Backend) RecvChannelOccupancy() float64 {
+	if b.recvCh == nil || cap(b.recvCh) == 0 {
+		return 0
+	}
+	return float64(len(b.recvCh)) / float64(cap(b.recvCh))
 }
 
 // Retire marks the backend as draining and closes Done once.

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -457,27 +457,68 @@ func ignoreNotFound(err error) error {
 	return err
 }
 
-// GetRandomBackend returns a random non-draining backend, falling back to a
-// random draining backend only when no non-draining agents are available.
+// lessOccupiedBackend returns the backend with less receive-channel pressure.
+// Equal occupancy is resolved randomly so idle backends continue to share load.
+// The caller must hold s.mu.
+func (s *DefaultBackendStorage) lessOccupiedBackend(first, second *Backend) *Backend {
+	firstOccupancy := first.RecvChannelOccupancy()
+	secondOccupancy := second.RecvChannelOccupancy()
+	if firstOccupancy < secondOccupancy {
+		return first
+	}
+	if secondOccupancy < firstOccupancy {
+		return second
+	}
+	if s.random.Intn(2) == 0 {
+		return first
+	}
+	return second
+}
+
+// GetRandomBackend samples two distinct non-draining agents and prefers the
+// primary backend with less receive-channel pressure. A sole non-draining
+// agent is used directly; draining agents are used only as a last resort.
+// The storage must maintain the random-routing index; otherwise this method
+// returns ErrNotFound even when backends are registered.
 func (s *DefaultBackendStorage) GetRandomBackend() (*Backend, error) {
+	// Selection may repair a state-list entry after observing a concurrently
+	// published draining transition, and rand.Rand is not safe for concurrent use.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if len(s.backends) == 0 {
 		return nil, &ErrNotFound{}
 	}
-
 	for len(s.nonDrainingAgentIDs) > 0 {
-		index := s.random.Intn(len(s.nonDrainingAgentIDs))
-		agentID := s.nonDrainingAgentIDs[index]
-		backend := s.backends[agentID][0]
+		firstIndex := s.random.Intn(len(s.nonDrainingAgentIDs))
+		firstAgentID := s.nonDrainingAgentIDs[firstIndex]
+		first := s.backends[firstAgentID][0]
 		// SetDraining publishes before each manager updates its state lists.
 		// Repair that short-lived stale entry instead of routing to it.
-		if backend.IsDraining() {
-			s.refreshIdentifierState(agentID)
+		if first.IsDraining() {
+			s.refreshIdentifierState(firstAgentID)
 			continue
 		}
-		klog.V(3).InfoS("Pick agent as backend", "agentID", agentID)
-		return backend, nil
+		if len(s.nonDrainingAgentIDs) == 1 {
+			klog.V(3).InfoS("Pick agent as backend", "agentID", firstAgentID)
+			return first, nil
+		}
+
+		secondIndex := s.random.Intn(len(s.nonDrainingAgentIDs) - 1)
+		if secondIndex >= firstIndex {
+			secondIndex++
+		}
+		secondAgentID := s.nonDrainingAgentIDs[secondIndex]
+		second := s.backends[secondAgentID][0]
+		if second.IsDraining() {
+			s.refreshIdentifierState(secondAgentID)
+			// Redraw both candidates. Returning first here would degrade this
+			// selection to a single random choice whenever a stale entry is found.
+			continue
+		}
+
+		selected := s.lessOccupiedBackend(first, second)
+		klog.V(3).InfoS("Pick agent as backend", "agentID", selected.GetAgentID())
+		return selected, nil
 	}
 
 	if len(s.drainingAgentIDs) > 0 {
@@ -487,5 +528,11 @@ func (s *DefaultBackendStorage) GetRandomBackend() (*Backend, error) {
 		return backend, nil
 	}
 
+	klog.ErrorS(nil, "Backends exist but no agent identifiers are classified",
+		"backendCount", len(s.backends),
+		"nonDrainingAgentCount", len(s.nonDrainingAgentIDs),
+		"drainingAgentCount", len(s.drainingAgentIDs),
+		"maintainRandomRoutingIndex", s.maintainRandomRoutingIndex,
+		"proxyStrategy", s.proxyStrategy)
 	return nil, &ErrNotFound{}
 }

--- a/pkg/server/backend_manager.go
+++ b/pkg/server/backend_manager.go
@@ -68,6 +68,8 @@ func (b *Backend) SetDraining() {
 	b.draining.Store(true)
 }
 
+// Retire marks the backend as draining and closes Done once.
+// It does not remove the backend from its backend managers.
 func (b *Backend) Retire() {
 	b.SetDraining()
 	b.retireOnce.Do(func() {
@@ -184,10 +186,18 @@ type BackendManager interface {
 	Backend(ctx context.Context) (*Backend, error)
 	// AddBackend adds a backend.
 	AddBackend(backend *Backend)
-	// RemoveBackend adds a backend.
+	// RemoveBackend removes a backend.
 	RemoveBackend(backend *Backend)
 	BackendStorage
 	ReadinessManager
+}
+
+// backendDrainingMarker is implemented by managers that maintain an index of
+// non-draining backends and therefore need notification of state transitions.
+// The caller must publish the backend's draining state before notification;
+// implementations only reclassify their own index.
+type backendDrainingMarker interface {
+	markBackendDraining(backend *Backend)
 }
 
 var _ BackendManager = &DefaultBackendManager{}
@@ -208,6 +218,11 @@ func (dbm *DefaultBackendManager) AddBackend(backend *Backend) {
 	dbm.addBackend(agentID, header.UID, backend)
 }
 
+func (dbm *DefaultBackendManager) markBackendDraining(backend *Backend) {
+	agentID := backend.GetAgentID()
+	dbm.DefaultBackendStorage.markIdentifierBackendDraining(agentID, header.UID, backend)
+}
+
 func (dbm *DefaultBackendManager) RemoveBackend(backend *Backend) {
 	agentID := backend.GetAgentID()
 	klog.V(5).InfoS("Remove the agent from the DefaultBackendManager", "agentID", agentID)
@@ -225,12 +240,14 @@ type DefaultBackendStorage struct {
 	// TODO: fix documentation. This is not always agentID, e.g. in
 	// the case of DestHostBackendManager.
 	backends map[string][]*Backend
-	// agentID is tracked in this slice to enable randomly picking an
-	// agentID in the Backend() method. There is no reliable way to
-	// randomly pick a key from a map (in this case, the backends) in
-	// Golang.
-	agentIDs []string
-	random   *rand.Rand
+	// These slices are the candidate index used by random routing. Each
+	// registered agent ID appears in exactly one slice, classified by the
+	// draining state of backends[agentID][0]. Destination-host routing does not
+	// use this index.
+	nonDrainingAgentIDs        []string
+	drainingAgentIDs           []string
+	maintainRandomRoutingIndex bool
+	random                     *rand.Rand
 	// idTypes contains the valid identifier types for this
 	// DefaultBackendStorage. The DefaultBackendStorage may only tolerate certain
 	// types of identifiers when associating to a specific BackendManager,
@@ -258,15 +275,54 @@ func NewDefaultBackendStorage(idTypes []header.IdentifierType, proxyStrategy pro
 	metrics.Metrics.SetTotalBackendCount(proxyStrategy, 0)
 
 	return &DefaultBackendStorage{
-		backends:      make(map[string][]*Backend),
-		random:        rand.New(rand.NewSource(time.Now().UnixNano())), /* #nosec G404 */
-		idTypes:       idTypes,
+		backends: make(map[string][]*Backend),
+		random:   rand.New(rand.NewSource(time.Now().UnixNano())), /* #nosec G404 */
+		idTypes:  idTypes,
+		maintainRandomRoutingIndex: proxyStrategy == proxystrategies.ProxyStrategyDefault ||
+			proxyStrategy == proxystrategies.ProxyStrategyDefaultRoute,
 		proxyStrategy: proxyStrategy,
 	}
 }
 
 func containIDType(idTypes []header.IdentifierType, idType header.IdentifierType) bool {
 	return slices.Contains(idTypes, idType)
+}
+
+// removeIdentifier removes identifier by replacing it with the final element.
+// It does not preserve order.
+func removeIdentifier(identifiers []string, identifier string) []string {
+	for i := range identifiers {
+		if identifiers[i] == identifier {
+			identifiers[i] = identifiers[len(identifiers)-1]
+			return identifiers[:len(identifiers)-1]
+		}
+	}
+	return identifiers
+}
+
+// refreshIdentifierState reconciles identifier's routing-index membership with
+// its primary backend. An identifier with no backends is removed from both
+// lists; otherwise it belongs to exactly one list. The caller must hold s.mu.
+func (s *DefaultBackendStorage) refreshIdentifierState(identifier string) {
+	backends := s.backends[identifier]
+	if len(backends) == 0 {
+		s.nonDrainingAgentIDs = removeIdentifier(s.nonDrainingAgentIDs, identifier)
+		s.drainingAgentIDs = removeIdentifier(s.drainingAgentIDs, identifier)
+		return
+	}
+	if backends[0].IsDraining() {
+		s.nonDrainingAgentIDs = removeIdentifier(s.nonDrainingAgentIDs, identifier)
+		if slices.Contains(s.drainingAgentIDs, identifier) {
+			return
+		}
+		s.drainingAgentIDs = append(s.drainingAgentIDs, identifier)
+		return
+	}
+	s.drainingAgentIDs = removeIdentifier(s.drainingAgentIDs, identifier)
+	if slices.Contains(s.nonDrainingAgentIDs, identifier) {
+		return
+	}
+	s.nonDrainingAgentIDs = append(s.nonDrainingAgentIDs, identifier)
 }
 
 // addBackend adds a backend.
@@ -290,9 +346,32 @@ func (s *DefaultBackendStorage) addBackend(identifier string, idType header.Iden
 		return
 	}
 	s.backends[identifier] = []*Backend{backend}
+	if s.maintainRandomRoutingIndex {
+		if backend.IsDraining() {
+			s.drainingAgentIDs = append(s.drainingAgentIDs, identifier)
+		} else {
+			s.nonDrainingAgentIDs = append(s.nonDrainingAgentIDs, identifier)
+		}
+	}
 	metrics.Metrics.SetBackendCountDeprecated(len(s.backends))
 	metrics.Metrics.SetTotalBackendCount(s.proxyStrategy, len(s.backends))
-	s.agentIDs = append(s.agentIDs, identifier)
+}
+
+// markIdentifierBackendDraining moves an identifier only when backend is its
+// primary connection. A draining secondary affects routing only if it is later
+// promoted.
+func (s *DefaultBackendStorage) markIdentifierBackendDraining(identifier string, idType header.IdentifierType, backend *Backend) {
+	if !containIDType(s.idTypes, idType) {
+		klog.ErrorS(&ErrWrongIDType{idType, s.idTypes}, "fail to mark backend draining")
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	backends, ok := s.backends[identifier]
+	if !ok || len(backends) == 0 || backends[0] != backend {
+		return
+	}
+	s.refreshIdentifierState(identifier)
 }
 
 // removeBackend removes a backend.
@@ -321,13 +400,9 @@ func (s *DefaultBackendStorage) removeBackend(identifier string, idType header.I
 	}
 	if len(s.backends[identifier]) == 0 {
 		delete(s.backends, identifier)
-		for i := range s.agentIDs {
-			if s.agentIDs[i] == identifier {
-				s.agentIDs[i] = s.agentIDs[len(s.agentIDs)-1]
-				s.agentIDs = s.agentIDs[:len(s.agentIDs)-1]
-				break
-			}
-		}
+	}
+	if s.maintainRandomRoutingIndex {
+		s.refreshIdentifierState(identifier)
 	}
 	if !found {
 		klog.V(1).InfoS("Could not find connection matching identifier to remove", "agentID", identifier, "idType", idType)
@@ -367,7 +442,8 @@ func ignoreNotFound(err error) error {
 	return err
 }
 
-// GetRandomBackend returns a random backend connection from all connected agents.
+// GetRandomBackend returns a random non-draining backend, falling back to a
+// random draining backend only when no non-draining agents are available.
 func (s *DefaultBackendStorage) GetRandomBackend() (*Backend, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -375,34 +451,25 @@ func (s *DefaultBackendStorage) GetRandomBackend() (*Backend, error) {
 		return nil, &ErrNotFound{}
 	}
 
-	var firstDrainingBackend *Backend
-
-	// Start at a random agent and check each agent in sequence
-	startIdx := s.random.Intn(len(s.agentIDs))
-	for i := 0; i < len(s.agentIDs); i++ {
-		// Wrap around using modulo
-		currentIdx := (startIdx + i) % len(s.agentIDs)
-		agentID := s.agentIDs[currentIdx]
-		// always return the first connection to an agent, because the agent
-		// will close later connections if there are multiple.
+	for len(s.nonDrainingAgentIDs) > 0 {
+		index := s.random.Intn(len(s.nonDrainingAgentIDs))
+		agentID := s.nonDrainingAgentIDs[index]
 		backend := s.backends[agentID][0]
-
-		if !backend.IsDraining() {
-			klog.V(3).InfoS("Pick agent as backend", "agentID", agentID)
-			return backend, nil
+		// SetDraining publishes before each manager updates its state lists.
+		// Repair that short-lived stale entry instead of routing to it.
+		if backend.IsDraining() {
+			s.refreshIdentifierState(agentID)
+			continue
 		}
-
-		// Keep track of first draining backend as fallback
-		if firstDrainingBackend == nil {
-			firstDrainingBackend = backend
-		}
+		klog.V(3).InfoS("Pick agent as backend", "agentID", agentID)
+		return backend, nil
 	}
 
-	// All agents are draining, use one as fallback
-	if firstDrainingBackend != nil {
-		agentID := firstDrainingBackend.id
+	if len(s.drainingAgentIDs) > 0 {
+		agentID := s.drainingAgentIDs[s.random.Intn(len(s.drainingAgentIDs))]
+		backend := s.backends[agentID][0]
 		klog.V(3).InfoS("No non-draining backends available, using draining backend as fallback", "agentID", agentID)
-		return firstDrainingBackend, nil
+		return backend, nil
 	}
 
 	return nil, &ErrNotFound{}

--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -18,12 +18,14 @@ package server
 
 import (
 	"context"
+	"math/rand"
 	"reflect"
 	"testing"
 
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/metadata"
 
+	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
 	agentmock "sigs.k8s.io/apiserver-network-proxy/proto/agent/mocks"
 )
 
@@ -57,6 +59,25 @@ func assertAgentIDs(t *testing.T, got []string, want ...string) {
 	if !reflect.DeepEqual(gotSet, wantSet) {
 		t.Fatalf("agent IDs = %v, want %v", got, want)
 	}
+}
+
+func markRandomBackendDraining(t *testing.T, manager BackendManager, backend *Backend) {
+	t.Helper()
+	backend.SetDraining()
+	marker, ok := manager.(backendDrainingMarker)
+	if !ok {
+		t.Fatalf("manager %T does not maintain draining-state lists", manager)
+	}
+	marker.markBackendDraining(backend)
+}
+
+func setBackendRecvChannel(backend *Backend, capacity, packets int) chan *client.Packet {
+	recvCh := make(chan *client.Packet, capacity)
+	for i := 0; i < packets; i++ {
+		recvCh <- &client.Packet{}
+	}
+	backend.recvCh = recvCh
+	return recvCh
 }
 
 func TestNewBackend(t *testing.T) {
@@ -454,9 +475,21 @@ func TestDefaultBackendManager_GetRandomBackend_DrainingFallback(t *testing.T) {
 		}
 	}
 
-	// Test 4: When all backends are draining, fallback to a draining backend
+	// Test 4: When only one backend is not draining, always use it
 	backend2.SetDraining()
 	p.markBackendDraining(backend2)
+
+	for i := 0; i < 20; i++ {
+		b, err = p.Backend(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error with one non-draining backend: %v", err)
+		}
+		if b != backend3 {
+			t.Fatalf("expected sole non-draining backend3, got %p", b)
+		}
+	}
+
+	// Test 5: When all backends are draining, fallback to a draining backend
 	backend3.SetDraining()
 	p.markBackendDraining(backend3)
 
@@ -469,6 +502,181 @@ func TestDefaultBackendManager_GetRandomBackend_DrainingFallback(t *testing.T) {
 	}
 	if !b.IsDraining() {
 		t.Error("expected draining backend as fallback")
+	}
+}
+
+func TestRandomBackendManagersPreferLowerRecvChannelOccupancyAmongNonDrainingAgents(t *testing.T) {
+	tests := []struct {
+		name             string
+		agentIdentifiers []string
+		newManager       func() BackendManager
+	}{
+		{
+			name:       "default",
+			newManager: func() BackendManager { return NewDefaultBackendManager() },
+		},
+		{
+			name:             "default route",
+			agentIdentifiers: []string{"default-route=true"},
+			newManager:       func() BackendManager { return NewDefaultRouteBackendManager() },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			busy, _ := NewBackend(mockAgentConn(ctrl, "busy", test.agentIdentifiers))
+			lessBusy, _ := NewBackend(mockAgentConn(ctrl, "less-busy", test.agentIdentifiers))
+			draining, _ := NewBackend(mockAgentConn(ctrl, "draining", test.agentIdentifiers))
+			setBackendRecvChannel(busy, 10, 9)
+			setBackendRecvChannel(lessBusy, 10, 1)
+			setBackendRecvChannel(draining, 10, 0)
+
+			manager := test.newManager()
+			manager.AddBackend(busy)
+			manager.AddBackend(lessBusy)
+			manager.AddBackend(draining)
+			markRandomBackendDraining(t, manager, draining)
+
+			for i := 0; i < 20; i++ {
+				got, err := manager.Backend(context.Background())
+				if err != nil {
+					t.Fatalf("Backend failed: %v", err)
+				}
+				if got != lessBusy {
+					t.Fatalf("Backend returned %p, want less occupied backend %p", got, lessBusy)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultBackendManager_GetRandomBackend_RecvChannelOccupancyRecovers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	first, _ := NewBackend(mockAgentConn(ctrl, "first", nil))
+	second, _ := NewBackend(mockAgentConn(ctrl, "second", nil))
+	setBackendRecvChannel(first, 10, 2)
+	secondRecvCh := setBackendRecvChannel(second, 10, 8)
+
+	manager := NewDefaultBackendManager()
+	manager.AddBackend(first)
+	manager.AddBackend(second)
+
+	for i := 0; i < 20; i++ {
+		got, err := manager.Backend(context.Background())
+		if err != nil {
+			t.Fatalf("Backend failed: %v", err)
+		}
+		if got != first {
+			t.Fatalf("Backend returned %p, want initially less occupied backend %p", got, first)
+		}
+	}
+
+	for i := 0; i < 7; i++ {
+		<-secondRecvCh
+	}
+	for i := 0; i < 20; i++ {
+		got, err := manager.Backend(context.Background())
+		if err != nil {
+			t.Fatalf("Backend failed after recovery: %v", err)
+		}
+		if got != second {
+			t.Fatalf("Backend returned %p after recovery, want %p", got, second)
+		}
+	}
+}
+
+func TestDefaultBackendManager_GetRandomBackend_BreaksOccupancyTiesRandomly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	first, _ := NewBackend(mockAgentConn(ctrl, "first", nil))
+	second, _ := NewBackend(mockAgentConn(ctrl, "second", nil))
+	setBackendRecvChannel(first, 10, 0)
+	setBackendRecvChannel(second, 10, 0)
+
+	manager := NewDefaultBackendManager()
+	manager.random = rand.New(rand.NewSource(1)) // #nosec G404 -- deterministic test source
+	manager.AddBackend(first)
+	manager.AddBackend(second)
+
+	selected := map[*Backend]int{}
+	for i := 0; i < 200; i++ {
+		got, err := manager.Backend(context.Background())
+		if err != nil {
+			t.Fatalf("Backend failed: %v", err)
+		}
+		selected[got]++
+	}
+	for _, backend := range []*Backend{first, second} {
+		if selected[backend] < 70 || selected[backend] > 130 {
+			t.Fatalf("backend %q selected %d times, want a random share", backend.id, selected[backend])
+		}
+	}
+}
+
+func TestDefaultBackendManager_GetRandomBackend_UsesPowerOfTwoChoices(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	leastBusy, _ := NewBackend(mockAgentConn(ctrl, "least-busy", nil))
+	middle, _ := NewBackend(mockAgentConn(ctrl, "middle", nil))
+	mostBusy, _ := NewBackend(mockAgentConn(ctrl, "most-busy", nil))
+	setBackendRecvChannel(leastBusy, 10, 0)
+	setBackendRecvChannel(middle, 10, 5)
+	setBackendRecvChannel(mostBusy, 10, 10)
+
+	manager := NewDefaultBackendManager()
+	manager.random = rand.New(rand.NewSource(2)) // #nosec G404 -- deterministic test source
+	manager.AddBackend(leastBusy)
+	manager.AddBackend(middle)
+	manager.AddBackend(mostBusy)
+
+	selected := map[*Backend]bool{}
+	for i := 0; i < 200; i++ {
+		got, err := manager.Backend(context.Background())
+		if err != nil {
+			t.Fatalf("Backend failed: %v", err)
+		}
+		if got == mostBusy {
+			t.Fatal("most occupied backend won a two-backend comparison")
+		}
+		selected[got] = true
+	}
+	if !selected[leastBusy] || !selected[middle] {
+		t.Fatalf("selected backends = %v, want both lower-pressure choices to be reachable", selected)
+	}
+}
+
+func TestDefaultBackendManager_GetRandomBackend_DrainingAgentsDoNotBiasEligibleSelection(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	manager := NewDefaultBackendManager()
+	manager.random = rand.New(rand.NewSource(3)) // #nosec G404 -- deterministic test source
+
+	selected := map[*Backend]int{}
+	for _, agentID := range []string{"eligible-a", "eligible-b", "eligible-c"} {
+		backend, _ := NewBackend(mockAgentConn(ctrl, agentID, nil))
+		setBackendRecvChannel(backend, 10, 0)
+		manager.AddBackend(backend)
+		selected[backend] = 0
+	}
+	for _, agentID := range []string{"draining-a", "draining-b", "draining-c"} {
+		backend, _ := NewBackend(mockAgentConn(ctrl, agentID, nil))
+		setBackendRecvChannel(backend, 10, 0)
+		backend.SetDraining()
+		manager.AddBackend(backend)
+	}
+
+	for i := 0; i < 6000; i++ {
+		got, err := manager.Backend(context.Background())
+		if err != nil {
+			t.Fatalf("Backend failed: %v", err)
+		}
+		if got.IsDraining() {
+			t.Fatalf("selected draining backend %q", got.id)
+		}
+		selected[got]++
+	}
+	for backend, count := range selected {
+		if count < 1700 || count > 2300 {
+			t.Fatalf("backend %q selected %d times, want approximately 2000", backend.id, count)
+		}
 	}
 }
 

--- a/pkg/server/backend_manager_test.go
+++ b/pkg/server/backend_manager_test.go
@@ -41,6 +41,24 @@ func mockAgentConn(ctrl *gomock.Controller, agentID string, agentIdentifiers []s
 	return agentConn
 }
 
+func assertAgentIDs(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("agent IDs = %v, want %v", got, want)
+	}
+	gotSet := make(map[string]struct{}, len(got))
+	for _, agentID := range got {
+		gotSet[agentID] = struct{}{}
+	}
+	wantSet := make(map[string]struct{}, len(want))
+	for _, agentID := range want {
+		wantSet[agentID] = struct{}{}
+	}
+	if !reflect.DeepEqual(gotSet, wantSet) {
+		t.Fatalf("agent IDs = %v, want %v", got, want)
+	}
+}
+
 func TestNewBackend(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -124,7 +142,7 @@ func TestDefaultBackendManager_AddRemoveBackends(t *testing.T) {
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+	if e, a := expectedAgentIDs, p.nonDrainingAgentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -147,9 +165,53 @@ func TestDefaultBackendManager_AddRemoveBackends(t *testing.T) {
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+	if e, a := expectedAgentIDs, p.nonDrainingAgentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+}
+
+func TestDefaultBackendManager_AgentListsFollowPrimaryBackendState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	primary, _ := NewBackend(mockAgentConn(ctrl, "agent1", nil))
+	drainingReplacement, _ := NewBackend(mockAgentConn(ctrl, "agent1", nil))
+	healthyReplacement, _ := NewBackend(mockAgentConn(ctrl, "agent1", nil))
+	drainingAgent, _ := NewBackend(mockAgentConn(ctrl, "agent2", nil))
+	drainingAgent.SetDraining()
+
+	manager := NewDefaultBackendManager()
+	manager.AddBackend(primary)
+	manager.AddBackend(drainingReplacement)
+	manager.AddBackend(healthyReplacement)
+	manager.AddBackend(drainingAgent)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs, "agent1")
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent2")
+
+	// Draining a secondary connection does not change the agent's state while
+	// its non-draining primary remains selected.
+	drainingReplacement.SetDraining()
+	manager.markBackendDraining(drainingReplacement)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs, "agent1")
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent2")
+
+	primary.SetDraining()
+	manager.markBackendDraining(primary)
+	manager.markBackendDraining(primary) // The state transition is idempotent.
+	assertAgentIDs(t, manager.nonDrainingAgentIDs)
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent1", "agent2")
+
+	// Removing primaries reclassifies the agent according to the promoted
+	// connection rather than retaining the removed primary's state.
+	manager.RemoveBackend(primary)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs)
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent1", "agent2")
+	manager.RemoveBackend(drainingReplacement)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs, "agent1")
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent2")
+
+	manager.RemoveBackend(healthyReplacement)
+	manager.RemoveBackend(drainingAgent)
+	assertAgentIDs(t, manager.nonDrainingAgentIDs)
+	assertAgentIDs(t, manager.drainingAgentIDs)
 }
 
 func TestDefaultRouteBackendManager_AddRemoveBackends(t *testing.T) {
@@ -171,7 +233,7 @@ func TestDefaultRouteBackendManager_AddRemoveBackends(t *testing.T) {
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+	if e, a := expectedAgentIDs, p.nonDrainingAgentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -196,9 +258,35 @@ func TestDefaultRouteBackendManager_AddRemoveBackends(t *testing.T) {
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
+	if e, a := expectedAgentIDs, p.nonDrainingAgentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
+}
+
+func TestDefaultBackendManager_SelectionRepairsDirectRetirement(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	retired, _ := NewBackend(mockAgentConn(ctrl, "retired", nil))
+	healthy, _ := NewBackend(mockAgentConn(ctrl, "healthy", nil))
+
+	manager := NewDefaultBackendManager()
+	manager.AddBackend(retired)
+	manager.AddBackend(healthy)
+
+	// Some lifecycle paths publish retirement immediately and remove the
+	// backend from its managers shortly afterward. Selection must repair the
+	// classification during that interval.
+	retired.Retire()
+	for i := 0; i < 20; i++ {
+		got, err := manager.Backend(context.Background())
+		if err != nil {
+			t.Fatalf("Backend failed: %v", err)
+		}
+		if got != healthy {
+			t.Fatalf("Backend returned retired backend %q, want %q", got.id, healthy.id)
+		}
+	}
+	assertAgentIDs(t, manager.nonDrainingAgentIDs, "healthy")
+	assertAgentIDs(t, manager.drainingAgentIDs, "retired")
 }
 
 func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
@@ -216,11 +304,7 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 	p.AddBackend(backend1)
 	p.RemoveBackend(backend1)
 	expectedBackends := make(map[string][]*Backend)
-	expectedAgentIDs := []string{}
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -233,17 +317,7 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 		"9878::7675:1292:9183:7562": {backend1},
 		"node1.mydomain.com":        {backend1},
 	}
-	expectedAgentIDs = []string{
-		"1.2.3.4",
-		"9878::7675:1292:9183:7562",
-		"localhost",
-		"node1.mydomain.com",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
@@ -259,22 +333,11 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 		"9878::7675:1292:9183:7562": {backend1},
 		"::":                        {backend3},
 	}
-	expectedAgentIDs = []string{
-		"1.2.3.4",
-		"9878::7675:1292:9183:7562",
-		"localhost",
-		"node1.mydomain.com",
-		"5.6.7.8",
-		"::",
-		"node2.mydomain.com",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
+	assertAgentIDs(t, p.nonDrainingAgentIDs)
+	assertAgentIDs(t, p.drainingAgentIDs)
 
 	p.RemoveBackend(backend2)
 	p.RemoveBackend(backend1)
@@ -284,27 +347,14 @@ func TestDestHostBackendManager_AddRemoveBackends(t *testing.T) {
 		"5.6.7.8":            {backend3},
 		"::":                 {backend3},
 	}
-	expectedAgentIDs = []string{
-		"node2.mydomain.com",
-		"::",
-		"5.6.7.8",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
 	p.RemoveBackend(backend3)
 	expectedBackends = map[string][]*Backend{}
-	expectedAgentIDs = []string{}
 
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }
@@ -332,22 +382,11 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 		"node1.mydomain.com":        {backend1, backend2},
 		"node2.mydomain.com":        {backend3},
 	}
-	expectedAgentIDs := []string{
-		"1.2.3.4",
-		"9878::7675:1292:9183:7562",
-		"localhost",
-		"node1.mydomain.com",
-		"5.6.7.8",
-		"::",
-		"node2.mydomain.com",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
+	assertAgentIDs(t, p.nonDrainingAgentIDs)
+	assertAgentIDs(t, p.drainingAgentIDs)
 
 	p.RemoveBackend(backend1)
 	p.RemoveBackend(backend3)
@@ -358,28 +397,14 @@ func TestDestHostBackendManager_WithDuplicateIdents(t *testing.T) {
 		"9878::7675:1292:9183:7562": {backend2},
 		"node1.mydomain.com":        {backend2},
 	}
-	expectedAgentIDs = []string{
-		"1.2.3.4",
-		"9878::7675:1292:9183:7562",
-		"localhost",
-		"node1.mydomain.com",
-	}
-
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
 	p.RemoveBackend(backend2)
 	expectedBackends = map[string][]*Backend{}
-	expectedAgentIDs = []string{}
 
 	if e, a := expectedBackends, p.backends; !reflect.DeepEqual(e, a) {
-		t.Errorf("expected %v, got %v", e, a)
-	}
-	if e, a := expectedAgentIDs, p.agentIDs; !reflect.DeepEqual(e, a) {
 		t.Errorf("expected %v, got %v", e, a)
 	}
 }
@@ -416,6 +441,7 @@ func TestDefaultBackendManager_GetRandomBackend_DrainingFallback(t *testing.T) {
 
 	// Test 3: When some backends are draining, non-draining ones are prioritized
 	backend1.SetDraining()
+	p.markBackendDraining(backend1)
 
 	// Call multiple times to ensure we never get the draining backend
 	for i := 0; i < 20; i++ {
@@ -430,7 +456,9 @@ func TestDefaultBackendManager_GetRandomBackend_DrainingFallback(t *testing.T) {
 
 	// Test 4: When all backends are draining, fallback to a draining backend
 	backend2.SetDraining()
+	p.markBackendDraining(backend2)
 	backend3.SetDraining()
+	p.markBackendDraining(backend3)
 
 	b, err = p.Backend(context.Background())
 	if err != nil {

--- a/pkg/server/backend_occupancy_test.go
+++ b/pkg/server/backend_occupancy_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	client "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
+)
+
+func TestBackendRecvChannelOccupancy(t *testing.T) {
+	tests := []struct {
+		name     string
+		capacity int
+		packets  int
+		want     float64
+	}{
+		{name: "unset", capacity: -1, want: 0},
+		{name: "unbuffered", capacity: 0, want: 0},
+		{name: "empty", capacity: 4, want: 0},
+		{name: "partially occupied", capacity: 4, packets: 1, want: 0.25},
+		{name: "full", capacity: 4, packets: 4, want: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var recvCh chan *client.Packet
+			if test.capacity >= 0 {
+				recvCh = make(chan *client.Packet, test.capacity)
+			}
+			for i := 0; i < test.packets; i++ {
+				recvCh <- &client.Packet{}
+			}
+
+			backend := &Backend{recvCh: recvCh}
+			if got := backend.RecvChannelOccupancy(); got != test.want {
+				t.Fatalf("RecvChannelOccupancy() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/server/default_route_backend_manager.go
+++ b/pkg/server/default_route_backend_manager.go
@@ -50,6 +50,13 @@ func (dibm *DefaultRouteBackendManager) AddBackend(backend *Backend) {
 	}
 }
 
+func (dibm *DefaultRouteBackendManager) markBackendDraining(backend *Backend) {
+	agentID := backend.GetAgentID()
+	if backend.GetAgentIdentifiers().DefaultRoute {
+		dibm.DefaultBackendStorage.markIdentifierBackendDraining(agentID, header.DefaultRoute, backend)
+	}
+}
+
 func (dibm *DefaultRouteBackendManager) RemoveBackend(backend *Backend) {
 	agentID := backend.GetAgentID()
 	agentIdentifiers := backend.GetAgentIdentifiers()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -915,10 +915,11 @@ func (s *ProxyServer) Connect(stream agent.AgentService_ConnectServer) error {
 	}
 
 	klog.V(2).InfoS("Agent connected", "agentID", agentID, "serverID", s.serverID)
+	recvCh := make(chan *client.Packet, s.xfrChannelSize)
+	backend.recvCh = recvCh
+
 	s.addBackend(backend)
 	defer s.removeBackend(backend)
-
-	recvCh := make(chan *client.Packet, s.xfrChannelSize)
 
 	go runpprof.Do(context.Background(), labels, func(context.Context) { s.serveRecvBackend(backend, agentID, recvCh) })
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -390,6 +390,17 @@ func (s *ProxyServer) addBackend(backend *Backend) {
 	}
 }
 
+func (s *ProxyServer) markBackendDraining(backend *Backend) {
+	// Publish the state before notifying managers so concurrent selection can
+	// reject or repair a stale non-draining index entry.
+	backend.SetDraining()
+	for _, bm := range s.BackendManagers {
+		if marker, ok := bm.(backendDrainingMarker); ok {
+			marker.markBackendDraining(backend)
+		}
+	}
+}
+
 func (s *ProxyServer) removeBackend(backend *Backend) {
 	for _, bm := range s.BackendManagers {
 		bm.RemoveBackend(backend)
@@ -1109,7 +1120,7 @@ func (s *ProxyServer) serveRecvBackend(backend *Backend, agentID string, recvCh 
 
 		case client.PacketType_DRAIN:
 			klog.V(2).InfoS("agent is draining", "agentID", agentID)
-			backend.SetDraining()
+			s.markBackendDraining(backend)
 			klog.V(2).InfoS("marked backend as draining, will not route new requests to this agent", "agentID", agentID)
 		default:
 			klog.V(5).InfoS("Ignoring unrecognized packet from backend", "packet", pkt, "agentID", agentID)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -327,6 +327,28 @@ func TestHTTPConnectTunnelBlockedBackendDialSendTimesOutCleansPendingDialAndReti
 	}
 }
 
+func TestBackendDrainPacketReclassifiesAgent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	backend, err := NewBackend(mockAgentConn(ctrl, "agent1", nil))
+	if err != nil {
+		t.Fatalf("NewBackend failed: %v", err)
+	}
+	manager := NewDefaultBackendManager()
+	manager.AddBackend(backend)
+	proxyServer := &ProxyServer{
+		BackendManagers: []BackendManager{manager},
+		established:     map[string]map[int64]*ProxyClientConnection{"agent1": {}},
+	}
+	recvCh := make(chan *client.Packet, 1)
+	recvCh <- &client.Packet{Type: client.PacketType_DRAIN}
+	close(recvCh)
+
+	proxyServer.serveRecvBackend(backend, "agent1", recvCh)
+
+	assertAgentIDs(t, manager.nonDrainingAgentIDs)
+	assertAgentIDs(t, manager.drainingAgentIDs, "agent1")
+}
+
 func TestAddRemoveFrontends(t *testing.T) {
 	agent1ConnID1 := new(ProxyClientConnection)
 	agent1ConnID2 := new(ProxyClientConnection)


### PR DESCRIPTION
Use receive-channel occupancy as a lightweight routing signal. Random routing samples two non-draining agents and selects the less occupied one, while preserving existing single-agent and all-draining fallback behavior. Destination-host routing is unchanged.

fixes: #900 , and helps in #881