### PR TITLE
Reject malformed certificate blocks in CA bundles

### DIFF
--- a/cmd/server/app/server.go
+++ b/cmd/server/app/server.go
@@ -19,14 +19,12 @@ package app
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
 	netpprof "net/http/pprof"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"runtime"
 	runpprof "runtime/pprof"
 	"strconv"
@@ -41,6 +39,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/apiserver-network-proxy/cmd/server/app/options"
 	"sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client"
@@ -422,14 +421,9 @@ func (p *Proxy) getTLSConfig(caFile, certFile, keyFile string, cipherSuites []st
 		return &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: minVersion, CipherSuites: cipherSuiteIDs}, nil // #nosec G402
 	}
 
-	certPool := x509.NewCertPool()
-	caCert, err := os.ReadFile(filepath.Clean(caFile))
+	certPool, err := certutil.NewPool(caFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read cluster CA cert %s: %v", caFile, err)
-	}
-	ok := certPool.AppendCertsFromPEM(caCert)
-	if !ok {
-		return nil, fmt.Errorf("failed to append cluster CA cert to the cert pool")
+		return nil, fmt.Errorf("failed to load CA cert: %w", err)
 	}
 
 	tlsConfig := &tls.Config{ // #nosec G402

--- a/pkg/util/certificates.go
+++ b/pkg/util/certificates.go
@@ -18,31 +18,16 @@ package util //nolint:revive
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
-	"os"
-	"path/filepath"
-)
 
-// getCACertPool loads CA certificates to pool
-func getCACertPool(caFile string) (*x509.CertPool, error) {
-	certPool := x509.NewCertPool()
-	caCert, err := os.ReadFile(filepath.Clean(caFile))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read CA cert %s: %v", caFile, err)
-	}
-	ok := certPool.AppendCertsFromPEM(caCert)
-	if !ok {
-		return nil, fmt.Errorf("failed to append CA cert to the cert pool")
-	}
-	return certPool, nil
-}
+	certutil "k8s.io/client-go/util/cert"
+)
 
 // GetClientTLSConfig returns tlsConfig based on x509 certs
 func GetClientTLSConfig(caFile, certFile, keyFile, serverName string, protos []string) (*tls.Config, error) {
-	certPool, err := getCACertPool(caFile)
+	certPool, err := certutil.NewPool(caFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load CA cert: %w", err)
 	}
 
 	tlsConfig := &tls.Config{
@@ -59,7 +44,7 @@ func GetClientTLSConfig(caFile, certFile, keyFile, serverName string, protos []s
 
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load X509 key pair %s and %s: %v", certFile, keyFile, err)
+		return nil, fmt.Errorf("failed to load X509 key pair %s and %s: %w", certFile, keyFile, err)
 	}
 
 	tlsConfig.ServerName = serverName

--- a/pkg/util/certificates_test.go
+++ b/pkg/util/certificates_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func TestGetClientTLSConfigCABundleValidation(t *testing.T) {
+	caPEM := newTestCAPEM(t)
+	nonCertificateBlock := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("not a private key")})
+
+	testCases := []struct {
+		name    string
+		bundle  []byte
+		wantErr bool
+	}{
+		{name: "valid bundle", bundle: caPEM},
+		{name: "non-certificate block is ignored", bundle: append(append([]byte(nil), caPEM...), nonCertificateBlock...)},
+		{name: "malformed certificate block is rejected", bundle: append(append([]byte(nil), caPEM...), malformedCertificatePEM()...), wantErr: true},
+		// Data that never forms a valid PEM block is skipped rather than
+		// rejected, the same boundary as kube-apiserver's dynamic CA reload.
+		{name: "truncated trailing block is skipped", bundle: append(append([]byte(nil), caPEM...), []byte("-----BEGIN CERTIFICATE-----\nMIIBtruncated\n")...)},
+		{name: "block with corrupted base64 is skipped", bundle: append(append([]byte(nil), caPEM...), []byte("-----BEGIN CERTIFICATE-----\n!!!!\n-----END CERTIFICATE-----\n")...)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			caFile := filepath.Join(t.TempDir(), "ca.crt")
+			if err := os.WriteFile(caFile, tc.bundle, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			tlsConfig, err := GetClientTLSConfig(caFile, "", "", "proxy.test", nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("partially invalid CA bundle unexpectedly loaded")
+				}
+				if !strings.Contains(err.Error(), caFile) {
+					t.Fatalf("error %q does not identify the CA file %q", err, caFile)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tlsConfig.RootCAs == nil {
+				t.Fatal("tlsConfig has no RootCAs")
+			}
+		})
+	}
+}
+
+func newTestCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := certutil.NewSelfSignedCACert(certutil.Config{CommonName: "ca"}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})
+}
+
+func malformedCertificatePEM() []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a DER-encoded certificate")})
+}


### PR DESCRIPTION
Loading a CA bundle goes through AppendCertsFromPEM, which silently skips anything it cannot parse. A corrupted bundle is accepted as long as one certificate in it still parses, and the proxy then quietly runs with partial trust, rejecting peers it should have accepted.

This switches the parsing to client-go's certutil, [the same code kube-apiserver uses when it reloads its client CA](https://github.com/kubernetes/kubernetes/blob/0f29094e5b73085e3802ecc1298ecae13866bfe6/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_cafile_content.go#L269-L280). A CERTIFICATE block that does not parse now fails the whole load.

Non-certificate PEM blocks are still ignored, and bytes that never form a PEM block (a truncated block, for example) are still skipped, same as kube-apiserver. The tests pin down both sides of that line.

## Manual verification on kind

I built and deployed the proxy agent and server from these two revisions side by side:

- Baseline: `master`
- Patched: this PR

Each deployment used a CA bundle containing two valid CA certificates followed by a valid PEM `CERTIFICATE` block with a malformed DER payload.

### Results with the partially malformed bundle

| Revision | Agent | Server | Result |
| --- | --- | --- | --- |
| `master` | Running | Running | The malformed certificate block was silently skipped |
| This PR | CrashLoopBackOff | CrashLoopBackOff | Startup failed because the malformed certificate block was rejected |

<img width="3326" height="164" alt="" src="https://github.com/user-attachments/assets/eeec6e63-91a5-4d66-ab51-fedcfe6128b1" />

Both the agent and server built from this PR rejected the bundle and exited with:

```text
failed to load CA cert: error creating pool from /tls/ca.crt: x509: malformed certificate
```

### Results with a fully valid bundle

After restoring the bundle so that it contained only valid CA certificates, the agent and server built from this PR both started successfully, and the agent connected to the server.

<img width="3282" height="158" alt="" src="https://github.com/user-attachments/assets/320c6d91-61e8-4c1e-942a-ec1a6c6972cf" />


/kind bug

```release-note
CA bundle files containing a certificate block that fails to parse are now rejected with an error instead of the malformed block being silently skipped.
```
